### PR TITLE
Audit - Add artifactory resolution for Pnpm

### DIFF
--- a/artifactory_test.go
+++ b/artifactory_test.go
@@ -46,6 +46,12 @@ func TestDependencyResolutionFromArtifactory(t *testing.T) {
 			projectType:     project.Npm,
 		},
 		{
+			testProjectPath: []string{"npm", "npm-no-lock"},
+			resolveRepoName: securityTests.PnpmRemoteRepo,
+			cacheRepoName:   securityTests.PnpmRemoteRepo,
+			projectType:     project.Pnpm,
+		},
+		{
 			testProjectPath: []string{"dotnet", "dotnet-single"},
 			resolveRepoName: securityTests.NugetRemoteRepo,
 			cacheRepoName:   securityTests.NugetRemoteRepo,

--- a/artifactory_test.go
+++ b/artifactory_test.go
@@ -2,11 +2,13 @@ package main
 
 import (
 	"errors"
-	"github.com/stretchr/testify/require"
+	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 
 	"github.com/jfrog/jfrog-cli-core/v2/utils/dependencies"
 	"github.com/jfrog/jfrog-client-go/utils/io/fileutils"
@@ -151,7 +153,7 @@ func testSingleTechDependencyResolution(t *testing.T, testProjectPartialPath []s
 	}
 
 	// Executing the 'audit' command on an uninstalled project, we anticipate the resolution of dependencies from the configured Artifactory server and repository.
-	assert.NoError(t, securityTests.PlatformCli.WithoutCredentials().Exec("audit"))
+	assert.NoError(t, securityTests.PlatformCli.WithoutCredentials().Exec("audit", fmt.Sprintf("--%s", projectType.String())))
 
 	// Following resolution from Artifactory, we anticipate the repository's cache to contain data.
 	output := coreTests.RunCmdWithOutput(t, func() error {

--- a/commands/audit/sca/npm/npm.go
+++ b/commands/audit/sca/npm/npm.go
@@ -35,7 +35,7 @@ func BuildDependencyTree(params utils.AuditParams) (dependencyTrees []*xrayUtils
 
 	treeDepsParam := createTreeDepsParam(params)
 
-	clearResolutionServerFunc, err := configNpmResolutionServerIfNeeded(params)
+	clearResolutionServerFunc, err := ConfigNpmResolutionServerIfNeeded(params)
 	if err != nil {
 		err = fmt.Errorf("failed while configuring a resolution server: %s", err.Error())
 		return
@@ -63,7 +63,7 @@ func BuildDependencyTree(params utils.AuditParams) (dependencyTrees []*xrayUtils
 }
 
 // Generates a .npmrc file to configure an Artifactory server as the resolver server.
-func configNpmResolutionServerIfNeeded(params utils.AuditParams) (clearResolutionServerFunc func() error, err error) {
+func ConfigNpmResolutionServerIfNeeded(params utils.AuditParams) (clearResolutionServerFunc func() error, err error) {
 	// If we don't have an artifactory repo's name we don't need to configure any Artifactory server as resolution server
 	if params.DepsRepo() == "" {
 		return

--- a/tests/consts.go
+++ b/tests/consts.go
@@ -36,6 +36,7 @@ var (
 	DockerLocalRepo   = "cli-docker-local"
 	DockerRemoteRepo  = "cli-docker-remote"
 	NpmRemoteRepo     = "cli-npm-remote"
+	PnpmRemoteRepo    = "cli-pnpm-remote"
 	NugetRemoteRepo   = "cli-nuget-remote"
 	YarnRemoteRepo    = "cli-yarn-remote"
 	GradleRemoteRepo  = "cli-gradle-remote"
@@ -52,6 +53,7 @@ const (
 	DockerLocalRepositoryConfig   = "docker_local_repository_config.json"
 	DockerRemoteRepositoryConfig  = "docker_remote_repository_config.json"
 	NpmRemoteRepositoryConfig     = "npm_remote_repository_config.json"
+	PnpmRemoteRepositoryConfig    = "pnpm_remote_repository_config.json"
 	NugetRemoteRepositoryConfig   = "nuget_remote_repository_config.json"
 	YarnRemoteRepositoryConfig    = "yarn_remote_repository_config.json"
 	GradleRemoteRepositoryConfig  = "gradle_remote_repository_config.json"
@@ -73,6 +75,7 @@ var reposConfigMap = map[*string]string{
 	&DockerLocalRepo:   DockerLocalRepositoryConfig,
 	&DockerRemoteRepo:  DockerRemoteRepositoryConfig,
 	&NpmRemoteRepo:     NpmRemoteRepositoryConfig,
+	&PnpmRemoteRepo:    PnpmRemoteRepositoryConfig,
 	&NugetRemoteRepo:   NugetRemoteRepositoryConfig,
 	&YarnRemoteRepo:    YarnRemoteRepositoryConfig,
 	&GradleRemoteRepo:  GradleRemoteRepositoryConfig,
@@ -87,7 +90,7 @@ var reposConfigMap = map[*string]string{
 func GetNonVirtualRepositories() map[*string]string {
 	nonVirtualReposMap := map[*bool][]*string{
 		TestDockerScan: {&DockerLocalRepo, &DockerRemoteRepo},
-		TestSecurity:   {&NpmRemoteRepo, &NugetRemoteRepo, &YarnRemoteRepo, &GradleRemoteRepo, &MvnRemoteRepo, &GoRepo, &GoRemoteRepo, &PypiRemoteRepo},
+		TestSecurity:   {&NpmRemoteRepo, &PnpmRemoteRepo, &NugetRemoteRepo, &YarnRemoteRepo, &GradleRemoteRepo, &MvnRemoteRepo, &GoRepo, &GoRemoteRepo, &PypiRemoteRepo},
 	}
 	return getNeededRepositories(nonVirtualReposMap)
 }
@@ -151,6 +154,7 @@ func AddTimestampToGlobalVars() {
 	GradleRemoteRepo += uniqueSuffix
 	MvnRemoteRepo += uniqueSuffix
 	NpmRemoteRepo += uniqueSuffix
+	PnpmRemoteRepo += uniqueSuffix
 	NugetRemoteRepo += uniqueSuffix
 	YarnRemoteRepo += uniqueSuffix
 	PypiRemoteRepo += uniqueSuffix
@@ -175,6 +179,7 @@ func GetSubstitutionMap() map[string]string {
 		"${GRADLE_REMOTE_REPO}": GradleRemoteRepo,
 		"${MAVEN_REMOTE_REPO}":  MvnRemoteRepo,
 		"${NPM_REMOTE_REPO}":    NpmRemoteRepo,
+		"${PNPM_REMOTE_REPO}":   PnpmRemoteRepo,
 		"${NUGET_REMOTE_REPO}":  NugetRemoteRepo,
 		"${PYPI_REMOTE_REPO}":   PypiRemoteRepo,
 		"${YARN_REMOTE_REPO}":   YarnRemoteRepo,

--- a/tests/testdata/artifactory-repo-configs/pnpm_remote_repository_config.json
+++ b/tests/testdata/artifactory-repo-configs/pnpm_remote_repository_config.json
@@ -1,0 +1,6 @@
+{
+  "key": "${PNPM_REMOTE_REPO}",
+  "rclass": "remote",
+  "packageType": "npm",
+  "url": "https://registry.npmjs.org"
+}


### PR DESCRIPTION
- [x] The pull request is targeting the `dev` branch.
- [x] The code has been validated to compile successfully by running `go vet ./...`.
- [x] The code has been formatted properly using `go fmt ./...`.
- [x] All [static analysis checks](https://github.com/jfrog/jfrog-cli-security/actions/workflows/analysis.yml) passed.
- [ ] All [tests](https://github.com/jfrog/jfrog-cli-security/actions/workflows/test.yml) have passed. If this feature is not already covered by the tests, new tests have been added.
- [x] All changes are detailed at the description. if not already covered at [JFrog Documentation](https://github.com/jfrog/documentation), new documentation have been added.

-----

When running `Audit` and installing the pnpm project, take into consideration the configured resolution server