### PR TITLE
Add option to run only specific sub scan

### DIFF
--- a/cli/docs/flags.go
+++ b/cli/docs/flags.go
@@ -44,11 +44,11 @@ const (
 )
 
 const (
-	Sca                  = "sca"
-	Iac                  = "iac"
-	Sast                 = "sast"
-	Secrets              = "secrets"
-	NoContextualAnalysis = "without-contextual-analysis"
+	Sca       = "sca"
+	Iac       = "iac"
+	Sast      = "sast"
+	Secrets   = "secrets"
+	WithoutCA = "without-contextual-analysis"
 )
 
 const (
@@ -133,7 +133,7 @@ var commandFlags = map[string][]string{
 		url, user, password, accessToken, ServerId, InsecureTls, Project, Watches, RepoPath, Licenses, OutputFormat, ExcludeTestDeps,
 		useWrapperAudit, DepType, RequirementsFile, Fail, ExtendedTable, WorkingDirs, ExclusionsAudit, Mvn, Gradle, Npm,
 		Pnpm, Yarn, Go, Nuget, Pip, Pipenv, Poetry, MinSeverity, FixableOnly, ThirdPartyContextualAnalysis, Threads,
-		Sca, Iac, Sast, Secrets, NoContextualAnalysis,
+		Sca, Iac, Sast, Secrets, WithoutCA,
 	},
 	CurationAudit: {
 		CurationOutput, WorkingDirs, Threads, RequirementsFile,
@@ -226,13 +226,13 @@ var flagsMap = map[string]components.Flag{
 		"[npm] when set, the Contextual Analysis scan also uses the code of the project dependencies to determine the applicability of the vulnerability.",
 		components.SetHiddenBoolFlag(),
 	),
-	RequirementsFile:     components.NewStringFlag(RequirementsFile, "[Pip] Defines pip requirements file name. For example: 'requirements.txt'."),
-	CurationOutput:       components.NewStringFlag(OutputFormat, "Defines the output format of the command. Acceptable values are: table, json.", components.WithStrDefaultValue("table")),
-	Sca:                  components.NewBoolFlag(Sca, "Set to true to request audit to only preform SCA sub scan."),
-	Iac:                  components.NewBoolFlag(Iac, "Set to true to request audit to only preform IAC sub scan."),
-	Sast:                 components.NewBoolFlag(Sast, "Set to true to request audit to only preform SAST sub scan."),
-	Secrets:              components.NewBoolFlag(Secrets, "Set to true to request audit to only preform Secrets sub scan."),
-	NoContextualAnalysis: components.NewBoolFlag(NoContextualAnalysis, fmt.Sprintf("Set to true to skip the Contextual Analysis scan. This flag is only relevant when using the --%s flag.", Sca)),
+	RequirementsFile: components.NewStringFlag(RequirementsFile, "[Pip] Defines pip requirements file name. For example: 'requirements.txt'."),
+	CurationOutput:   components.NewStringFlag(OutputFormat, "Defines the output format of the command. Acceptable values are: table, json.", components.WithStrDefaultValue("table")),
+	Sca:              components.NewBoolFlag(Sca, "Set to true to request audit to only preform SCA sub scan."),
+	Iac:              components.NewBoolFlag(Iac, "Set to true to request audit to only preform IAC sub scan."),
+	Sast:             components.NewBoolFlag(Sast, "Set to true to request audit to only preform SAST sub scan."),
+	Secrets:          components.NewBoolFlag(Secrets, "Set to true to request audit to only preform Secrets sub scan."),
+	WithoutCA:        components.NewBoolFlag(WithoutCA, fmt.Sprintf("Set to true to skip the Contextual Analysis scan. This flag is only relevant when using the --%s flag.", Sca)),
 }
 
 func GetCommandFlags(cmdKey string) []components.Flag {

--- a/cli/docs/flags.go
+++ b/cli/docs/flags.go
@@ -133,7 +133,7 @@ var commandFlags = map[string][]string{
 		url, user, password, accessToken, ServerId, InsecureTls, Project, Watches, RepoPath, Licenses, OutputFormat, ExcludeTestDeps,
 		useWrapperAudit, DepType, RequirementsFile, Fail, ExtendedTable, WorkingDirs, ExclusionsAudit, Mvn, Gradle, Npm,
 		Pnpm, Yarn, Go, Nuget, Pip, Pipenv, Poetry, MinSeverity, FixableOnly, ThirdPartyContextualAnalysis, Threads,
-		Sca, Iac, Sast, Secrets,
+		Sca, Iac, Sast, Secrets, NoContextualAnalysis,
 	},
 	CurationAudit: {
 		CurationOutput, WorkingDirs, Threads, RequirementsFile,

--- a/cli/docs/flags.go
+++ b/cli/docs/flags.go
@@ -45,6 +45,13 @@ const (
 )
 
 const (
+	Sca     = "sca"
+	Iac     = "iac"
+	Sast    = "sast"
+	Secrets = "secrets"
+)
+
+const (
 	// Base flags keys
 	ServerId    = "server-id"
 	url         = "url"
@@ -126,6 +133,7 @@ var commandFlags = map[string][]string{
 	Audit: {
 		url, user, password, accessToken, ServerId, InsecureTls, Project, Watches, RepoPath, Licenses, OutputFormat, ExcludeTestDeps,
 		useWrapperAudit, DepType, RequirementsFile, Fail, ExtendedTable, WorkingDirs, ExclusionsAudit, Mvn, Gradle, Npm, Pnpm, Yarn, Go, Nuget, Pip, Pipenv, Poetry, MinSeverity, FixableOnly, ThirdPartyContextualAnalysis,
+		Sca, Iac, Sast, Secrets,
 	},
 	CurationAudit: {
 		CurationOutput, WorkingDirs, CurationThreads, RequirementsFile,
@@ -221,6 +229,10 @@ var flagsMap = map[string]components.Flag{
 	RequirementsFile: components.NewStringFlag(RequirementsFile, "[Pip] Defines pip requirements file name. For example: 'requirements.txt'."),
 	CurationThreads:  components.NewStringFlag(Threads, "Number of working threads.", components.WithIntDefaultValue(curation.TotalConcurrentRequests)),
 	CurationOutput:   components.NewStringFlag(OutputFormat, "Defines the output format of the command. Acceptable values are: table, json.", components.WithStrDefaultValue("table")),
+	Sca:              components.NewBoolFlag(Sca, "Set to true to request audit to only preform SCA sub scan."),
+	Iac:              components.NewBoolFlag(Iac, "Set to true to request audit to only preform IAC sub scan."),
+	Sast:             components.NewBoolFlag(Sast, "Set to true to request audit to only preform SAST sub scan."),
+	Secrets:          components.NewBoolFlag(Secrets, "Set to true to request audit to only preform Secrets sub scan."),
 }
 
 func GetCommandFlags(cmdKey string) []components.Flag {

--- a/cli/docs/flags.go
+++ b/cli/docs/flags.go
@@ -44,10 +44,10 @@ const (
 )
 
 const (
-	Sca     = "sca"
-	Iac     = "iac"
-	Sast    = "sast"
-	Secrets = "secrets"
+	Sca                  = "sca"
+	Iac                  = "iac"
+	Sast                 = "sast"
+	Secrets              = "secrets"
 	NoContextualAnalysis = "without-contextual-analysis"
 )
 
@@ -226,12 +226,12 @@ var flagsMap = map[string]components.Flag{
 		"[npm] when set, the Contextual Analysis scan also uses the code of the project dependencies to determine the applicability of the vulnerability.",
 		components.SetHiddenBoolFlag(),
 	),
-	RequirementsFile: components.NewStringFlag(RequirementsFile, "[Pip] Defines pip requirements file name. For example: 'requirements.txt'."),
-	CurationOutput:   components.NewStringFlag(OutputFormat, "Defines the output format of the command. Acceptable values are: table, json.", components.WithStrDefaultValue("table")),
-	Sca:              components.NewBoolFlag(Sca, "Set to true to request audit to only preform SCA sub scan."),
-	Iac:              components.NewBoolFlag(Iac, "Set to true to request audit to only preform IAC sub scan."),
-	Sast:             components.NewBoolFlag(Sast, "Set to true to request audit to only preform SAST sub scan."),
-	Secrets:          components.NewBoolFlag(Secrets, "Set to true to request audit to only preform Secrets sub scan."),
+	RequirementsFile:     components.NewStringFlag(RequirementsFile, "[Pip] Defines pip requirements file name. For example: 'requirements.txt'."),
+	CurationOutput:       components.NewStringFlag(OutputFormat, "Defines the output format of the command. Acceptable values are: table, json.", components.WithStrDefaultValue("table")),
+	Sca:                  components.NewBoolFlag(Sca, "Set to true to request audit to only preform SCA sub scan."),
+	Iac:                  components.NewBoolFlag(Iac, "Set to true to request audit to only preform IAC sub scan."),
+	Sast:                 components.NewBoolFlag(Sast, "Set to true to request audit to only preform SAST sub scan."),
+	Secrets:              components.NewBoolFlag(Secrets, "Set to true to request audit to only preform Secrets sub scan."),
 	NoContextualAnalysis: components.NewBoolFlag(NoContextualAnalysis, fmt.Sprintf("Set to true to skip the Contextual Analysis scan. This flag is only relevant when using the --%s flag.", Sca)),
 }
 

--- a/cli/docs/flags.go
+++ b/cli/docs/flags.go
@@ -48,6 +48,7 @@ const (
 	Iac     = "iac"
 	Sast    = "sast"
 	Secrets = "secrets"
+	NoContextualAnalysis = "without-contextual-analysis"
 )
 
 const (
@@ -231,6 +232,7 @@ var flagsMap = map[string]components.Flag{
 	Iac:              components.NewBoolFlag(Iac, "Set to true to request audit to only preform IAC sub scan."),
 	Sast:             components.NewBoolFlag(Sast, "Set to true to request audit to only preform SAST sub scan."),
 	Secrets:          components.NewBoolFlag(Secrets, "Set to true to request audit to only preform Secrets sub scan."),
+	NoContextualAnalysis: components.NewBoolFlag(NoContextualAnalysis, fmt.Sprintf("Set to true to skip the Contextual Analysis scan. This flag is only relevant when using the --%s flag.", Sca)),
 }
 
 func GetCommandFlags(cmdKey string) []components.Flag {

--- a/cli/scancommands.go
+++ b/cli/scancommands.go
@@ -335,6 +335,13 @@ func AuditCmd(c *components.Context) error {
 	allSubScans := utils.GetAllSupportedScans()
 	subScans := []utils.SubScanType{}
 	for _, subScan := range allSubScans {
+		if subScan == utils.ContextualAnalysisScan && c.GetBoolFlagValue(flags.NoContextualAnalysis) {
+			if !c.IsFlagSet(flags.Sca) {
+				// No CA flag provided but sca flag is not provided as well, error
+				return pluginsCommon.PrintHelpAndReturnError(fmt.Sprintf("flag '--%s' cannot be used without '--%s'", flags.NoContextualAnalysis, flags.Sca), c)
+			}
+			continue
+		}
 		if c.GetBoolFlagValue(subScan.String()) {
 			subScans = append(subScans, subScan)
 		}

--- a/cli/scancommands.go
+++ b/cli/scancommands.go
@@ -335,7 +335,7 @@ func AuditCmd(c *components.Context) error {
 	allSubScans := utils.GetAllSupportedScans()
 	subScans := []utils.SubScanType{}
 	for _, subScan := range allSubScans {
-		if subScan == utils.ContextualAnalysisScan { 
+		if subScan == utils.ContextualAnalysisScan {
 			if c.GetBoolFlagValue(flags.NoContextualAnalysis) {
 				if !c.GetBoolFlagValue(flags.Sca) {
 					// No CA flag provided but sca flag is not provided as well, error

--- a/cli/scancommands.go
+++ b/cli/scancommands.go
@@ -331,8 +331,22 @@ func AuditCmd(c *components.Context) error {
 		}
 	}
 	auditCmd.SetTechnologies(technologies)
-	err = progressbar.ExecWithProgress(auditCmd)
 
+	allSubScans := utils.GetAllSupportedScans()
+	subScans := []utils.SubScanType{}
+	for _, subScan := range allSubScans {
+		if c.GetBoolFlagValue(subScan.String()) {
+			subScans = append(subScans, subScan)
+		}
+	}
+	if len(subScans) > 0 {
+		auditCmd.SetScansToPerform(subScans)
+	} else {
+		// If no specific sub-scan was provided, default to all sub-scans
+		auditCmd.SetScansToPerform(allSubScans)
+	}
+
+	err = progressbar.ExecWithProgress(auditCmd)
 	// Reporting error if Xsc service is enabled
 	reportErrorIfExists(err, auditCmd)
 	return err

--- a/cli/scancommands.go
+++ b/cli/scancommands.go
@@ -335,16 +335,18 @@ func AuditCmd(c *components.Context) error {
 	allSubScans := utils.GetAllSupportedScans()
 	subScans := []utils.SubScanType{}
 	for _, subScan := range allSubScans {
-		if subScan == utils.ContextualAnalysisScan && c.GetBoolFlagValue(flags.NoContextualAnalysis) {
-			if !c.IsFlagSet(flags.Sca) {
-				// No CA flag provided but sca flag is not provided as well, error
-				return pluginsCommon.PrintHelpAndReturnError(fmt.Sprintf("flag '--%s' cannot be used without '--%s'", flags.NoContextualAnalysis, flags.Sca), c)
+		if subScan == utils.ContextualAnalysisScan { 
+			if c.GetBoolFlagValue(flags.NoContextualAnalysis) {
+				if !c.GetBoolFlagValue(flags.Sca) {
+					// No CA flag provided but sca flag is not provided as well, error
+					return pluginsCommon.PrintHelpAndReturnError(fmt.Sprintf("flag '--%s' cannot be used without '--%s'", flags.NoContextualAnalysis, flags.Sca), c)
+				}
+				continue
 			}
+		} else if !c.GetBoolFlagValue(subScan.String()) {
 			continue
 		}
-		if c.GetBoolFlagValue(subScan.String()) {
-			subScans = append(subScans, subScan)
-		}
+		subScans = append(subScans, subScan)
 	}
 	if len(subScans) > 0 {
 		auditCmd.SetScansToPerform(subScans)

--- a/cli/scancommands.go
+++ b/cli/scancommands.go
@@ -2,9 +2,10 @@ package cli
 
 import (
 	"fmt"
-	"github.com/jfrog/jfrog-cli-core/v2/utils/usage"
 	"os"
 	"strings"
+
+	"github.com/jfrog/jfrog-cli-core/v2/utils/usage"
 
 	"github.com/jfrog/jfrog-cli-core/v2/common/cliutils"
 	commandsCommon "github.com/jfrog/jfrog-cli-core/v2/common/commands"
@@ -332,9 +333,9 @@ func AuditCmd(c *components.Context) error {
 	}
 	auditCmd.SetTechnologies(technologies)
 
-	if c.GetBoolFlagValue(flags.NoContextualAnalysis) && !c.GetBoolFlagValue(flags.Sca) {
+	if c.GetBoolFlagValue(flags.WithoutCA) && !c.GetBoolFlagValue(flags.Sca) {
 		// No CA flag provided but sca flag is not provided, error
-		return pluginsCommon.PrintHelpAndReturnError(fmt.Sprintf("flag '--%s' cannot be used without '--%s'", flags.NoContextualAnalysis, flags.Sca), c)
+		return pluginsCommon.PrintHelpAndReturnError(fmt.Sprintf("flag '--%s' cannot be used without '--%s'", flags.WithoutCA, flags.Sca), c)
 	}
 
 	allSubScans := utils.GetAllSupportedScans()
@@ -361,7 +362,7 @@ func AuditCmd(c *components.Context) error {
 
 func shouldAddSubScan(subScan utils.SubScanType, c *components.Context) bool {
 	return c.GetBoolFlagValue(subScan.String()) ||
-		(subScan == utils.ContextualAnalysisScan && c.GetBoolFlagValue(flags.Sca) && !c.GetBoolFlagValue(flags.NoContextualAnalysis))
+		(subScan == utils.ContextualAnalysisScan && c.GetBoolFlagValue(flags.Sca) && !c.GetBoolFlagValue(flags.WithoutCA))
 }
 
 func reportErrorIfExists(err error, auditCmd *audit.AuditCommand) {

--- a/commands/audit/audit.go
+++ b/commands/audit/audit.go
@@ -150,6 +150,7 @@ func (auditCmd *AuditCommand) Run() (err error) {
 			SetPrintExtendedTable(auditCmd.PrintExtendedTable).
 			SetExtraMessages(messages).
 			SetScanType(services.Dependency).
+			SetSubScansPreformed(auditCmd.ScansToPerform()).
 			PrintScanResults(); err != nil {
 			return
 		}
@@ -211,7 +212,7 @@ func RunAudit(auditParams *AuditParams) (results *xrayutils.Results, err error) 
 
 	// Run scanners only if the user is entitled for Advanced Security
 	if results.ExtendedScanResults.EntitledForJas {
-		results.JasError = runner.RunJasScannersAndSetResults(results.ExtendedScanResults, results.GetScaScannedTechnologies(), results.GetScaScansXrayResults(), auditParams.DirectDependencies(), serverDetails, auditParams.workingDirs, auditParams.Progress(), auditParams.thirdPartyApplicabilityScan, auditParams.XrayGraphScanParams().MultiScanId, applicability.ApplicabilityScannerType, secrets.SecretsScannerType)
+		results.JasError = runner.RunJasScannersAndSetResults(results.ExtendedScanResults, results.GetScaScannedTechnologies(), results.GetScaScansXrayResults(), auditParams.DirectDependencies(), serverDetails, auditParams.workingDirs, auditParams.Progress(), auditParams.thirdPartyApplicabilityScan, auditParams.XrayGraphScanParams().MultiScanId, applicability.ApplicabilityScannerType, secrets.SecretsScannerType, auditParams.ScansToPerform())
 	}
 	return
 }

--- a/commands/audit/audit.go
+++ b/commands/audit/audit.go
@@ -154,7 +154,7 @@ func (auditCmd *AuditCommand) Run() (err error) {
 		SetPrintExtendedTable(auditCmd.PrintExtendedTable).
 		SetExtraMessages(messages).
 		SetScanType(services.Dependency).
-			SetSubScansPreformed(auditCmd.ScansToPerform()).
+		SetSubScansPreformed(auditCmd.ScansToPerform()).
 		PrintScanResults(); err != nil {
 		return
 	}
@@ -256,7 +256,7 @@ func downloadAnalyzerManagerAndRunScanners(auditParallelRunner *utils.SecurityPa
 	if err != nil {
 		return fmt.Errorf("failed to create jas scanner: %s", err.Error())
 	}
-	if err = runner.AddJasScannersTasks(auditParallelRunner, scanResults, scanResults.GetScaScannedTechnologies(), auditParams.DirectDependencies(), serverDetails, auditParams.thirdPartyApplicabilityScan, auditParams.commonGraphScanParams.MultiScanId, scanner, applicability.ApplicabilityScannerType, secrets.SecretsScannerType, auditParams.ScansToPerform(), auditParallelRunner.AddErrorToChan); err != nil {
+	if err = runner.AddJasScannersTasks(auditParallelRunner, scanResults, scanResults.GetScaScannedTechnologies(), auditParams.DirectDependencies(), serverDetails, auditParams.thirdPartyApplicabilityScan, auditParams.commonGraphScanParams.MultiScanId, scanner, applicability.ApplicabilityScannerType, secrets.SecretsScannerType, auditParallelRunner.AddErrorToChan, auditParams.ScansToPerform()); err != nil {
 		return fmt.Errorf("%s failed to run JAS scanners: %s", clientutils.GetLogMsgPrefix(threadId, false), err.Error())
 	}
 	return

--- a/commands/audit/scarunner.go
+++ b/commands/audit/scarunner.go
@@ -37,7 +37,7 @@ import (
 
 func buildDepTreeAndRunScaScan(auditParallelRunner *utils.SecurityParallelRunner, auditParams *AuditParams, results *xrayutils.Results) (err error) {
 	if len(auditParams.ScansToPerform()) > 0 && !slices.Contains(auditParams.ScansToPerform(), xrayutils.ScaScan) {
-		log.Debug("Skipping SCA scan...")
+		log.Debug("Skipping SCA scan as requested by input...")
 		return
 	}
 	// Prepare

--- a/commands/audit/scarunner.go
+++ b/commands/audit/scarunner.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/jfrog/build-info-go/utils/pythonutils"
 	"github.com/jfrog/jfrog-client-go/utils/io/fileutils"
+	"golang.org/x/exp/slices"
 
 	"github.com/jfrog/gofrog/datastructures"
 	"github.com/jfrog/jfrog-cli-core/v2/common/project"
@@ -33,6 +34,10 @@ import (
 )
 
 func runScaScan(params *AuditParams, results *xrayutils.Results) (err error) {
+	if len(params.ScansToPerform()) > 0 && !slices.Contains(params.ScansToPerform(), xrayutils.ScaScan) {
+		log.Debug("Skipping SCA scan...")
+		return
+	}
 	// Prepare
 	currentWorkingDir, err := os.Getwd()
 	if errorutils.CheckError(err) != nil {

--- a/commands/audit/scarunner.go
+++ b/commands/audit/scarunner.go
@@ -36,7 +36,7 @@ import (
 )
 
 func buildDepTreeAndRunScaScan(auditParallelRunner *utils.SecurityParallelRunner, auditParams *AuditParams, results *xrayutils.Results) (err error) {
-	if len(params.ScansToPerform()) > 0 && !slices.Contains(params.ScansToPerform(), xrayutils.ScaScan) {
+	if len(auditParams.ScansToPerform()) > 0 && !slices.Contains(auditParams.ScansToPerform(), xrayutils.ScaScan) {
 		log.Debug("Skipping SCA scan...")
 		return
 	}

--- a/commands/scan/buildscan.go
+++ b/commands/scan/buildscan.go
@@ -140,8 +140,7 @@ func (bsc *BuildScanCommand) runBuildScanAndPrintResults(xrayManager *xray.XrayS
 		SetIsMultipleRootProject(true).
 		SetPrintExtendedTable(bsc.printExtendedTable).
 		SetScanType(services.Binary).
-		SetExtraMessages(nil).
-		SetSubScansPreformed(utils.GetAllSupportedScans())
+		SetExtraMessages(nil)
 
 	if bsc.outputFormat != outputFormat.Table {
 		// Print the violations and/or vulnerabilities as part of one JSON.

--- a/commands/scan/buildscan.go
+++ b/commands/scan/buildscan.go
@@ -140,7 +140,8 @@ func (bsc *BuildScanCommand) runBuildScanAndPrintResults(xrayManager *xray.XrayS
 		SetIsMultipleRootProject(true).
 		SetPrintExtendedTable(bsc.printExtendedTable).
 		SetScanType(services.Binary).
-		SetExtraMessages(nil)
+		SetExtraMessages(nil).
+		SetSubScansPreformed(utils.GetAllSupportedScans())
 
 	if bsc.outputFormat != outputFormat.Table {
 		// Print the violations and/or vulnerabilities as part of one JSON.

--- a/commands/scan/scan.go
+++ b/commands/scan/scan.go
@@ -300,6 +300,7 @@ func (scanCmd *ScanCommand) RunAndRecordResults(recordResFunc func(scanResults *
 		SetPrintExtendedTable(scanCmd.printExtendedTable).
 		SetIsMultipleRootProject(true).
 		SetScanType(services.Binary).
+		SetSubScansPreformed(utils.GetAllSupportedScans()).
 		PrintScanResults(); err != nil {
 		return
 	}
@@ -409,7 +410,7 @@ func (scanCmd *ScanCommand) createIndexerHandlerFunc(file *spec.File, entitledFo
 				if entitledForJas && scanCmd.commandSupportsJAS {
 					// Run Jas scans
 					workingDirs := []string{filePath}
-					err = runner.RunJasScannersAndSetResults(&extendedScanResults, []techutils.Technology{techutils.Technology(scanResults.ScannedPackageType)}, []services.ScanResponse{*scanResults}, depsListFromVulnerabilities(*scanResults), scanCmd.serverDetails, workingDirs, nil, false, "", applicability.ApplicabilityDockerScanScanType, secrets.SecretsScannerDockerScanType)
+					err = runner.RunJasScannersAndSetResults(&extendedScanResults, []techutils.Technology{techutils.Technology(scanResults.ScannedPackageType)}, []services.ScanResponse{*scanResults}, depsListFromVulnerabilities(*scanResults), scanCmd.serverDetails, workingDirs, nil, false, "", applicability.ApplicabilityDockerScanScanType, secrets.SecretsScannerDockerScanType, utils.GetAllSupportedScans())
 
 					if err != nil {
 						log.Error(fmt.Sprintf("scanning '%s' failed with error: %s", graph.Id, err.Error()))

--- a/commands/scan/scan.go
+++ b/commands/scan/scan.go
@@ -305,7 +305,6 @@ func (scanCmd *ScanCommand) RunAndRecordResults(recordResFunc func(scanResults *
 		SetPrintExtendedTable(scanCmd.printExtendedTable).
 		SetIsMultipleRootProject(true).
 		SetScanType(services.Binary).
-		SetSubScansPreformed(utils.GetAllSupportedScans()).
 		PrintScanResults(); err != nil {
 		return
 	}

--- a/commands/scan/scan.go
+++ b/commands/scan/scan.go
@@ -432,7 +432,7 @@ func (scanCmd *ScanCommand) createIndexerHandlerFunc(file *spec.File, entitledFo
 						log.Error(fmt.Sprintf("failed to create jas scanner: %s", err.Error()))
 						indexedFileErrors[threadId] = append(indexedFileErrors[threadId], formats.SimpleJsonError{FilePath: filePath, ErrorMessage: err.Error()})
 					}
-					err = runner.AddJasScannersTasks(jasFileProducerConsumer, &scanResults, []techutils.Technology{techutils.Technology(graphScanResults.ScannedPackageType)}, &depsList, scanCmd.serverDetails, false, "", scanner, applicability.ApplicabilityDockerScanScanType, secrets.SecretsScannerDockerScanType, utils.GetAllSupportedScans(), jasErrHandlerFunc)
+					err = runner.AddJasScannersTasks(jasFileProducerConsumer, &scanResults, []techutils.Technology{techutils.Technology(graphScanResults.ScannedPackageType)}, &depsList, scanCmd.serverDetails, false, "", scanner, applicability.ApplicabilityDockerScanScanType, secrets.SecretsScannerDockerScanType, jasErrHandlerFunc, utils.GetAllSupportedScans())
 					if err != nil {
 						log.Error(fmt.Sprintf("scanning '%s' failed with error: %s", graph.Id, err.Error()))
 						indexedFileErrors[threadId] = append(indexedFileErrors[threadId], formats.SimpleJsonError{FilePath: filePath, ErrorMessage: err.Error()})

--- a/jas/runner/jasrunner.go
+++ b/jas/runner/jasrunner.go
@@ -36,14 +36,20 @@ func AddJasScannersTasks(securityParallelRunner *utils.SecurityParallelRunner, s
 	// Don't execute other scanners when scanning third party dependencies.
 	if !thirdPartyApplicabilityScan {
 		for _, module := range scanner.JFrogAppsConfig.Modules {
-			if err = addModuleJasScanTask(module, utils.Secrets, securityParallelRunner, runSecretsScan(securityParallelRunner, scanner, scanResults.ExtendedScanResults, module, secretsScanType), errHandlerFunc); err != nil {
+			if len(scansToPreform) > 0 && !slices.Contains(scansToPreform, utils.SecretsScan) {
+				log.Debug("Skipping Secrets scan...")
+			} else if err = addModuleJasScanTask(module, utils.Secrets, securityParallelRunner, runSecretsScan(securityParallelRunner, scanner, scanResults.ExtendedScanResults, module, secretsScanType), errHandlerFunc); err != nil {
 				return
 			}
 			if runAllScanners {
-				if err = addModuleJasScanTask(module, utils.IaC, securityParallelRunner, runIacScan(securityParallelRunner, scanner, scanResults.ExtendedScanResults, module), errHandlerFunc); err != nil {
+				if len(scansToPreform) > 0 && !slices.Contains(scansToPreform, utils.IacScan) {
+					log.Debug("Skipping Iac scan...")
+				} else if err = addModuleJasScanTask(module, utils.IaC, securityParallelRunner, runIacScan(securityParallelRunner, scanner, scanResults.ExtendedScanResults, module), errHandlerFunc); err != nil {
 					return
 				}
-				if err = addModuleJasScanTask(module, utils.Sast, securityParallelRunner, runSastScan(securityParallelRunner, scanner, scanResults.ExtendedScanResults, module), errHandlerFunc); err != nil {
+				if len(scansToPreform) > 0 && !slices.Contains(scansToPreform, utils.IacScan) {
+					log.Debug("Skipping Sast scan...")
+				} else if err = addModuleJasScanTask(module, utils.Sast, securityParallelRunner, runSastScan(securityParallelRunner, scanner, scanResults.ExtendedScanResults, module), errHandlerFunc); err != nil {
 					return
 				}
 			}

--- a/jas/runner/jasrunner.go
+++ b/jas/runner/jasrunner.go
@@ -47,7 +47,7 @@ func AddJasScannersTasks(securityParallelRunner *utils.SecurityParallelRunner, s
 				} else if err = addModuleJasScanTask(module, utils.IaC, securityParallelRunner, runIacScan(securityParallelRunner, scanner, scanResults.ExtendedScanResults, module), errHandlerFunc); err != nil {
 					return
 				}
-				if len(scansToPreform) > 0 && !slices.Contains(scansToPreform, utils.IacScan) {
+				if len(scansToPreform) > 0 && !slices.Contains(scansToPreform, utils.SastScan) {
 					log.Debug("Skipping Sast scan...")
 				} else if err = addModuleJasScanTask(module, utils.Sast, securityParallelRunner, runSastScan(securityParallelRunner, scanner, scanResults.ExtendedScanResults, module), errHandlerFunc); err != nil {
 					return

--- a/jas/runner/jasrunner.go
+++ b/jas/runner/jasrunner.go
@@ -37,25 +37,28 @@ func AddJasScannersTasks(securityParallelRunner *utils.SecurityParallelRunner, s
 	if !thirdPartyApplicabilityScan {
 		for _, module := range scanner.JFrogAppsConfig.Modules {
 			if len(scansToPreform) > 0 && !slices.Contains(scansToPreform, utils.SecretsScan) {
-				log.Debug("Skipping Secrets scan...")
+				log.Debug("Skipping secrets scan as requested by input...")
 			} else if err = addModuleJasScanTask(module, utils.Secrets, securityParallelRunner, runSecretsScan(securityParallelRunner, scanner, scanResults.ExtendedScanResults, module, secretsScanType), errHandlerFunc); err != nil {
 				return
 			}
 			if runAllScanners {
 				if len(scansToPreform) > 0 && !slices.Contains(scansToPreform, utils.IacScan) {
-					log.Debug("Skipping Iac scan...")
+					log.Debug("Skipping Iac scan as requested by input...")
 				} else if err = addModuleJasScanTask(module, utils.IaC, securityParallelRunner, runIacScan(securityParallelRunner, scanner, scanResults.ExtendedScanResults, module), errHandlerFunc); err != nil {
 					return
 				}
 				if len(scansToPreform) > 0 && !slices.Contains(scansToPreform, utils.SastScan) {
-					log.Debug("Skipping Sast scan...")
+					log.Debug("Skipping Sast scan as requested by input...")
 				} else if err = addModuleJasScanTask(module, utils.Sast, securityParallelRunner, runSastScan(securityParallelRunner, scanner, scanResults.ExtendedScanResults, module), errHandlerFunc); err != nil {
 					return
 				}
 			}
 		}
 	}
-
+	if len(scansToPreform) > 0 && !slices.Contains(scansToPreform, utils.ContextualAnalysisScan) {
+		log.Debug("Skipping contextual analysis scan as requested by input...")
+		return err
+	}
 	for _, module := range scanner.JFrogAppsConfig.Modules {
 		if err = addModuleJasScanTask(module, utils.Applicability, securityParallelRunner, runContextualScan(securityParallelRunner, scanner, scanResults, module, directDependencies, thirdPartyApplicabilityScan, scanType), errHandlerFunc); err != nil {
 			return

--- a/jas/runner/jasrunner_test.go
+++ b/jas/runner/jasrunner_test.go
@@ -37,7 +37,7 @@ func TestGetExtendedScanResults_ServerNotValid(t *testing.T) {
 	jasScanner, err := jas.CreateJasScanner(scanner, nil, &jas.FakeServerDetails)
 	assert.NoError(t, err)
 	scanResults := &utils.Results{ScaResults: []*utils.ScaScanResult{{Technology: techutils.Pip, XrayResults: jas.FakeBasicXrayResults}}, ExtendedScanResults: &utils.ExtendedScanResults{}}
-	err = AddJasScannersTasks(securityParallelRunnerForTest, scanResults, scanResults.GetScaScannedTechnologies(), &[]string{"issueId_1_direct_dependency", "issueId_2_direct_dependency"}, nil, false, "", jasScanner, applicability.ApplicabilityScannerType, secrets.SecretsScannerType, utils.GetAllSupportedScans(), securityParallelRunnerForTest.AddErrorToChan)
+	err = AddJasScannersTasks(securityParallelRunnerForTest, scanResults, scanResults.GetScaScannedTechnologies(), &[]string{"issueId_1_direct_dependency", "issueId_2_direct_dependency"}, nil, false, "", jasScanner, applicability.ApplicabilityScannerType, secrets.SecretsScannerType, securityParallelRunnerForTest.AddErrorToChan, utils.GetAllSupportedScans())
 	assert.NoError(t, err)
 }
 

--- a/jas/runner/jasrunner_test.go
+++ b/jas/runner/jasrunner_test.go
@@ -25,14 +25,14 @@ func TestGetExtendedScanResults_AnalyzerManagerDoesntExist(t *testing.T) {
 		assert.NoError(t, os.Unsetenv(coreutils.HomeDir))
 	}()
 	scanResults := &utils.Results{ScaResults: []utils.ScaScanResult{{Technology: techutils.Yarn, XrayResults: jas.FakeBasicXrayResults}}, ExtendedScanResults: &utils.ExtendedScanResults{}}
-	err = RunJasScannersAndSetResults(scanResults.ExtendedScanResults, scanResults.GetScaScannedTechnologies(), scanResults.GetScaScansXrayResults(), []string{"issueId_1_direct_dependency", "issueId_2_direct_dependency"}, &jas.FakeServerDetails, nil, nil, false, "", applicability.ApplicabilityScannerType, secrets.SecretsScannerType)
+	err = RunJasScannersAndSetResults(scanResults.ExtendedScanResults, scanResults.GetScaScannedTechnologies(), scanResults.GetScaScansXrayResults(), []string{"issueId_1_direct_dependency", "issueId_2_direct_dependency"}, &jas.FakeServerDetails, nil, nil, false, "", applicability.ApplicabilityScannerType, secrets.SecretsScannerType, utils.GetAllSupportedScans())
 	// Expect error:
 	assert.Error(t, err)
 }
 
 func TestGetExtendedScanResults_ServerNotValid(t *testing.T) {
 	scanResults := &utils.Results{ScaResults: []utils.ScaScanResult{{Technology: techutils.Pip, XrayResults: jas.FakeBasicXrayResults}}, ExtendedScanResults: &utils.ExtendedScanResults{}}
-	err := RunJasScannersAndSetResults(scanResults.ExtendedScanResults, scanResults.GetScaScannedTechnologies(), scanResults.GetScaScansXrayResults(), []string{"issueId_1_direct_dependency", "issueId_2_direct_dependency"}, nil, nil, nil, false, "", applicability.ApplicabilityScannerType, secrets.SecretsScannerType)
+	err := RunJasScannersAndSetResults(scanResults.ExtendedScanResults, scanResults.GetScaScannedTechnologies(), scanResults.GetScaScansXrayResults(), []string{"issueId_1_direct_dependency", "issueId_2_direct_dependency"}, nil, nil, nil, false, "", applicability.ApplicabilityScannerType, secrets.SecretsScannerType, utils.GetAllSupportedScans())
 	assert.NoError(t, err)
 }
 
@@ -40,7 +40,7 @@ func TestGetExtendedScanResults_AnalyzerManagerReturnsError(t *testing.T) {
 	assert.NoError(t, utils.DownloadAnalyzerManagerIfNeeded())
 
 	scanResults := &utils.Results{ScaResults: []utils.ScaScanResult{{Technology: techutils.Yarn, XrayResults: jas.FakeBasicXrayResults}}, ExtendedScanResults: &utils.ExtendedScanResults{}}
-	err := RunJasScannersAndSetResults(scanResults.ExtendedScanResults, scanResults.GetScaScannedTechnologies(), scanResults.GetScaScansXrayResults(), []string{"issueId_2_direct_dependency", "issueId_1_direct_dependency"}, &jas.FakeServerDetails, nil, nil, false, "", applicability.ApplicabilityScannerType, secrets.SecretsScannerType)
+	err := RunJasScannersAndSetResults(scanResults.ExtendedScanResults, scanResults.GetScaScannedTechnologies(), scanResults.GetScaScansXrayResults(), []string{"issueId_2_direct_dependency", "issueId_1_direct_dependency"}, &jas.FakeServerDetails, nil, nil, false, "", applicability.ApplicabilityScannerType, secrets.SecretsScannerType, utils.GetAllSupportedScans())
 
 	// Expect error:
 	assert.ErrorContains(t, err, "failed to run Applicability scan")

--- a/utils/auditbasicparams.go
+++ b/utils/auditbasicparams.go
@@ -56,6 +56,7 @@ type AuditBasicParams struct {
 	depsRepo                         string
 	installCommandName               string
 	technologies                     []string
+	scansToPreform                   []SubScanType
 	args                             []string
 	installCommandArgs               []string
 	dependenciesForApplicabilityScan []string
@@ -134,6 +135,15 @@ func (abp *AuditBasicParams) Technologies() []string {
 func (abp *AuditBasicParams) SetTechnologies(technologies []string) *AuditBasicParams {
 	abp.technologies = technologies
 	return abp
+}
+
+func (abp *AuditBasicParams) SetScansToPerform(scansToPerform []SubScanType) *AuditBasicParams {
+	abp.scansToPreform = scansToPerform
+	return abp
+}
+
+func (abp *AuditBasicParams) ScansToPerform() []SubScanType {
+	return abp.scansToPreform
 }
 
 func (abp *AuditBasicParams) Progress() ioUtils.ProgressMgr {

--- a/utils/resultwriter.go
+++ b/utils/resultwriter.go
@@ -129,7 +129,7 @@ func (rw *ResultsWriter) printScanResultsTables() (err error) {
 		printMessage(coreutils.PrintTitle("The full scan results are available here: ") + coreutils.PrintLink(resultsPath))
 	}
 	log.Output()
-	if slices.Contains(rw.subScansPreformed, ScaScan) {
+	if shouldPrintTable(rw.subScansPreformed, ScaScan, rw.scanType) {
 		if rw.includeVulnerabilities {
 			err = PrintVulnerabilitiesTable(vulnerabilities, rw.results, rw.isMultipleRoots, rw.printExtended, rw.scanType)
 		} else {
@@ -144,20 +144,27 @@ func (rw *ResultsWriter) printScanResultsTables() (err error) {
 			}
 		}
 	}
-	if slices.Contains(rw.subScansPreformed, SecretsScan) {
+	if shouldPrintTable(rw.subScansPreformed, SecretsScan, rw.scanType) {
 		if err = PrintSecretsTable(rw.results.ExtendedScanResults.SecretsScanResults, rw.results.ExtendedScanResults.EntitledForJas); err != nil {
 			return
 		}
 	}
-	if slices.Contains(rw.subScansPreformed, IacScan) {
+	if shouldPrintTable(rw.subScansPreformed, IacScan, rw.scanType) {
 		if err = PrintIacTable(rw.results.ExtendedScanResults.IacScanResults, rw.results.ExtendedScanResults.EntitledForJas); err != nil {
 			return
 		}
 	}
-	if !slices.Contains(rw.subScansPreformed, SastScan) {
+	if !shouldPrintTable(rw.subScansPreformed, SastScan, rw.scanType) {
 		return nil
 	}
 	return PrintSastTable(rw.results.ExtendedScanResults.SastScanResults, rw.results.ExtendedScanResults.EntitledForJas)
+}
+
+func shouldPrintTable(requestedScans []SubScanType, subScan SubScanType, scanType services.ScanType) bool {
+	if scanType == services.Binary && (subScan == IacScan || subScan == SastScan) {
+		return false
+	}
+	return len(requestedScans) == 0 || slices.Contains(requestedScans, subScan)
 }
 
 func printMessages(messages []string) {

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -1,0 +1,18 @@
+package utils
+
+const (
+	ScaScan     SubScanType = "sca"
+	IacScan     SubScanType = "iac"
+	SastScan    SubScanType = "sast"
+	SecretsScan SubScanType = "secrets"
+)
+
+type SubScanType string
+
+func (s SubScanType) String() string {
+	return string(s)
+}
+
+func GetAllSupportedScans() []SubScanType {
+	return []SubScanType{ScaScan, IacScan, SastScan, SecretsScan}
+}

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -2,10 +2,10 @@ package utils
 
 const (
 	ContextualAnalysisScan SubScanType = "contextual_analysis"
-	ScaScan     SubScanType = "sca"
-	IacScan     SubScanType = "iac"
-	SastScan    SubScanType = "sast"
-	SecretsScan SubScanType = "secrets"
+	ScaScan                SubScanType = "sca"
+	IacScan                SubScanType = "iac"
+	SastScan               SubScanType = "sast"
+	SecretsScan            SubScanType = "secrets"
 )
 
 type SubScanType string

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -1,6 +1,7 @@
 package utils
 
 const (
+	ContextualAnalysisScan SubScanType = "contextual_analysis"
 	ScaScan     SubScanType = "sca"
 	IacScan     SubScanType = "iac"
 	SastScan    SubScanType = "sast"
@@ -14,5 +15,5 @@ func (s SubScanType) String() string {
 }
 
 func GetAllSupportedScans() []SubScanType {
-	return []SubScanType{ScaScan, IacScan, SastScan, SecretsScan}
+	return []SubScanType{ScaScan, ContextualAnalysisScan, IacScan, SastScan, SecretsScan}
 }


### PR DESCRIPTION
- [x] The pull request is targeting the `dev` branch.
- [x] The code has been validated to compile successfully by running `go vet ./...`.
- [x] The code has been formatted properly using `go fmt ./...`.
- [x] All [static analysis checks](https://github.com/jfrog/jfrog-cli-security/actions/workflows/analysis.yml) passed.
- [x] All [tests](https://github.com/jfrog/jfrog-cli-security/actions/workflows/test.yml) have passed. If this feature is not already covered by the tests, new tests have been added.
- [x] All changes are detailed at the description. if not already covered at [JFrog Documentation](https://github.com/jfrog/documentation), new documentation have been added.

-----

Audit is running multiple scans (Sca, Contextual analysis, secrets, IAC and SAST).
This PR adds the ability to control what type of sub scans will be preformed in the `audit` command. 

The following flags are added: `--sca`, `--secrets`, `--iac` and `--sast`, `--without-contextual-analysis`
* If none of those flags are specified - audit will run all the sub scans
* If one or more of those flags are specified, `audit` will only preform the specified sub scans
* `--without-contextual-analysis` can only be provided with `--sca` flag

Documentation changes: https://github.com/jfrog/documentation/pull/136