### PR TITLE
Ignore test secrets in scans

### DIFF
--- a/commands/audit/jas/secrets/secretsscanner_test.go
+++ b/commands/audit/jas/secrets/secretsscanner_test.go
@@ -123,6 +123,7 @@ func TestHideSecret(t *testing.T) {
 		{secret: "12", expectedOutput: "***"},
 		{secret: "123", expectedOutput: "***"},
 		{secret: "123456789", expectedOutput: "123************"},
+		// jfrog-ignore: test case
 		{secret: "3478hfnkjhvd848446gghgfh", expectedOutput: "347************"},
 	}
 

--- a/commands/audit/sca/go/gloang_test.go
+++ b/commands/audit/sca/go/gloang_test.go
@@ -50,7 +50,7 @@ func TestBuildGoDependencyList(t *testing.T) {
 	rootNode, uniqueDeps, err := BuildDependencyTree(auditBasicParams)
 	assert.NoError(t, err)
 	assert.ElementsMatch(t, uniqueDeps, expectedUniqueDeps, "First is actual, Second is Expected")
-
+	// jfrog-ignore: test case
 	assert.Equal(t, "https://user:sdsdccs2232@api.go.here/artifactory/api/go/test-remote|direct", os.Getenv("GOPROXY"))
 	assert.NotEmpty(t, rootNode)
 


### PR DESCRIPTION
- [ ] The pull request is targeting the `dev` branch.
- [ ] The code has been validated to compile successfully by running `go vet ./...`.
- [ ] The code has been formatted properly using `go fmt ./...`.
- [ ] All [static analysis checks](https://github.com/jfrog/jfrog-cli-security/actions/workflows/analysis.yml) passed.
- [ ] All [tests](https://github.com/jfrog/jfrog-cli-security/actions/workflows/test.yml) have passed. If this feature is not already covered by the tests, new tests have been added.

-----

Ignore results that shows at JFrog secret scan.
Reason: Test cases