### PR TITLE
Use multi-scan-id as env variable

### DIFF
--- a/commands/audit/audit.go
+++ b/commands/audit/audit.go
@@ -181,7 +181,7 @@ func RunAudit(auditParams *AuditParams) (results *xrayutils.Results, err error) 
 
 	// Run scanners only if the user is entitled for Advanced Security
 	if results.ExtendedScanResults.EntitledForJas {
-		results.JasError = runJasScannersAndSetResults(results, auditParams.DirectDependencies(), serverDetails, auditParams.workingDirs, auditParams.Progress(), auditParams.xrayGraphScanParams.MultiScanId, auditParams.thirdPartyApplicabilityScan)
+		results.JasError = runJasScannersAndSetResults(results, auditParams.DirectDependencies(), serverDetails, auditParams.workingDirs, auditParams.Progress(), auditParams.thirdPartyApplicabilityScan)
 	}
 	return
 }

--- a/commands/audit/jas/common.go
+++ b/commands/audit/jas/common.go
@@ -49,7 +49,7 @@ type JasScanner struct {
 	ScannerDirCleanupFunc func() error
 }
 
-func NewJasScanner(workingDirs []string, serverDetails *config.ServerDetails, multiScanId string) (scanner *JasScanner, err error) {
+func NewJasScanner(workingDirs []string, serverDetails *config.ServerDetails) (scanner *JasScanner, err error) {
 	scanner = &JasScanner{}
 	if scanner.AnalyzerManager.AnalyzerManagerFullPath, err = utils.GetAnalyzerManagerExecutable(); err != nil {
 		return
@@ -65,7 +65,6 @@ func NewJasScanner(workingDirs []string, serverDetails *config.ServerDetails, mu
 	scanner.ConfigFileName = filepath.Join(tempDir, "config.yaml")
 	scanner.ResultsFileName = filepath.Join(tempDir, "results.sarif")
 	scanner.JFrogAppsConfig, err = createJFrogAppsConfig(workingDirs)
-	scanner.AnalyzerManager.MultiScanId = multiScanId
 	return
 }
 
@@ -230,7 +229,7 @@ var FakeBasicXrayResults = []services.ScanResponse{
 
 func InitJasTest(t *testing.T, workingDirs ...string) (*JasScanner, func()) {
 	assert.NoError(t, utils.DownloadAnalyzerManagerIfNeeded())
-	scanner, err := NewJasScanner(workingDirs, &FakeServerDetails, "")
+	scanner, err := NewJasScanner(workingDirs, &FakeServerDetails)
 	assert.NoError(t, err)
 	return scanner, func() {
 		assert.NoError(t, scanner.ScannerDirCleanupFunc())

--- a/commands/audit/jasrunner.go
+++ b/commands/audit/jasrunner.go
@@ -14,12 +14,12 @@ import (
 )
 
 func runJasScannersAndSetResults(scanResults *utils.Results, directDependencies []string,
-	serverDetails *config.ServerDetails, workingDirs []string, progress io.ProgressMgr, multiScanId string, thirdPartyApplicabilityScan bool) (err error) {
+	serverDetails *config.ServerDetails, workingDirs []string, progress io.ProgressMgr, thirdPartyApplicabilityScan bool) (err error) {
 	if serverDetails == nil || len(serverDetails.Url) == 0 {
 		log.Warn("To include 'Advanced Security' scan as part of the audit output, please run the 'jf c add' command before running this command.")
 		return
 	}
-	scanner, err := jas.NewJasScanner(workingDirs, serverDetails, multiScanId)
+	scanner, err := jas.NewJasScanner(workingDirs, serverDetails)
 	if err != nil {
 		return
 	}

--- a/commands/audit/jasrunner_test.go
+++ b/commands/audit/jasrunner_test.go
@@ -22,14 +22,14 @@ func TestGetExtendedScanResults_AnalyzerManagerDoesntExist(t *testing.T) {
 		assert.NoError(t, os.Unsetenv(coreutils.HomeDir))
 	}()
 	scanResults := &utils.Results{ScaResults: []utils.ScaScanResult{{Technology: coreutils.Yarn, XrayResults: jas.FakeBasicXrayResults}}, ExtendedScanResults: &utils.ExtendedScanResults{}}
-	err = runJasScannersAndSetResults(scanResults, []string{"issueId_1_direct_dependency", "issueId_2_direct_dependency"}, &jas.FakeServerDetails, nil, nil, "", false)
+	err = runJasScannersAndSetResults(scanResults, []string{"issueId_1_direct_dependency", "issueId_2_direct_dependency"}, &jas.FakeServerDetails, nil, nil, false)
 	// Expect error:
 	assert.Error(t, err)
 }
 
 func TestGetExtendedScanResults_ServerNotValid(t *testing.T) {
 	scanResults := &utils.Results{ScaResults: []utils.ScaScanResult{{Technology: coreutils.Pip, XrayResults: jas.FakeBasicXrayResults}}, ExtendedScanResults: &utils.ExtendedScanResults{}}
-	err := runJasScannersAndSetResults(scanResults, []string{"issueId_1_direct_dependency", "issueId_2_direct_dependency"}, nil, nil, nil, "", false)
+	err := runJasScannersAndSetResults(scanResults, []string{"issueId_1_direct_dependency", "issueId_2_direct_dependency"}, nil, nil, nil, false)
 	assert.NoError(t, err)
 }
 
@@ -37,7 +37,7 @@ func TestGetExtendedScanResults_AnalyzerManagerReturnsError(t *testing.T) {
 	assert.NoError(t, utils.DownloadAnalyzerManagerIfNeeded())
 
 	scanResults := &utils.Results{ScaResults: []utils.ScaScanResult{{Technology: coreutils.Yarn, XrayResults: jas.FakeBasicXrayResults}}, ExtendedScanResults: &utils.ExtendedScanResults{}}
-	err := runJasScannersAndSetResults(scanResults, []string{"issueId_2_direct_dependency", "issueId_1_direct_dependency"}, &jas.FakeServerDetails, nil, nil, "", false)
+	err := runJasScannersAndSetResults(scanResults, []string{"issueId_2_direct_dependency", "issueId_1_direct_dependency"}, &jas.FakeServerDetails, nil, nil, false)
 
 	// Expect error:
 	assert.ErrorContains(t, err, "failed to run Applicability scan")

--- a/go.mod
+++ b/go.mod
@@ -100,4 +100,4 @@ require (
 
 replace github.com/jfrog/jfrog-cli-core/v2 => github.com/jfrog/jfrog-cli-core/v2 v2.31.1-0.20240118100957-b4e1537e91dd
 
-replace github.com/jfrog/jfrog-client-go => github.com/orz25/jfrog-client-go v0.0.0-20231231083311-ca7e0cc28374
+replace github.com/jfrog/jfrog-client-go => github.com/jfrog/jfrog-client-go v1.28.1-0.20240122091504-cd958f60aef7

--- a/go.mod
+++ b/go.mod
@@ -99,3 +99,5 @@ require (
 )
 
 replace github.com/jfrog/jfrog-cli-core/v2 => github.com/jfrog/jfrog-cli-core/v2 v2.31.1-0.20240118100957-b4e1537e91dd
+
+replace github.com/jfrog/jfrog-client-go => github.com/orz25/jfrog-client-go v0.0.0-20231231083311-ca7e0cc28374

--- a/go.sum
+++ b/go.sum
@@ -95,6 +95,8 @@ github.com/jfrog/jfrog-apps-config v1.0.1 h1:mtv6k7g8A8BVhlHGlSveapqf4mJfonwvXYL
 github.com/jfrog/jfrog-apps-config v1.0.1/go.mod h1:8AIIr1oY9JuH5dylz2S6f8Ym2MaadPLR6noCBO4C22w=
 github.com/jfrog/jfrog-cli-core/v2 v2.31.1-0.20240118100957-b4e1537e91dd h1:7JOQANVaULKq0b2X10ERsEAZOGccfooOvstr3UZcGTc=
 github.com/jfrog/jfrog-cli-core/v2 v2.31.1-0.20240118100957-b4e1537e91dd/go.mod h1:tbplJYWXBgQNLMWadfZYh2uaajZjG1tLgBb1txLNAQw=
+github.com/jfrog/jfrog-client-go v1.28.1-0.20240122091504-cd958f60aef7 h1:+6FMON+6D2ojqR+bKewlahVcQGXLifFH76hXITg9p6k=
+github.com/jfrog/jfrog-client-go v1.28.1-0.20240122091504-cd958f60aef7/go.mod h1:V+XKC27k6GA5OcWIAItpnxZAZnCigg8xCkpXKP905Fk=
 github.com/kevinburke/ssh_config v1.2.0 h1:x584FjTGwHzMwvHx18PXxbBVzfnxogHaAReU4gf13a4=
 github.com/kevinburke/ssh_config v1.2.0/go.mod h1:CT57kijsi8u/K/BOFA39wgDQJ9CxiF4nAY/ojJ6r6mM=
 github.com/klauspost/compress v1.4.1/go.mod h1:RyIbtBH6LamlWaDj8nUwkbUhJ87Yi3uG0guNDohfE1A=
@@ -139,8 +141,6 @@ github.com/mitchellh/mapstructure v1.5.0/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RR
 github.com/nwaples/rardecode v1.1.0 h1:vSxaY8vQhOcVr4mm5e8XllHWTiM4JF507A0Katqw7MQ=
 github.com/nwaples/rardecode v1.1.0/go.mod h1:5DzqNKiOdpKKBH87u8VlvAnPZMXcGRhxWkRpHbbfGS0=
 github.com/onsi/gomega v1.27.10 h1:naR28SdDFlqrG6kScpT8VWpu1xWY5nJRCF3XaYyBjhI=
-github.com/orz25/jfrog-client-go v0.0.0-20231231083311-ca7e0cc28374 h1:k08DoImakx+o/LQTm7CXFx5yb2Sjl5zplAm50gUC2c8=
-github.com/orz25/jfrog-client-go v0.0.0-20231231083311-ca7e0cc28374/go.mod h1:Leua+MdhCV+M4gl746PcTsHF8dDP7+LLJ/NgHCTl/Fo=
 github.com/owenrumney/go-sarif v1.1.1/go.mod h1:dNDiPlF04ESR/6fHlPyq7gHKmrM0sHUvAGjsoh8ZH0U=
 github.com/owenrumney/go-sarif/v2 v2.3.0 h1:wP5yEpI53zr0v5cBmagXzLbHZp9Oylyo3AJDpfLBITs=
 github.com/owenrumney/go-sarif/v2 v2.3.0/go.mod h1:MSqMMx9WqlBSY7pXoOZWgEsVB4FDNfhcaXDA1j6Sr+w=

--- a/go.sum
+++ b/go.sum
@@ -95,8 +95,6 @@ github.com/jfrog/jfrog-apps-config v1.0.1 h1:mtv6k7g8A8BVhlHGlSveapqf4mJfonwvXYL
 github.com/jfrog/jfrog-apps-config v1.0.1/go.mod h1:8AIIr1oY9JuH5dylz2S6f8Ym2MaadPLR6noCBO4C22w=
 github.com/jfrog/jfrog-cli-core/v2 v2.31.1-0.20240118100957-b4e1537e91dd h1:7JOQANVaULKq0b2X10ERsEAZOGccfooOvstr3UZcGTc=
 github.com/jfrog/jfrog-cli-core/v2 v2.31.1-0.20240118100957-b4e1537e91dd/go.mod h1:tbplJYWXBgQNLMWadfZYh2uaajZjG1tLgBb1txLNAQw=
-github.com/jfrog/jfrog-client-go v1.35.6 h1:nVS94x6cwSRkhtj8OM3elbUcGgQhqsK8YMPvC/gf5sk=
-github.com/jfrog/jfrog-client-go v1.35.6/go.mod h1:V+XKC27k6GA5OcWIAItpnxZAZnCigg8xCkpXKP905Fk=
 github.com/kevinburke/ssh_config v1.2.0 h1:x584FjTGwHzMwvHx18PXxbBVzfnxogHaAReU4gf13a4=
 github.com/kevinburke/ssh_config v1.2.0/go.mod h1:CT57kijsi8u/K/BOFA39wgDQJ9CxiF4nAY/ojJ6r6mM=
 github.com/klauspost/compress v1.4.1/go.mod h1:RyIbtBH6LamlWaDj8nUwkbUhJ87Yi3uG0guNDohfE1A=
@@ -141,6 +139,8 @@ github.com/mitchellh/mapstructure v1.5.0/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RR
 github.com/nwaples/rardecode v1.1.0 h1:vSxaY8vQhOcVr4mm5e8XllHWTiM4JF507A0Katqw7MQ=
 github.com/nwaples/rardecode v1.1.0/go.mod h1:5DzqNKiOdpKKBH87u8VlvAnPZMXcGRhxWkRpHbbfGS0=
 github.com/onsi/gomega v1.27.10 h1:naR28SdDFlqrG6kScpT8VWpu1xWY5nJRCF3XaYyBjhI=
+github.com/orz25/jfrog-client-go v0.0.0-20231231083311-ca7e0cc28374 h1:k08DoImakx+o/LQTm7CXFx5yb2Sjl5zplAm50gUC2c8=
+github.com/orz25/jfrog-client-go v0.0.0-20231231083311-ca7e0cc28374/go.mod h1:Leua+MdhCV+M4gl746PcTsHF8dDP7+LLJ/NgHCTl/Fo=
 github.com/owenrumney/go-sarif v1.1.1/go.mod h1:dNDiPlF04ESR/6fHlPyq7gHKmrM0sHUvAGjsoh8ZH0U=
 github.com/owenrumney/go-sarif/v2 v2.3.0 h1:wP5yEpI53zr0v5cBmagXzLbHZp9Oylyo3AJDpfLBITs=
 github.com/owenrumney/go-sarif/v2 v2.3.0/go.mod h1:MSqMMx9WqlBSY7pXoOZWgEsVB4FDNfhcaXDA1j6Sr+w=

--- a/utils/analyzermanager.go
+++ b/utils/analyzermanager.go
@@ -91,12 +91,13 @@ func (am *AnalyzerManager) ExecWithOutputFile(configFile, scanCommand, workingDi
 		return
 	}
 	var cmd *exec.Cmd
+	multiScanId := os.Getenv("JF_MSI")
 	if len(outputFile) > 0 {
-		log.Debug("Executing", am.AnalyzerManagerFullPath, scanCommand, configFile, outputFile, am.MultiScanId)
-		cmd = exec.Command(am.AnalyzerManagerFullPath, scanCommand, configFile, outputFile, am.MultiScanId)
+		log.Debug("Executing", am.AnalyzerManagerFullPath, scanCommand, configFile, outputFile, multiScanId)
+		cmd = exec.Command(am.AnalyzerManagerFullPath, scanCommand, configFile, outputFile)
 	} else {
-		log.Debug("Executing", am.AnalyzerManagerFullPath, scanCommand, configFile, am.MultiScanId)
-		cmd = exec.Command(am.AnalyzerManagerFullPath, scanCommand, configFile, am.MultiScanId)
+		log.Debug("Executing", am.AnalyzerManagerFullPath, scanCommand, configFile, multiScanId)
+		cmd = exec.Command(am.AnalyzerManagerFullPath, scanCommand, configFile)
 	}
 	defer func() {
 		if cmd.ProcessState != nil && !cmd.ProcessState.Exited() {

--- a/utils/analyzermanager.go
+++ b/utils/analyzermanager.go
@@ -36,7 +36,7 @@ const (
 	unsupportedOsExitCode                     = 55
 	ErrFailedScannerRun                       = "failed to run %s scan. Exit code received: %s"
 	jfrogCliAnalyzerManagerVersionEnvVariable = "JFROG_CLI_ANALYZER_MANAGER_VERSION"
-	JF_MSI                                    = "JF_MSI"
+	jfMsiEnvVariable                          = "JF_MSI"
 )
 
 type ApplicabilityStatus string
@@ -92,7 +92,7 @@ func (am *AnalyzerManager) ExecWithOutputFile(configFile, scanCommand, workingDi
 		return
 	}
 	var cmd *exec.Cmd
-	multiScanId := os.Getenv(JF_MSI)
+	multiScanId := os.Getenv(jfMsiEnvVariable)
 	if len(outputFile) > 0 {
 		log.Debug("Executing", am.AnalyzerManagerFullPath, scanCommand, configFile, outputFile, multiScanId)
 		cmd = exec.Command(am.AnalyzerManagerFullPath, scanCommand, configFile, outputFile)

--- a/utils/analyzermanager.go
+++ b/utils/analyzermanager.go
@@ -36,6 +36,7 @@ const (
 	unsupportedOsExitCode                     = 55
 	ErrFailedScannerRun                       = "failed to run %s scan. Exit code received: %s"
 	jfrogCliAnalyzerManagerVersionEnvVariable = "JFROG_CLI_ANALYZER_MANAGER_VERSION"
+	JF_MSI                                    = "JF_MSI"
 )
 
 type ApplicabilityStatus string
@@ -91,7 +92,7 @@ func (am *AnalyzerManager) ExecWithOutputFile(configFile, scanCommand, workingDi
 		return
 	}
 	var cmd *exec.Cmd
-	multiScanId := os.Getenv("JF_MSI")
+	multiScanId := os.Getenv(JF_MSI)
 	if len(outputFile) > 0 {
 		log.Debug("Executing", am.AnalyzerManagerFullPath, scanCommand, configFile, outputFile, multiScanId)
 		cmd = exec.Command(am.AnalyzerManagerFullPath, scanCommand, configFile, outputFile)


### PR DESCRIPTION
Analyzer Manager is expecting to get the multi_scan_id as env variable named JF_MSI. 

PR for creating this env variable right after we get the multi_scan_id from xsc (in jfrog-client-go):
https://github.com/jfrog/jfrog-client-go/pull/883