### PR TITLE
Curation - Generate a cache directory dedicated to each project

### DIFF
--- a/commands/audit/scarunner.go
+++ b/commands/audit/scarunner.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"github.com/jfrog/jfrog-client-go/utils/io/fileutils"
 	"os"
 	"time"
 
@@ -174,12 +175,26 @@ func getDirectDependenciesFromTree(dependencyTrees []*xrayCmdUtils.GraphNode) []
 	return directDependencies.ToSlice()
 }
 
+func getCurationCacheByTech(tech coreutils.Technology) (string, error) {
+	if tech == coreutils.Maven {
+		return xrayutils.GetCurationMavenCacheFolder(true)
+	}
+	return "", nil
+}
+
 func GetTechDependencyTree(params xrayutils.AuditParams, tech coreutils.Technology) (flatTree *xrayCmdUtils.GraphNode, fullDependencyTrees []*xrayCmdUtils.GraphNode, err error) {
 	logMessage := fmt.Sprintf("Calculating %s dependencies", tech.ToFormal())
+	// in case it's not curation command these params will be empty
+	curationLogMsg, curationCacheFolder, err := getCurationCacheFolderAndLogMsg(params, tech)
+	if err != nil {
+		return
+	}
+	logMessage += curationLogMsg
 	log.Info(logMessage + "...")
 	if params.Progress() != nil {
 		params.Progress().SetHeadlineMsg(logMessage)
 	}
+
 	err = SetResolutionRepoIfExists(params, tech)
 	if err != nil {
 		return
@@ -191,15 +206,9 @@ func GetTechDependencyTree(params xrayutils.AuditParams, tech coreutils.Technolo
 	var uniqueDeps []string
 	var uniqDepsWithTypes map[string][]string
 	startTime := time.Now()
+
 	switch tech {
 	case coreutils.Maven, coreutils.Gradle:
-		curationCacheFolder := ""
-		if params.IsCurationCmd() {
-			curationCacheFolder, err = xrayutils.GetCurationMavenCacheFolder()
-			if err != nil {
-				return
-			}
-		}
 		fullDependencyTrees, uniqDepsWithTypes, err = java.BuildDependencyTree(java.DepTreeParams{
 			Server:                  serverDetails,
 			DepsRepo:                params.DepsRepo(),
@@ -236,6 +245,29 @@ func GetTechDependencyTree(params xrayutils.AuditParams, tech coreutils.Technolo
 	}
 	flatTree, err = createFlatTree(uniqueDeps)
 	return
+}
+
+func getCurationCacheFolderAndLogMsg(params xrayutils.AuditParams, tech coreutils.Technology) (logMessage string, curationCacheFolder string, err error) {
+	if params.IsCurationCmd() {
+		curationCacheFolder, err = getCurationCacheByTech(tech)
+		if err != nil {
+			return logMessage, curationCacheFolder, err
+		}
+
+		if isExist, err := fileutils.IsDirExists(curationCacheFolder, false); isExist {
+			if isEmpty, err := fileutils.IsDirEmpty(curationCacheFolder); !isEmpty {
+				return logMessage, curationCacheFolder, err
+			} else if err != nil {
+				return logMessage, curationCacheFolder, err
+			}
+		} else if err != nil {
+			return logMessage, curationCacheFolder, err
+		}
+
+		logMessage = ". Project's cache is currently empty, so this run may take longer to complete"
+
+	}
+	return logMessage, curationCacheFolder, err
 }
 
 // Associates a technology with another of a different type in the structure.

--- a/commands/audit/scarunner.go
+++ b/commands/audit/scarunner.go
@@ -261,7 +261,8 @@ func getCurationCacheFolderAndLogMsg(params xrayutils.AuditParams, tech coreutil
 	}
 
 	if dirExist {
-		if dirIsEmpty, err := fileutils.IsDirEmpty(curationCacheFolder); err != nil || !dirIsEmpty {
+		if dirIsEmpty, scopErr := fileutils.IsDirEmpty(curationCacheFolder); scopErr != nil || !dirIsEmpty {
+			err = scopErr
 			return
 		}
 	}

--- a/commands/curation/curationaudit_test.go
+++ b/commands/curation/curationaudit_test.go
@@ -496,7 +496,12 @@ func getTestCasesForDoCurationAudit() []testCase {
 			pathToPreTest: filepath.Join(TestDataDir, "projects", "package-managers", "maven", "maven-curation", "pretest"),
 			preTestExec:   "mvn",
 			funcToGetGoals: func(t *testing.T) []string {
-				curationCache, err := utils.GetCurationMavenCacheFolder(false)
+				rootDir, err := os.Getwd()
+				assert.NoError(t, err)
+				// set the cache to test project dir, in order to fill its cache with dependencies
+				callbackPreTest := clienttestutils.ChangeDirWithCallback(t, rootDir, filepath.Join("..", "test"))
+				curationCache, err := utils.GetCurationMavenCacheFolder(true)
+				callbackPreTest()
 				require.NoError(t, err)
 				return []string{"com.jfrog:maven-dep-tree:tree", "-DdepsTreeOutputFile=output", "-Dmaven.repo.local=" + curationCache}
 			},

--- a/commands/curation/curationaudit_test.go
+++ b/commands/curation/curationaudit_test.go
@@ -500,7 +500,7 @@ func getTestCasesForDoCurationAudit() []testCase {
 				assert.NoError(t, err)
 				// set the cache to test project dir, in order to fill its cache with dependencies
 				callbackPreTest := clienttestutils.ChangeDirWithCallback(t, rootDir, filepath.Join("..", "test"))
-				curationCache, err := utils.GetCurationMavenCacheFolder(true)
+				curationCache, err := utils.GetCurationMavenCacheFolder()
 				callbackPreTest()
 				require.NoError(t, err)
 				return []string{"com.jfrog:maven-dep-tree:tree", "-DdepsTreeOutputFile=output", "-Dmaven.repo.local=" + curationCache}

--- a/commands/curation/curationaudit_test.go
+++ b/commands/curation/curationaudit_test.go
@@ -496,7 +496,7 @@ func getTestCasesForDoCurationAudit() []testCase {
 			pathToPreTest: filepath.Join(TestDataDir, "projects", "package-managers", "maven", "maven-curation", "pretest"),
 			preTestExec:   "mvn",
 			funcToGetGoals: func(t *testing.T) []string {
-				curationCache, err := utils.GetCurationMavenCacheFolder()
+				curationCache, err := utils.GetCurationMavenCacheFolder(false)
 				require.NoError(t, err)
 				return []string{"com.jfrog:maven-dep-tree:tree", "-DdepsTreeOutputFile=output", "-Dmaven.repo.local=" + curationCache}
 			},

--- a/utils/paths.go
+++ b/utils/paths.go
@@ -1,6 +1,8 @@
 package utils
 
 import (
+	"crypto/sha1"
+	"encoding/hex"
 	"github.com/jfrog/jfrog-cli-core/v2/utils/coreutils"
 	"os"
 	"path/filepath"
@@ -35,10 +37,23 @@ func GetCurationCacheFolder() (string, error) {
 	return filepath.Join(curationFolder, "cache"), nil
 }
 
-func GetCurationMavenCacheFolder() (string, error) {
+func GetCurationMavenCacheFolder(withProjectDir bool) (string, error) {
 	curationFolder, err := GetCurationCacheFolder()
 	if err != nil {
 		return "", err
 	}
-	return filepath.Join(curationFolder, "maven"), nil
+	projectDir := ""
+	if withProjectDir {
+		workingDir, err := os.Getwd()
+		if err != nil {
+			return "", err
+		}
+		hasher := sha1.New()
+		_, err = hasher.Write([]byte(workingDir))
+		if err != nil {
+			return "", err
+		}
+		projectDir = hex.EncodeToString(hasher.Sum(nil))
+	}
+	return filepath.Join(curationFolder, "maven", projectDir), nil
 }

--- a/utils/paths.go
+++ b/utils/paths.go
@@ -1,6 +1,7 @@
 package utils
 
 import (
+	// #nosec G505 -- Not in use for secrets.
 	"crypto/sha1"
 	"encoding/hex"
 	"github.com/jfrog/jfrog-cli-core/v2/utils/coreutils"
@@ -48,6 +49,7 @@ func GetCurationMavenCacheFolder(withProjectDir bool) (string, error) {
 		if err != nil {
 			return "", err
 		}
+		// #nosec G401 -- Not a secret hash.
 		hasher := sha1.New()
 		_, err = hasher.Write([]byte(workingDir))
 		if err != nil {

--- a/utils/paths.go
+++ b/utils/paths.go
@@ -38,24 +38,21 @@ func GetCurationCacheFolder() (string, error) {
 	return filepath.Join(curationFolder, "cache"), nil
 }
 
-func GetCurationMavenCacheFolder(withProjectDir bool) (string, error) {
+func GetCurationMavenCacheFolder() (projectDir string, err error) {
 	curationFolder, err := GetCurationCacheFolder()
 	if err != nil {
 		return "", err
 	}
-	projectDir := ""
-	if withProjectDir {
-		workingDir, err := os.Getwd()
-		if err != nil {
-			return "", err
-		}
-		// #nosec G401 -- Not a secret hash.
-		hasher := sha1.New()
-		_, err = hasher.Write([]byte(workingDir))
-		if err != nil {
-			return "", err
-		}
-		projectDir = hex.EncodeToString(hasher.Sum(nil))
+	workingDir, err := os.Getwd()
+	if err != nil {
+		return "", err
 	}
-	return filepath.Join(curationFolder, "maven", projectDir), nil
+	// #nosec G401 -- Not a secret hash.
+	hasher := sha1.New()
+	_, err = hasher.Write([]byte(workingDir))
+	if err != nil {
+		return "", err
+	}
+	projectDir = filepath.Join(curationFolder, "maven", hex.EncodeToString(hasher.Sum(nil)))
+	return
 }


### PR DESCRIPTION
- [X] The pull request is targeting the `dev` branch.
- [X] The code has been validated to compile successfully by running `go vet ./...`.
- [X] The code has been formatted properly using `go fmt ./...`.
- [X] All [static analysis checks](https://github.com/jfrog/jfrog-cli-security/actions/workflows/analysis.yml) passed.
- [X] All [tests](https://github.com/jfrog/jfrog-cli-security/actions/workflows/test.yml) have passed. If this feature is not already covered by the tests, new tests have been added.
- [X] All changes are detailed at the description. if not already covered at [JFrog Documentation](https://github.com/jfrog/documentation), new documentation have been added.

-----

Generate a cache directory dedicated to each project and inform the user that the initial setup might result in longer processing times due to an empty cache.