### PR TITLE
If project flag provided with empty value, act like there is no project

### DIFF
--- a/cli/scancommands.go
+++ b/cli/scancommands.go
@@ -230,7 +230,10 @@ func validateXrayContext(c *components.Context, serverDetails *coreConfig.Server
 }
 
 func isProjectProvided(c *components.Context) bool {
-	return c.GetStringFlagValue(flags.Project) != "" || os.Getenv(coreutils.Project) != ""
+	if c.IsFlagSet(flags.Project) {
+		return c.GetStringFlagValue(flags.Project) != ""
+	}
+	return os.Getenv(coreutils.Project) != ""
 }
 
 func addTrailingSlashToRepoPathIfNeeded(c *components.Context) string {


### PR DESCRIPTION
- [x] The pull request is targeting the `dev` branch.
- [x] The code has been validated to compile successfully by running `go vet ./...`.
- [x] The code has been formatted properly using `go fmt ./...`.
- [x] All [static analysis checks](https://github.com/jfrog/jfrog-cli-security/actions/workflows/analysis.yml) passed.
- [x] All [tests](https://github.com/jfrog/jfrog-cli-security/actions/workflows/test.yml) have passed. If this feature is not already covered by the tests, new tests have been added.

-----