### PR TITLE
Always show relative target on command summary

### DIFF
--- a/utils/securityJobSummary.go
+++ b/utils/securityJobSummary.go
@@ -72,7 +72,7 @@ func loadContentFromFiles(dataFilePaths []string, scs *SecurityCommandsSummary) 
 		}
 		results := cmdResults.Results
 		// Update the working directory
-		updateSummaryNamesToRelativePath(cmdResults.WorkingDirectory, &results)
+		updateSummaryNamesToRelativePath(&results, cmdResults.WorkingDirectory)
 		// Append the new data
 		switch cmdResults.Section {
 		case Build:
@@ -339,20 +339,18 @@ func GetSummaryContentString(summary formats.SummaryCount, delimiter string, wra
 	return
 }
 
-func updateSummaryNamesToRelativePath(wd string, summaries ...*formats.SummaryResults) {
-	for _, summary := range summaries {
-		for i, scan := range summary.Scans {
-			if scan.Target == "" {
-				continue
-			}
-			if !strings.HasPrefix(scan.Target, wd) {
-				continue
-			}
-			if scan.Target == wd {
-				summary.Scans[i].Target = filepath.Base(wd)
-			}
-			summary.Scans[i].Target = strings.TrimPrefix(scan.Target, wd)
+func updateSummaryNamesToRelativePath(summary *formats.SummaryResults, wd string) {
+	for i, scan := range summary.Scans {
+		if scan.Target == "" {
+			continue
 		}
+		if !strings.HasPrefix(scan.Target, wd) {
+			continue
+		}
+		if scan.Target == wd {
+			summary.Scans[i].Target = filepath.Base(wd)
+		}
+		summary.Scans[i].Target = strings.TrimPrefix(scan.Target, wd)
 	}
 }
 

--- a/utils/securityJobSummary.go
+++ b/utils/securityJobSummary.go
@@ -117,9 +117,7 @@ func ConvertSummaryToString(results SecurityCommandsSummary) (summary string, er
 	addSectionTitle := len(sectionsWithContent) > 1
 	var sectionSummary string
 	for i, section := range sectionsWithContent {
-		if sectionSummary, err = getSummaryString(results.getSectionSummaries(section)...); err != nil {
-			return
-		}
+		sectionSummary = getSummaryString(results.getSectionSummaries(section)...)
 		if addSectionTitle {
 			if i > 0 {
 				summary += "\n"
@@ -131,7 +129,7 @@ func ConvertSummaryToString(results SecurityCommandsSummary) (summary string, er
 	return
 }
 
-func getSummaryString(summaries ...formats.SummaryResults) (str string, err error) {
+func getSummaryString(summaries ...formats.SummaryResults) (str string) {
 	parsed := 0
 	singleScan := isSingleCommandAndScan(summaries...)
 	if !singleScan {

--- a/utils/securityJobSummary_test.go
+++ b/utils/securityJobSummary_test.go
@@ -27,8 +27,9 @@ func TestConvertSummaryToString(t *testing.T) {
 			name: "One Section - No Issues",
 			summary: getDummySecurityCommandsSummary(
 				ScanCommandSummaryResult{
-					Section: Binary,
-					Results: formats.SummaryResults{Scans: []formats.ScanSummaryResult{{Target: filepath.Join(wd, "binary-name")}}},
+					Section:          Binary,
+					WorkingDirectory: wd,
+					Results:          formats.SummaryResults{Scans: []formats.ScanSummaryResult{{Target: filepath.Join(wd, "binary-name")}}},
 				},
 			),
 			expectedContentPath: filepath.Join(summaryExpectedContentDir, "single_no_issue.md"),
@@ -66,7 +67,8 @@ func TestConvertSummaryToString(t *testing.T) {
 					}}},
 				},
 				ScanCommandSummaryResult{
-					Section: Binary,
+					Section:          Binary,
+					WorkingDirectory: wd,
 					Results: formats.SummaryResults{Scans: []formats.ScanSummaryResult{
 						{
 							Target: filepath.Join(wd, "binary-name"),
@@ -81,7 +83,8 @@ func TestConvertSummaryToString(t *testing.T) {
 					}},
 				},
 				ScanCommandSummaryResult{
-					Section: Modules,
+					Section:          Modules,
+					WorkingDirectory: wd,
 					Results: formats.SummaryResults{Scans: []formats.ScanSummaryResult{
 						{
 							Target: filepath.Join(wd, "application1"),
@@ -141,6 +144,9 @@ func getDummySecurityCommandsSummary(cmdResults ...ScanCommandSummaryResult) Sec
 		AuditCommands:     []formats.SummaryResults{},
 	}
 	for _, cmdResult := range cmdResults {
+		results := cmdResult.Results
+		// Update the working directory
+		updateSummaryNamesToRelativePath(&results, cmdResult.WorkingDirectory)
 		switch cmdResult.Section {
 		case Build:
 			summary.BuildScanCommands = append(summary.BuildScanCommands, cmdResult.Results)


### PR DESCRIPTION
- [x] The pull request is targeting the `dev` branch.
- [x] The code has been validated to compile successfully by running `go vet ./...`.
- [x] The code has been formatted properly using `go fmt ./...`.
- [x] All [static analysis checks](https://github.com/jfrog/jfrog-cli-security/actions/workflows/analysis.yml) passed.
- [x] All [tests](https://github.com/jfrog/jfrog-cli-security/actions/workflows/test.yml) have passed. If this feature is not already covered by the tests, new tests have been added.
- [x] All changes are detailed at the description. if not already covered at [JFrog Documentation](https://github.com/jfrog/documentation), new documentation have been added.

-----

Fixes:
![image](https://github.com/jfrog/jfrog-cli-security/assets/49212512/584efd88-35cb-4b51-9b8c-6870e21a54c1)
