### PR TITLE
Audit - Control Pip install cmd with custom args

### DIFF
--- a/commands/audit/sca/python/python.go
+++ b/commands/audit/sca/python/python.go
@@ -285,7 +285,7 @@ func getPipInstallArgs(requirementsFile, remoteUrl, cacheFolder, reportFileName 
 	args := []string{"-m", "pip", "install"}
 	if requirementsFile == "" {
 		// Run 'pip install .'
-		// args = append(args, ".")
+		args = append(args, ".")
 	} else {
 		// Run pip 'install -r requirements <requirementsFile>'
 		args = append(args, "-r", requirementsFile)

--- a/commands/audit/sca/python/python.go
+++ b/commands/audit/sca/python/python.go
@@ -285,7 +285,7 @@ func getPipInstallArgs(requirementsFile, remoteUrl, cacheFolder, reportFileName 
 	args := []string{"-m", "pip", "install"}
 	if requirementsFile == "" {
 		// Run 'pip install .'
-		args = append(args, ".")
+		// args = append(args, ".")
 	} else {
 		// Run pip 'install -r requirements <requirementsFile>'
 		args = append(args, "-r", requirementsFile)

--- a/commands/audit/sca/python/python_test.go
+++ b/commands/audit/sca/python/python_test.go
@@ -47,7 +47,7 @@ func TestPipDependencyListCustomInstallArgs(t *testing.T) {
 	mainPath := filepath.Join("projects", "package-managers", "python", "pip", "pip")
 	actualMainPath, cleanUp := sca.CreateTestWorkspace(t, mainPath)
 	defer cleanUp()
-	os.Chdir(filepath.Join(actualMainPath, "referenceproject"))
+	assert.NoError(t, os.Chdir(filepath.Join(actualMainPath, "referenceproject")))
 	// Run getModulesDependencyTrees
 	rootNode, uniqueDeps, _, err := BuildDependencyTree(&AuditPython{
 		Tool:               pythonutils.PythonTool(techutils.Pip),

--- a/commands/audit/sca/python/python_test.go
+++ b/commands/audit/sca/python/python_test.go
@@ -51,7 +51,8 @@ func TestPipDependencyListCustomInstallArgs(t *testing.T) {
 	// Run getModulesDependencyTrees
 	rootNode, uniqueDeps, _, err := BuildDependencyTree(&AuditPython{
 		Tool:          pythonutils.PythonTool(techutils.Pip),
-		InstallCommandArgs: []string{"-e", filepath.Join(actualMainPath,"requirementsproject")},
+		InstallCommandArgs: []string{"--break-system-packages"},
+		PipRequirementsFile: "requirements.txt",
 	})
 	validatePipRequirementsProject(t, err, uniqueDeps, rootNode)
 }

--- a/commands/audit/sca/python/python_test.go
+++ b/commands/audit/sca/python/python_test.go
@@ -50,9 +50,8 @@ func TestPipDependencyListCustomInstallArgs(t *testing.T) {
 	os.Chdir(filepath.Join(actualMainPath, "referenceproject"))
 	// Run getModulesDependencyTrees
 	rootNode, uniqueDeps, _, err := BuildDependencyTree(&AuditPython{
-		Tool:          pythonutils.PythonTool(techutils.Pip),
+		Tool:               pythonutils.PythonTool(techutils.Pip),
 		InstallCommandArgs: []string{"--break-system-packages"},
-		PipRequirementsFile: "requirements.txt",
 	})
 	validatePipRequirementsProject(t, err, uniqueDeps, rootNode)
 }

--- a/commands/audit/scarunner.go
+++ b/commands/audit/scarunner.go
@@ -244,6 +244,7 @@ func GetTechDependencyTree(params xrayutils.AuditParams, tech techutils.Technolo
 			Tool:                pythonutils.PythonTool(tech),
 			RemotePypiRepo:      params.DepsRepo(),
 			PipRequirementsFile: params.PipRequirementsFile(),
+			InstallCommandArgs:  params.InstallCommandArgs(),
 			IsCurationCmd:       params.IsCurationCmd(),
 		})
 	case techutils.Nuget:

--- a/tests/testdata/projects/package-managers/python/pip/pip/referenceproject/requirements.txt
+++ b/tests/testdata/projects/package-managers/python/pip/pip/referenceproject/requirements.txt
@@ -1,1 +1,3 @@
--e ../requirementsproject
+-e file://../requriementsproject # git+https://github.com/ShiftLeftSecurity/flask-webgoat.git#egg=flask-webgoat
+
+# -r https://raw.githubusercontent.com/ShiftLeftSecurity/flask-webgoat/master/requirements.txt

--- a/tests/testdata/projects/package-managers/python/pip/pip/referenceproject/requirements.txt
+++ b/tests/testdata/projects/package-managers/python/pip/pip/referenceproject/requirements.txt
@@ -1,3 +1,2 @@
--e file://../requriementsproject # git+https://github.com/ShiftLeftSecurity/flask-webgoat.git#egg=flask-webgoat
-
-# -r https://raw.githubusercontent.com/ShiftLeftSecurity/flask-webgoat/master/requirements.txt
+python-pkgbuild @ git+https://github.com/z3ntu/python-pkgbuild@7afcd99050ba091e7bf1f2aa4bc87e83df3cdea2
+pexpect==4.7.0

--- a/tests/testdata/projects/package-managers/python/pip/pip/referenceproject/requirements.txt
+++ b/tests/testdata/projects/package-managers/python/pip/pip/referenceproject/requirements.txt
@@ -1,0 +1,1 @@
+-e ../requirementsproject


### PR DESCRIPTION
- [x] The pull request is targeting the `dev` branch.
- [x] The code has been validated to compile successfully by running `go vet ./...`.
- [x] The code has been formatted properly using `go fmt ./...`.
- [x] All [static analysis checks](https://github.com/jfrog/jfrog-cli-security/actions/workflows/analysis.yml) passed.
- [x] All [tests](https://github.com/jfrog/jfrog-cli-security/actions/workflows/test.yml) have passed. If this feature is not already covered by the tests, new tests have been added.
- [x] All changes are detailed at the description. if not already covered at [JFrog Documentation](https://github.com/jfrog/documentation), new documentation have been added.

-----

You can now add custom args when installing Pip project for Audit command. (Applicable only when using Frogbot)