### PR TITLE
Fix resolving Maven dependency tree with snapshot versions

### DIFF
--- a/artifactory_test.go
+++ b/artifactory_test.go
@@ -70,6 +70,12 @@ func TestDependencyResolutionFromArtifactory(t *testing.T) {
 			projectType:     project.Maven,
 		},
 		{
+			testProjectPath: []string{"maven", "maven-snapshot"},
+			resolveRepoName: securityTests.MvnVirtualRepo,
+			cacheRepoName:   securityTests.MvnRemoteRepo,
+			projectType:     project.Maven,
+		},
+		{
 			testProjectPath: []string{"go", "simple-project"},
 			resolveRepoName: securityTests.GoVirtualRepo,
 			cacheRepoName:   securityTests.GoRemoteRepo,
@@ -120,8 +126,10 @@ func testSingleTechDependencyResolution(t *testing.T, testProjectPartialPath []s
 		Url:            *securityTests.JfrogUrl,
 		ArtifactoryUrl: *securityTests.JfrogUrl + securityTests.ArtifactoryEndpoint,
 		XrayUrl:        *securityTests.JfrogUrl + securityTests.XrayEndpoint,
-		AccessToken:    *securityTests.JfrogAccessToken,
-		ServerId:       securityTests.ServerId,
+		//AccessToken:    *securityTests.JfrogAccessToken,
+		User:     *securityTests.JfrogUser,
+		Password: *securityTests.JfrogPassword,
+		ServerId: securityTests.ServerId,
 	}
 	configCmd := commonCommands.NewConfigCommand(commonCommands.AddOrEdit, securityTests.ServerId).SetDetails(server).SetUseBasicAuthOnly(true).SetInteractive(false)
 	assert.NoError(t, configCmd.Run())

--- a/artifactory_test.go
+++ b/artifactory_test.go
@@ -126,10 +126,8 @@ func testSingleTechDependencyResolution(t *testing.T, testProjectPartialPath []s
 		Url:            *securityTests.JfrogUrl,
 		ArtifactoryUrl: *securityTests.JfrogUrl + securityTests.ArtifactoryEndpoint,
 		XrayUrl:        *securityTests.JfrogUrl + securityTests.XrayEndpoint,
-		//AccessToken:    *securityTests.JfrogAccessToken,
-		User:     *securityTests.JfrogUser,
-		Password: *securityTests.JfrogPassword,
-		ServerId: securityTests.ServerId,
+		AccessToken:    *securityTests.JfrogAccessToken,
+		ServerId:       securityTests.ServerId,
 	}
 	configCmd := commonCommands.NewConfigCommand(commonCommands.AddOrEdit, securityTests.ServerId).SetDetails(server).SetUseBasicAuthOnly(true).SetInteractive(false)
 	assert.NoError(t, configCmd.Run())

--- a/commands/audit/sca/java/mvn.go
+++ b/commands/audit/sca/java/mvn.go
@@ -1,6 +1,7 @@
 package java
 
 import (
+	"bytes"
 	_ "embed"
 	"errors"
 	"fmt"
@@ -10,6 +11,7 @@ import (
 	"path"
 	"path/filepath"
 	"strings"
+	"text/template"
 
 	"github.com/jfrog/jfrog-cli-security/commands/audit/sca"
 	"github.com/jfrog/jfrog-cli-security/utils"
@@ -229,10 +231,26 @@ func (mdt *MavenDepTreeManager) createSettingsXmlWithConfiguredArtifactory(setti
 	if err != nil {
 		return err
 	}
-	mdt.settingsXmlPath = filepath.Join(settingsXmlPath, settingsXmlFile)
-	settingsXmlContent := fmt.Sprintf(settingsXmlTemplate, username, password, remoteRepositoryFullPath)
 
-	return errorutils.CheckError(os.WriteFile(mdt.settingsXmlPath, []byte(settingsXmlContent), 0600))
+	mdt.settingsXmlPath = filepath.Join(settingsXmlPath, settingsXmlFile)
+	SettingsTemplate, err := template.New("settings").Parse(settingsXmlTemplate)
+	if err != nil {
+		return err
+	}
+	buf := &bytes.Buffer{}
+	err = SettingsTemplate.Execute(buf, struct {
+		Username                 string
+		Password                 string
+		RemoteRepositoryFullPath string
+	}{
+		Username:                 username,
+		Password:                 password,
+		RemoteRepositoryFullPath: remoteRepositoryFullPath,
+	})
+	if err != nil {
+		return err
+	}
+	return errorutils.CheckError(os.WriteFile(mdt.settingsXmlPath, buf.Bytes(), 0600))
 }
 
 // Creates a temporary directory.

--- a/commands/audit/sca/java/mvn_test.go
+++ b/commands/audit/sca/java/mvn_test.go
@@ -35,6 +35,24 @@ const (
             <mirrorOf>*</mirrorOf>
         </mirror>
     </mirrors>
+    <profiles>
+        <profile>
+            <repositories>
+                <repository>
+                    <snapshots>
+                        <enabled>true</enabled>
+                    </snapshots>
+                    <id>artifactory</id>
+                    <name>mavenRepo</name>
+                    <url>https://myartifactory.com/artifactory/testRepo</url>
+                </repository>
+            </repositories>
+            <id>artifactory</id>
+        </profile>
+    </profiles>
+    <activeProfiles>
+        <activeProfile>artifactory</activeProfile>
+    </activeProfiles>
 </settings>`
 	//#nosec G101 - dummy token for testing
 	settingsXmlWithUsernameAndPasswordAndCurationDedicatedAPi = `<?xml version="1.0" encoding="UTF-8"?>
@@ -55,6 +73,24 @@ const (
             <mirrorOf>*</mirrorOf>
         </mirror>
     </mirrors>
+    <profiles>
+        <profile>
+            <repositories>
+                <repository>
+                    <snapshots>
+                        <enabled>true</enabled>
+                    </snapshots>
+                    <id>artifactory</id>
+                    <name>mavenRepo</name>
+                    <url>https://myartifactory.com/artifactory/api/curation/audit/testRepo</url>
+                </repository>
+            </repositories>
+            <id>artifactory</id>
+        </profile>
+    </profiles>
+    <activeProfiles>
+        <activeProfile>artifactory</activeProfile>
+    </activeProfiles>
 </settings>`
 	//#nosec G101 - dummy token for testing
 	settingsXmlWithUsernameAndToken = `<?xml version="1.0" encoding="UTF-8"?>
@@ -75,6 +111,24 @@ const (
             <mirrorOf>*</mirrorOf>
         </mirror>
     </mirrors>
+    <profiles>
+        <profile>
+            <repositories>
+                <repository>
+                    <snapshots>
+                        <enabled>true</enabled>
+                    </snapshots>
+                    <id>artifactory</id>
+                    <name>mavenRepo</name>
+                    <url>https://myartifactory.com/artifactory/testRepo</url>
+                </repository>
+            </repositories>
+            <id>artifactory</id>
+        </profile>
+    </profiles>
+    <activeProfiles>
+        <activeProfile>artifactory</activeProfile>
+    </activeProfiles>
 </settings>`
 	//#nosec G101 - dummy token for testing
 	settingsXmlWithAccessToken = `<?xml version="1.0" encoding="UTF-8"?>
@@ -95,6 +149,24 @@ const (
             <mirrorOf>*</mirrorOf>
         </mirror>
     </mirrors>
+    <profiles>
+        <profile>
+            <repositories>
+                <repository>
+                    <snapshots>
+                        <enabled>true</enabled>
+                    </snapshots>
+                    <id>artifactory</id>
+                    <name>mavenRepo</name>
+                    <url>https://myartifactory.com/artifactory/testRepo</url>
+                </repository>
+            </repositories>
+            <id>artifactory</id>
+        </profile>
+    </profiles>
+    <activeProfiles>
+        <activeProfile>artifactory</activeProfile>
+    </activeProfiles>
 </settings>`
 )
 

--- a/commands/audit/sca/java/resources/settings.xml
+++ b/commands/audit/sca/java/resources/settings.xml
@@ -5,15 +5,33 @@
     <servers>
         <server>
             <id>artifactory</id>
-            <username>%s</username>
-            <password>%s</password>
+            <username>{{.Username}}</username>
+            <password>{{.Password}}</password>
         </server>
     </servers>
     <mirrors>
         <mirror>
             <id>artifactory</id>
-            <url>%s</url>
+            <url>{{.RemoteRepositoryFullPath}}</url>
             <mirrorOf>*</mirrorOf>
         </mirror>
     </mirrors>
+    <profiles>
+        <profile>
+            <repositories>
+                <repository>
+                    <snapshots>
+                        <enabled>true</enabled>
+                    </snapshots>
+                    <id>artifactory</id>
+                    <name>mavenRepo</name>
+                    <url>{{.RemoteRepositoryFullPath}}</url>
+                </repository>
+            </repositories>
+            <id>artifactory</id>
+        </profile>
+    </profiles>
+    <activeProfiles>
+        <activeProfile>artifactory</activeProfile>
+    </activeProfiles>
 </settings>

--- a/tests/consts.go
+++ b/tests/consts.go
@@ -33,34 +33,38 @@ var (
 	RtRepo1       = "cli-rt1"
 	RtVirtualRepo = "cli-rt-virtual"
 
-	DockerVirtualRepo = "cli-docker-virtual"
-	DockerLocalRepo   = "cli-docker-local"
-	DockerRemoteRepo  = "cli-docker-remote"
-	NpmRemoteRepo     = "cli-npm-remote"
-	NugetRemoteRepo   = "cli-nuget-remote"
-	YarnRemoteRepo    = "cli-yarn-remote"
-	GradleRemoteRepo  = "cli-gradle-remote"
-	MvnRemoteRepo     = "cli-mvn-remote"
-	GoVirtualRepo     = "cli-go-virtual"
-	GoRemoteRepo      = "cli-go-remote"
-	GoRepo            = "cli-go"
-	PypiRemoteRepo    = "cli-pypi-remote"
+	DockerVirtualRepo      = "cli-docker-virtual"
+	DockerLocalRepo        = "cli-docker-local"
+	DockerRemoteRepo       = "cli-docker-remote"
+	NpmRemoteRepo          = "cli-npm-remote"
+	NugetRemoteRepo        = "cli-nuget-remote"
+	YarnRemoteRepo         = "cli-yarn-remote"
+	GradleRemoteRepo       = "cli-gradle-remote"
+	MvnRemoteRepo          = "cli-mvn-remote"
+	MvnRemoteSnapshotsRepo = "cli-mvn-snapshots-remote"
+	MvnVirtualRepo         = "cli-mvn-virtual"
+	GoVirtualRepo          = "cli-go-virtual"
+	GoRemoteRepo           = "cli-go-remote"
+	GoRepo                 = "cli-go"
+	PypiRemoteRepo         = "cli-pypi-remote"
 )
 
 // Integration tests - Artifactory repositories creation templates
 const (
-	DockerVirtualRepositoryConfig = "docker_virtual_repository_config.json"
-	DockerLocalRepositoryConfig   = "docker_local_repository_config.json"
-	DockerRemoteRepositoryConfig  = "docker_remote_repository_config.json"
-	NpmRemoteRepositoryConfig     = "npm_remote_repository_config.json"
-	NugetRemoteRepositoryConfig   = "nuget_remote_repository_config.json"
-	YarnRemoteRepositoryConfig    = "yarn_remote_repository_config.json"
-	GradleRemoteRepositoryConfig  = "gradle_remote_repository_config.json"
-	MavenRemoteRepositoryConfig   = "maven_remote_repository_config.json"
-	GoVirtualRepositoryConfig     = "go_virtual_repository_config.json"
-	GoRemoteRepositoryConfig      = "go_remote_repository_config.json"
-	GoLocalRepositoryConfig       = "go_local_repository_config.json"
-	PypiRemoteRepositoryConfig    = "pypi_remote_repository_config.json"
+	DockerVirtualRepositoryConfig        = "docker_virtual_repository_config.json"
+	DockerLocalRepositoryConfig          = "docker_local_repository_config.json"
+	DockerRemoteRepositoryConfig         = "docker_remote_repository_config.json"
+	NpmRemoteRepositoryConfig            = "npm_remote_repository_config.json"
+	NugetRemoteRepositoryConfig          = "nuget_remote_repository_config.json"
+	YarnRemoteRepositoryConfig           = "yarn_remote_repository_config.json"
+	GradleRemoteRepositoryConfig         = "gradle_remote_repository_config.json"
+	MavenRemoteRepositoryConfig          = "maven_remote_repository_config.json"
+	MavenRemoteSnapshotsRepositoryConfig = "maven_remote_snapshots_repository_config.json"
+	MavenVirtualRepositoryConfig         = "maven_virtual_repository_config.json"
+	GoVirtualRepositoryConfig            = "go_virtual_repository_config.json"
+	GoRemoteRepositoryConfig             = "go_remote_repository_config.json"
+	GoLocalRepositoryConfig              = "go_local_repository_config.json"
+	PypiRemoteRepositoryConfig           = "pypi_remote_repository_config.json"
 
 	Repo1RepositoryConfig   = "repo1_repository_config.json"
 	VirtualRepositoryConfig = "specs_virtual_repository_config.json"
@@ -70,25 +74,27 @@ var reposConfigMap = map[*string]string{
 	&RtRepo1:       Repo1RepositoryConfig,
 	&RtVirtualRepo: VirtualRepositoryConfig,
 
-	&DockerVirtualRepo: DockerVirtualRepositoryConfig,
-	&DockerLocalRepo:   DockerLocalRepositoryConfig,
-	&DockerRemoteRepo:  DockerRemoteRepositoryConfig,
-	&NpmRemoteRepo:     NpmRemoteRepositoryConfig,
-	&NugetRemoteRepo:   NugetRemoteRepositoryConfig,
-	&YarnRemoteRepo:    YarnRemoteRepositoryConfig,
-	&GradleRemoteRepo:  GradleRemoteRepositoryConfig,
-	&MvnRemoteRepo:     MavenRemoteRepositoryConfig,
-	&GoVirtualRepo:     GoVirtualRepositoryConfig,
-	&GoRemoteRepo:      GoRemoteRepositoryConfig,
-	&GoRepo:            GoLocalRepositoryConfig,
-	&PypiRemoteRepo:    PypiRemoteRepositoryConfig,
+	&DockerVirtualRepo:      DockerVirtualRepositoryConfig,
+	&DockerLocalRepo:        DockerLocalRepositoryConfig,
+	&DockerRemoteRepo:       DockerRemoteRepositoryConfig,
+	&NpmRemoteRepo:          NpmRemoteRepositoryConfig,
+	&NugetRemoteRepo:        NugetRemoteRepositoryConfig,
+	&YarnRemoteRepo:         YarnRemoteRepositoryConfig,
+	&GradleRemoteRepo:       GradleRemoteRepositoryConfig,
+	&MvnRemoteRepo:          MavenRemoteRepositoryConfig,
+	&MvnRemoteSnapshotsRepo: MavenRemoteSnapshotsRepositoryConfig,
+	&MvnVirtualRepo:         MavenVirtualRepositoryConfig,
+	&GoVirtualRepo:          GoVirtualRepositoryConfig,
+	&GoRemoteRepo:           GoRemoteRepositoryConfig,
+	&GoRepo:                 GoLocalRepositoryConfig,
+	&PypiRemoteRepo:         PypiRemoteRepositoryConfig,
 }
 
 // Return local and remote repositories for the test suites, respectfully
 func GetNonVirtualRepositories() map[*string]string {
 	nonVirtualReposMap := map[*bool][]*string{
 		TestDockerScan: {&DockerLocalRepo, &DockerRemoteRepo},
-		TestSecurity:   {&NpmRemoteRepo, &NugetRemoteRepo, &YarnRemoteRepo, &GradleRemoteRepo, &MvnRemoteRepo, &GoRepo, &GoRemoteRepo, &PypiRemoteRepo},
+		TestSecurity:   {&NpmRemoteRepo, &NugetRemoteRepo, &YarnRemoteRepo, &GradleRemoteRepo, &MvnRemoteRepo, &MvnRemoteSnapshotsRepo, &GoRepo, &GoRemoteRepo, &PypiRemoteRepo},
 	}
 	return getNeededRepositories(nonVirtualReposMap)
 }
@@ -97,7 +103,7 @@ func GetNonVirtualRepositories() map[*string]string {
 func GetVirtualRepositories() map[*string]string {
 	virtualReposMap := map[*bool][]*string{
 		TestDockerScan: {&DockerVirtualRepo},
-		TestSecurity:   {&GoVirtualRepo},
+		TestSecurity:   {&GoVirtualRepo, &MvnVirtualRepo},
 	}
 	return getNeededRepositories(virtualReposMap)
 }
@@ -151,6 +157,8 @@ func AddTimestampToGlobalVars() {
 	DockerVirtualRepo += uniqueSuffix
 	GradleRemoteRepo += uniqueSuffix
 	MvnRemoteRepo += uniqueSuffix
+	MvnRemoteSnapshotsRepo += uniqueSuffix
+	MvnVirtualRepo += uniqueSuffix
 	NpmRemoteRepo += uniqueSuffix
 	NugetRemoteRepo += uniqueSuffix
 	YarnRemoteRepo += uniqueSuffix
@@ -170,14 +178,16 @@ func GetSubstitutionMap() map[string]string {
 		"${DOCKER_REMOTE_REPO}":  DockerRemoteRepo,
 		"${DOCKER_VIRTUAL_REPO}": DockerVirtualRepo,
 
-		"${GO_REPO}":            GoRepo,
-		"${GO_REMOTE_REPO}":     GoRemoteRepo,
-		"${GO_VIRTUAL_REPO}":    GoVirtualRepo,
-		"${GRADLE_REMOTE_REPO}": GradleRemoteRepo,
-		"${MAVEN_REMOTE_REPO}":  MvnRemoteRepo,
-		"${NPM_REMOTE_REPO}":    NpmRemoteRepo,
-		"${NUGET_REMOTE_REPO}":  NugetRemoteRepo,
-		"${PYPI_REMOTE_REPO}":   PypiRemoteRepo,
-		"${YARN_REMOTE_REPO}":   YarnRemoteRepo,
+		"${GO_REPO}":                     GoRepo,
+		"${GO_REMOTE_REPO}":              GoRemoteRepo,
+		"${GO_VIRTUAL_REPO}":             GoVirtualRepo,
+		"${GRADLE_REMOTE_REPO}":          GradleRemoteRepo,
+		"${MAVEN_REMOTE_REPO}":           MvnRemoteRepo,
+		"${MAVEN_REMOTE_SNAPSHOTS_REPO}": MvnRemoteSnapshotsRepo,
+		"${MAVEN_VIRTUAL_REPO}":          MvnVirtualRepo,
+		"${NPM_REMOTE_REPO}":             NpmRemoteRepo,
+		"${NUGET_REMOTE_REPO}":           NugetRemoteRepo,
+		"${PYPI_REMOTE_REPO}":            PypiRemoteRepo,
+		"${YARN_REMOTE_REPO}":            YarnRemoteRepo,
 	}
 }

--- a/tests/testdata/artifactory-repo-configs/maven_remote_snapshots_repository_config.json
+++ b/tests/testdata/artifactory-repo-configs/maven_remote_snapshots_repository_config.json
@@ -1,0 +1,6 @@
+{
+  "key": "${MAVEN_REMOTE_SNAPSHOTS_REPO}",
+  "rclass": "remote",
+  "packageType": "maven",
+  "url": "https://repo.spring.io/snapshot"
+}

--- a/tests/testdata/artifactory-repo-configs/maven_virtual_repository_config.json
+++ b/tests/testdata/artifactory-repo-configs/maven_virtual_repository_config.json
@@ -1,0 +1,6 @@
+{
+  "key": "${MAVEN_VIRTUAL_REPO}",
+  "rclass": "virtual",
+  "packageType": "maven",
+  "repositories": ["${MAVEN_REMOTE_REPO}", "${MAVEN_REMOTE_SNAPSHOTS_REPO}"]
+}

--- a/tests/testdata/projects/package-managers/maven/maven-snapshot/pom.xml
+++ b/tests/testdata/projects/package-managers/maven/maven-snapshot/pom.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <artifactId>test</artifactId>
+    <packaging>jar</packaging>
+        <parent>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-parent</artifactId>
+        <version>3.2.0-SNAPSHOT</version>
+    </parent>
+    <dependencies>
+       <dependency>
+    <groupId>ai.kassette</groupId>
+    <artifactId>kassette-java-sdk</artifactId>
+    <version>1.0.4-SNAPSHOT</version>
+      </dependency>
+    </dependencies>
+</project>


### PR DESCRIPTION
- [X] The pull request is targeting the `dev` branch.
- [X] The code has been validated to compile successfully by running `go vet ./...`.
- [X] The code has been formatted properly using `go fmt ./...`.
- [X] All [static analysis checks](https://github.com/jfrog/jfrog-cli-security/actions/workflows/analysis.yml) passed.
- [X] All [tests](https://github.com/jfrog/jfrog-cli-security/actions/workflows/test.yml) have passed. If this feature is not already covered by the tests, new tests have been added.
- [X] All changes are detailed at the description. if not already covered at [JFrog Documentation](https://github.com/jfrog/documentation), new documentation have been added.

-----
Description:

Building the Maven dependency tree for security commands can sometimes fail when the project dependencies include snapshot versions. This occurs because the settings.xml file created for configuration only includes a mirror tag, which Maven apparently sometimes fails to resolve for snapshot versions. To resolve this issue, I added a repository section to the settings.xml with the snapshot tag enabled, which fixed the issue. a reference to this issue

https://stackoverflow.com/questions/17348118/maven-not-downloading-recognizing-snapshot