### PR TITLE
Fix testdata project path in Yarn tests

### DIFF
--- a/commands/audit/sca/yarn/yarn_test.go
+++ b/commands/audit/sca/yarn/yarn_test.go
@@ -62,9 +62,6 @@ func TestIsInstallRequired(t *testing.T) {
 	assert.NoError(t, err)
 	assert.True(t, installRequired)
 
-	// Validates we are not operating on an empty test dir.
-	// Yarn 1, That is currently installed on the machines that are running the tests, allows running 'install' on an empty project. This makes the test pass without actually checking what needs to be checked.
-	// This check can be deleted after the Yarn version on the runner machine will be upgraded to Yarn berry.
 	isTempDirEmpty, err := fileutils.IsDirEmpty(tempDirPath)
 	assert.NoError(t, err)
 	assert.False(t, isTempDirEmpty)
@@ -97,9 +94,6 @@ func executeRunYarnInstallAccordingToVersionAndVerifyInstallation(t *testing.T, 
 	yarnProjectPath := filepath.Join("..", "..", "..", "..", "tests", "testdata", "projects", "package-managers", "yarn", "yarn-project")
 	assert.NoError(t, utils2.CopyDir(yarnProjectPath, tempDirPath, true, nil))
 
-	// Validates we are not operating on an empty test dir.
-	// Yarn 1, That is currently installed on the machines that are running the tests, allows running 'install' on an empty project. This makes the test pass without actually checking what needs to be checked.
-	// This check can be deleted after the Yarn version on the runner machine will be upgraded to Yarn berry.
 	isTempDirEmpty, err := fileutils.IsDirEmpty(tempDirPath)
 	assert.NoError(t, err)
 	assert.False(t, isTempDirEmpty)

--- a/commands/audit/sca/yarn/yarn_test.go
+++ b/commands/audit/sca/yarn/yarn_test.go
@@ -55,7 +55,7 @@ func TestParseYarnDependenciesList(t *testing.T) {
 func TestIsInstallRequired(t *testing.T) {
 	tempDirPath, createTempDirCallback := tests.CreateTempDirWithCallbackAndAssert(t)
 	defer createTempDirCallback()
-	yarnProjectPath := filepath.Join("..", "..", "..", "testdata", "yarn-project")
+	yarnProjectPath := filepath.Join("..", "..", "..", "..", "tests", "testdata", "projects", "package-managers", "yarn", "yarn-project")
 	assert.NoError(t, utils2.CopyDir(yarnProjectPath, tempDirPath, true, nil))
 	installRequired, err := isInstallRequired(tempDirPath, []string{})
 	assert.NoError(t, err)
@@ -85,8 +85,10 @@ func TestRunYarnInstallAccordingToVersion(t *testing.T) {
 func executeRunYarnInstallAccordingToVersionAndVerifyInstallation(t *testing.T, params []string) {
 	tempDirPath, createTempDirCallback := tests.CreateTempDirWithCallbackAndAssert(t)
 	defer createTempDirCallback()
-	yarnProjectPath := filepath.Join("..", "..", "..", "testdata", "yarn-project")
-	assert.NoError(t, utils2.CopyDir(yarnProjectPath, tempDirPath, true, nil))
+	yarnProjectPath := filepath.Join("..", "..", "..", "..", "tests", "testdata", "projects", "package-managers", "yarn", "yarn-project")
+	fullPath, err := filepath.Abs(yarnProjectPath)
+	assert.NoError(t, err)
+	assert.NoError(t, utils2.CopyDir(fullPath, tempDirPath, true, nil))
 
 	executablePath, err := biutils.GetYarnExecutable()
 	assert.NoError(t, err)


### PR DESCRIPTION
- [x] The pull request is targeting the `dev` branch.
- [x] The code has been validated to compile successfully by running `go vet ./...`.
- [x] The code has been formatted properly using `go fmt ./...`.
- [x] All [static analysis checks](https://github.com/jfrog/jfrog-cli-security/actions/workflows/analysis.yml) passed.
- [x] All [tests](https://github.com/jfrog/jfrog-cli-security/actions/workflows/test.yml) have passed. If this feature is not already covered by the tests, new tests have been added.
- [x] All changes are detailed at the description. if not already covered at [JFrog Documentation](https://github.com/jfrog/documentation), new documentation have been added.

-----
This PR fixs testdata project path in yarn tests. The local path for the tests projects was changed during the migration to security-cli but the path wasn't changed in the tests.
The tests currently pass in Prod since the machine that runs the tests contains lower yarn version (Yarn 1), that enables running 'install' on an empty directory, which causes the tests to pass without actually checking what the test is intended to check. 
This is not allowed in higher yarn versions.