### PR TITLE
Add the logic of sending git info request to xsc

### DIFF
--- a/commands/audit/audit.go
+++ b/commands/audit/audit.go
@@ -2,10 +2,10 @@ package audit
 
 import (
 	"errors"
+	"github.com/jfrog/jfrog-cli-security/scangraph"
 	"os"
 
 	"github.com/jfrog/jfrog-cli-core/v2/utils/coreutils"
-	"github.com/jfrog/jfrog-cli-security/scangraph"
 	"github.com/jfrog/jfrog-cli-security/utils"
 	clientutils "github.com/jfrog/jfrog-client-go/utils"
 	"github.com/jfrog/jfrog-client-go/utils/log"
@@ -170,6 +170,12 @@ func RunAudit(auditParams *AuditParams) (results *xrayutils.Results, err error) 
 	if results.ExtendedScanResults.EntitledForJas {
 		// Download (if needed) the analyzer manager in a background routine.
 		errGroup.Go(utils.DownloadAnalyzerManagerIfNeeded)
+	}
+
+	if auditParams.xrayGraphScanParams.XscGitInfoContext != nil {
+		if err = xrayutils.SendXscGitInfoRequestIfEnabled(auditParams.xrayGraphScanParams, xrayManager); err != nil {
+			return nil, err
+		}
 	}
 
 	// The sca scan doesn't require the analyzer manager, so it can run separately from the analyzer manager download routine.

--- a/commands/audit/sca/common.go
+++ b/commands/audit/sca/common.go
@@ -5,6 +5,7 @@ import (
 	"github.com/jfrog/jfrog-cli-core/v2/utils/coreutils"
 	"github.com/jfrog/jfrog-cli-core/v2/utils/tests"
 	"github.com/jfrog/jfrog-cli-security/scangraph"
+	"github.com/jfrog/jfrog-cli-security/utils"
 	"github.com/jfrog/jfrog-client-go/utils/errorutils"
 	ioUtils "github.com/jfrog/jfrog-client-go/utils/io"
 	"github.com/jfrog/jfrog-client-go/utils/log"
@@ -28,7 +29,11 @@ func RunXrayDependenciesTreeScanGraph(dependencyTree *xrayUtils.GraphNode, progr
 	}
 	log.Info(scanMessage + "...")
 	var scanResults *services.ScanResponse
-	scanResults, err = scangraph.RunScanGraphAndGetResults(scanGraphParams)
+	xrayManager, err := utils.CreateXrayServiceManager(scanGraphParams.ServerDetails())
+	if err != nil {
+		return nil, err
+	}
+	scanResults, err = scangraph.RunScanGraphAndGetResults(scanGraphParams, xrayManager)
 	if err != nil {
 		err = errorutils.CheckErrorf("scanning %s dependencies failed with error: %s", string(technology), err.Error())
 		return

--- a/go.mod
+++ b/go.mod
@@ -100,4 +100,4 @@ require (
 
 // replace github.com/jfrog/jfrog-cli-core/v2 => github.com/jfrog/jfrog-cli-core/v2 dev
 
-// replace github.com/jfrog/jfrog-client-go => github.com/jfrog/jfrog-client-go dev
+replace github.com/jfrog/jfrog-client-go => github.com/orz25/jfrog-client-go v0.0.0-20240204100437-b823bf27a759

--- a/go.sum
+++ b/go.sum
@@ -95,8 +95,6 @@ github.com/jfrog/jfrog-apps-config v1.0.1 h1:mtv6k7g8A8BVhlHGlSveapqf4mJfonwvXYL
 github.com/jfrog/jfrog-apps-config v1.0.1/go.mod h1:8AIIr1oY9JuH5dylz2S6f8Ym2MaadPLR6noCBO4C22w=
 github.com/jfrog/jfrog-cli-core/v2 v2.47.12 h1:xsEVdzbdhNGkI8Ey4Othx5+zpgCMnT99Uy71LOn+Q7k=
 github.com/jfrog/jfrog-cli-core/v2 v2.47.12/go.mod h1:RVn4pIkR5fPUnr8gFXt61ou3pCNrrDdRQUpcolP4lhw=
-github.com/jfrog/jfrog-client-go v1.36.1 h1:22Ucy5XdEP1yHEjbN8zOt2dZys5rbwcwhC3l3pcOdf4=
-github.com/jfrog/jfrog-client-go v1.36.1/go.mod h1:y1WF6eiZ7V2DortiwjpMEicEH6NIJH+hOXI5QI2W3NU=
 github.com/kevinburke/ssh_config v1.2.0 h1:x584FjTGwHzMwvHx18PXxbBVzfnxogHaAReU4gf13a4=
 github.com/kevinburke/ssh_config v1.2.0/go.mod h1:CT57kijsi8u/K/BOFA39wgDQJ9CxiF4nAY/ojJ6r6mM=
 github.com/klauspost/compress v1.4.1/go.mod h1:RyIbtBH6LamlWaDj8nUwkbUhJ87Yi3uG0guNDohfE1A=
@@ -140,6 +138,8 @@ github.com/mitchellh/mapstructure v1.5.0/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RR
 github.com/nwaples/rardecode v1.1.3 h1:cWCaZwfM5H7nAD6PyEdcVnczzV8i/JtotnyW/dD9lEc=
 github.com/nwaples/rardecode v1.1.3/go.mod h1:5DzqNKiOdpKKBH87u8VlvAnPZMXcGRhxWkRpHbbfGS0=
 github.com/onsi/gomega v1.27.10 h1:naR28SdDFlqrG6kScpT8VWpu1xWY5nJRCF3XaYyBjhI=
+github.com/orz25/jfrog-client-go v0.0.0-20240204100437-b823bf27a759 h1:Le0KW6GuT5hWylbHMyXFvujAU8fj11qUTu6+UGIqj+s=
+github.com/orz25/jfrog-client-go v0.0.0-20240204100437-b823bf27a759/go.mod h1:y1WF6eiZ7V2DortiwjpMEicEH6NIJH+hOXI5QI2W3NU=
 github.com/owenrumney/go-sarif v1.1.1/go.mod h1:dNDiPlF04ESR/6fHlPyq7gHKmrM0sHUvAGjsoh8ZH0U=
 github.com/owenrumney/go-sarif/v2 v2.3.0 h1:wP5yEpI53zr0v5cBmagXzLbHZp9Oylyo3AJDpfLBITs=
 github.com/owenrumney/go-sarif/v2 v2.3.0/go.mod h1:MSqMMx9WqlBSY7pXoOZWgEsVB4FDNfhcaXDA1j6Sr+w=

--- a/scangraph/scangraph.go
+++ b/scangraph/scangraph.go
@@ -3,6 +3,7 @@ package scangraph
 import (
 	"github.com/jfrog/jfrog-cli-security/utils"
 	clientutils "github.com/jfrog/jfrog-client-go/utils"
+	"github.com/jfrog/jfrog-client-go/xray"
 	"github.com/jfrog/jfrog-client-go/xray/services"
 	"golang.org/x/text/cases"
 	"golang.org/x/text/language"
@@ -13,22 +14,11 @@ const (
 	ScanTypeMinXrayVersion  = "3.37.2"
 )
 
-func RunScanGraphAndGetResults(params *ScanGraphParams) (*services.ScanResponse, error) {
-	xrayManager, err := utils.CreateXrayServiceManager(params.serverDetails)
-	if err != nil {
-		return nil, err
-	}
-
-	err = clientutils.ValidateMinimumVersion(clientutils.Xray, params.xrayVersion, ScanTypeMinXrayVersion)
+func RunScanGraphAndGetResults(params *ScanGraphParams, xrayManager *xray.XrayServicesManager) (*services.ScanResponse, error) {
+	err := clientutils.ValidateMinimumVersion(clientutils.Xray, params.xrayVersion, ScanTypeMinXrayVersion)
 	if err != nil {
 		// Remove scan type param if Xray version is under the minimum supported version
 		params.xrayGraphScanParams.ScanType = ""
-	}
-
-	if params.xrayGraphScanParams.XscGitInfoContext != nil {
-		if params.xrayGraphScanParams.XscVersion, err = xrayManager.XscEnabled(); err != nil {
-			return nil, err
-		}
 	}
 
 	scanId, err := xrayManager.ScanGraph(*params.xrayGraphScanParams)

--- a/utils/xraymanager.go
+++ b/utils/xraymanager.go
@@ -1,9 +1,13 @@
 package utils
 
 import (
+	"fmt"
 	"github.com/jfrog/jfrog-cli-core/v2/utils/config"
 	clientconfig "github.com/jfrog/jfrog-client-go/config"
+	"github.com/jfrog/jfrog-client-go/utils/log"
 	"github.com/jfrog/jfrog-client-go/xray"
+	"github.com/jfrog/jfrog-client-go/xray/services"
+	"os"
 )
 
 func CreateXrayServiceManager(serviceDetails *config.ServerDetails) (*xray.XrayServicesManager, error) {
@@ -30,4 +34,22 @@ func CreateXrayServiceManagerAndGetVersion(serviceDetails *config.ServerDetails)
 		return nil, "", err
 	}
 	return xrayManager, xrayVersion, nil
+}
+
+func SendXscGitInfoRequestIfEnabled(graphScanParams *services.XrayGraphScanParams, xrayManager *xray.XrayServicesManager) (err error) {
+	if graphScanParams.XscVersion, err = xrayManager.XscEnabled(); err != nil {
+		return err
+	}
+	if graphScanParams.XscVersion != "" && graphScanParams.MultiScanId == "" {
+		multiScanId, err := xrayManager.SendXscGitInfoRequest(graphScanParams.XscGitInfoContext)
+		if err != nil {
+			return fmt.Errorf("failed sending Git Info request to XSC service, error: %s ", err.Error())
+		}
+		graphScanParams.MultiScanId = multiScanId
+		if err = os.Setenv("JF_MSI", multiScanId); err != nil {
+			// Not a fatal error, if not set the scan will not be shown at the XSC UI, should not fail the scan.
+			log.Debug(fmt.Sprintf("failed setting MSI as environment variable. Cause: %s", err.Error()))
+		}
+	}
+	return nil
 }


### PR DESCRIPTION
- [ ] The pull request is targeting the `dev` branch.
- [ ] The code has been validated to compile successfully by running `go vet ./...`.
- [ ] The code has been formatted properly using `go fmt ./...`.
- [ ] All [static analysis checks](https://github.com/jfrog/jfrog-cli-security/actions/workflows/analysis.yml) passed.
- [ ] All [tests](https://github.com/jfrog/jfrog-cli-security/actions/workflows/test.yml) have passed. If this feature is not already covered by the tests, new tests have been added.

-----

Add the logic of sending git info request to xsc (taken from client-go package) in order to have one multi scan id to multiple sca scans (we send a scan request per technology and we wish to associate all the scans to one multi scan id).