### PR TITLE
Show image name as target for command summary in docker scan cmd

### DIFF
--- a/commands/scan/dockerscan.go
+++ b/commands/scan/dockerscan.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/jfrog/jfrog-cli-core/v2/common/spec"
+	"github.com/jfrog/jfrog-cli-security/utils"
 	xrayutils "github.com/jfrog/jfrog-cli-security/utils"
 	clientutils "github.com/jfrog/jfrog-client-go/utils"
 	"github.com/jfrog/jfrog-client-go/utils/errorutils"
@@ -93,7 +94,16 @@ func (dsc *DockerScanCommand) Run() (err error) {
 			err = errorutils.CheckError(e)
 		}
 	}()
-	return dsc.ScanCommand.Run()
+	return dsc.ScanCommand.RunAndRecordResults(func(scanResults *utils.Results) (err error) {
+		if scanResults == nil {
+			return
+		}
+		for _, scaResult := range scanResults.ScaResults {
+			// Set the image tag as the target for the scan results (will show `image.tar` as target if not set)
+			scaResult.Target = dsc.imageTag
+		}
+		return utils.RecordSecurityCommandOutput(utils.ScanCommandSummaryResult{Results: scanResults.GetSummary(), Section: utils.Binary})
+	})
 }
 
 // When indexing RPM files inside the docker container, the indexer-app needs to connect to the Xray Server.

--- a/commands/scan/scan.go
+++ b/commands/scan/scan.go
@@ -182,6 +182,12 @@ func (scanCmd *ScanCommand) indexFile(filePath string) (*xrayUtils.BinaryGraphNo
 }
 
 func (scanCmd *ScanCommand) Run() (err error) {
+	return scanCmd.RunAndRecordResults(func(scanResults *utils.Results) error {
+		return utils.RecordSecurityCommandOutput(utils.ScanCommandSummaryResult{Results: scanResults.GetSummary(), Section: utils.Binary})
+	})
+}
+
+func (scanCmd *ScanCommand) RunAndRecordResults(recordResFunc func(scanResults *utils.Results) error) (err error) {
 	defer func() {
 		if err != nil {
 			var e *exec.ExitError
@@ -302,7 +308,7 @@ func (scanCmd *ScanCommand) Run() (err error) {
 		return err
 	}
 
-	if err = utils.RecordSecurityCommandOutput(utils.ScanCommandSummaryResult{Results: scanResults.GetSummary(), Section: utils.Binary}); err != nil {
+	if err = recordResFunc(scanResults); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
- [x] The pull request is targeting the `dev` branch.
- [x] The code has been validated to compile successfully by running `go vet ./...`.
- [x] The code has been formatted properly using `go fmt ./...`.
- [x] All [static analysis checks](https://github.com/jfrog/jfrog-cli-security/actions/workflows/analysis.yml) passed.
- [ ] All [tests](https://github.com/jfrog/jfrog-cli-security/actions/workflows/test.yml) have passed. If this feature is not already covered by the tests, new tests have been added.
- [x] All changes are detailed at the description. if not already covered at [JFrog Documentation](https://github.com/jfrog/documentation), new documentation have been added.

-----

Should show `imageTag` argument as target value in the job summary if `docker scan` command performed.
It was showing the default `image.tar` file path that we are creating hard coded when performing `docker save`

![image](https://github.com/jfrog/jfrog-cli-security/assets/49212512/d35a88a1-b161-4f02-a5c6-ffab1faa9c58)
