### PR TITLE
Audit - Fix panic when platform has no JAS

### DIFF
--- a/audit_test.go
+++ b/audit_test.go
@@ -444,7 +444,7 @@ func TestXrayAuditNotEntitledForJas(t *testing.T) {
 	defer cleanUp()
 	output := testXrayAuditJas(t, cliToRun, filepath.Join("jas", "jas"), "3")
 	// Verify that scan results are printed
-	securityTestUtils.VerifySimpleJsonScanResults(t, output, 0, 35, 0)
+	securityTestUtils.VerifySimpleJsonScanResults(t, output, 0, 8, 0)
 	// Verify that JAS results are not printed
 	securityTestUtils.VerifySimpleJsonJasResults(t, output, 0, 0, 0, 0, 0, 0, 0)
 }
@@ -467,11 +467,13 @@ func getNoJasAuditMockCommand(t *testing.T) components.Command {
 
 func TestXrayAuditJasSimpleJson(t *testing.T) {
 	output := testXrayAuditJas(t, securityTests.PlatformCli, filepath.Join("jas", "jas"), "3")
+	securityTestUtils.VerifySimpleJsonScanResults(t, output, 0, 8, 0)
 	securityTestUtils.VerifySimpleJsonJasResults(t, output, 1, 9, 6, 3, 0, 2, 2)
 }
 
 func TestXrayAuditJasSimpleJsonWithOneThread(t *testing.T) {
 	output := testXrayAuditJas(t, securityTests.PlatformCli, filepath.Join("jas", "jas"), "1")
+	securityTestUtils.VerifySimpleJsonScanResults(t, output, 0, 8, 0)
 	securityTestUtils.VerifySimpleJsonJasResults(t, output, 1, 9, 6, 3, 0, 2, 2)
 }
 

--- a/audit_test.go
+++ b/audit_test.go
@@ -3,22 +3,27 @@ package main
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/jfrog/jfrog-cli-core/v2/utils/coreutils"
-	"github.com/jfrog/jfrog-cli-security/formats"
-	"github.com/jfrog/jfrog-cli-security/utils"
-	xrayUtils "github.com/jfrog/jfrog-client-go/xray/services/utils"
-	xscservices "github.com/jfrog/jfrog-client-go/xsc/services"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
 
+	"github.com/jfrog/jfrog-cli-core/v2/plugins/components"
+	"github.com/jfrog/jfrog-cli-core/v2/utils/coreutils"
+	"github.com/jfrog/jfrog-cli-security/cli"
+	"github.com/jfrog/jfrog-cli-security/cli/docs"
+	"github.com/jfrog/jfrog-cli-security/formats"
+	"github.com/jfrog/jfrog-cli-security/utils"
+	xrayUtils "github.com/jfrog/jfrog-client-go/xray/services/utils"
+	xscservices "github.com/jfrog/jfrog-client-go/xsc/services"
+
 	"github.com/stretchr/testify/assert"
 
 	biutils "github.com/jfrog/build-info-go/utils"
 
 	"github.com/jfrog/jfrog-cli-core/v2/common/format"
+	"github.com/jfrog/jfrog-cli-core/v2/common/progressbar"
 	coreTests "github.com/jfrog/jfrog-cli-core/v2/utils/tests"
 
 	"github.com/jfrog/jfrog-cli-security/scangraph"
@@ -27,15 +32,6 @@ import (
 	clientTests "github.com/jfrog/jfrog-client-go/utils/tests"
 	"github.com/jfrog/jfrog-client-go/xray/services"
 )
-
-// func TestXrayAuditNotEntitledForJas(t *testing.T) {
-// 	cliToRun, cleanUp := securityTestUtils.InitTestWithMockCommandOrParams(t, getNoJasAuditMockCommand)
-// 	defer cleanUp()
-// }
-
-// func getNoJasAuditMockCommand(t *testing.T) components.Command {
-
-// }
 
 func TestXrayAuditNpmJson(t *testing.T) {
 	output := testAuditNpm(t, string(format.Json))
@@ -441,30 +437,53 @@ func addDummyPackageDescriptor(t *testing.T, hasPackageJson bool) {
 	assert.NoError(t, dummyFile.Close())
 }
 
-// JAS
+//
+
+func TestXrayAuditNotEntitledForJas(t *testing.T) {
+	cliToRun, cleanUp := securityTestUtils.InitTestWithMockCommandOrParams(t, getNoJasAuditMockCommand)
+	defer cleanUp()
+	output := testXrayAuditJas(t, cliToRun, filepath.Join("jas", "jas"), "3")
+	securityTestUtils.VerifySimpleJsonJasResults(t, output, 1, 9, 6, 3, 0, 2, 2)
+}
+
+func getNoJasAuditMockCommand(t *testing.T) components.Command {
+	return components.Command{
+		Name:  docs.Audit,
+		Flags: docs.GetCommandFlags(docs.Audit),
+		Action: func(c *components.Context) error {
+			auditCmd, err := cli.CreateAuditCmd(c)
+			if err != nil {
+				return err
+			}
+			// Disable Jas for this test
+			auditCmd.SetUseJas(false)
+			return progressbar.ExecWithProgress(auditCmd)
+		},
+	}
+}
 
 func TestXrayAuditJasSimpleJson(t *testing.T) {
-	output := testXrayAuditJas(t, filepath.Join("jas", "jas"), "3")
+	output := testXrayAuditJas(t, securityTests.PlatformCli, filepath.Join("jas", "jas"), "3")
 	securityTestUtils.VerifySimpleJsonJasResults(t, output, 1, 9, 6, 3, 0, 2, 2)
 }
 
 func TestXrayAuditJasSimpleJsonWithOneThread(t *testing.T) {
-	output := testXrayAuditJas(t, filepath.Join("jas", "jas"), "1")
+	output := testXrayAuditJas(t, securityTests.PlatformCli, filepath.Join("jas", "jas"), "1")
 	securityTestUtils.VerifySimpleJsonJasResults(t, output, 1, 9, 6, 3, 0, 2, 2)
 }
 
 func TestXrayAuditJasSimpleJsonWithConfig(t *testing.T) {
-	output := testXrayAuditJas(t, filepath.Join("jas", "jas-config"), "3")
+	output := testXrayAuditJas(t, securityTests.PlatformCli, filepath.Join("jas", "jas-config"), "3")
 	securityTestUtils.VerifySimpleJsonJasResults(t, output, 0, 0, 1, 3, 0, 2, 2)
 }
 
 func TestXrayAuditJasNoViolationsSimpleJson(t *testing.T) {
-	output := testXrayAuditJas(t, filepath.Join("package-managers", "npm", "npm"), "3")
+	output := testXrayAuditJas(t, securityTests.PlatformCli, filepath.Join("package-managers", "npm", "npm"), "3")
 	securityTestUtils.VerifySimpleJsonScanResults(t, output, 0, 1, 0)
 	securityTestUtils.VerifySimpleJsonJasResults(t, output, 0, 0, 0, 0, 0, 0, 1)
 }
 
-func testXrayAuditJas(t *testing.T, project string, threads string) string {
+func testXrayAuditJas(t *testing.T, testCli *coreTests.JfrogCli, project string, threads string) string {
 	securityTestUtils.InitSecurityTest(t, scangraph.GraphScanMinXrayVersion)
 	tempDirPath, createTempDirCallback := coreTests.CreateTempDirWithCallbackAndAssert(t)
 	defer createTempDirCallback()
@@ -478,7 +497,7 @@ func testXrayAuditJas(t *testing.T, project string, threads string) string {
 	assert.NoError(t, err)
 	chdirCallback := clientTests.ChangeDirWithCallback(t, baseWd, tempDirPath)
 	defer chdirCallback()
-	return securityTests.PlatformCli.WithoutCredentials().RunCliCmdWithOutput(t, "audit", "--format="+string(format.SimpleJson), "--threads="+threads)
+	return testCli.WithoutCredentials().RunCliCmdWithOutput(t, "audit", "--format="+string(format.SimpleJson), "--threads="+threads)
 }
 
 func TestXrayAuditDetectTech(t *testing.T) {

--- a/audit_test.go
+++ b/audit_test.go
@@ -28,6 +28,15 @@ import (
 	"github.com/jfrog/jfrog-client-go/xray/services"
 )
 
+// func TestXrayAuditNotEntitledForJas(t *testing.T) {
+// 	cliToRun, cleanUp := securityTestUtils.InitTestWithMockCommandOrParams(t, getNoJasAuditMockCommand)
+// 	defer cleanUp()
+// }
+
+// func getNoJasAuditMockCommand(t *testing.T) components.Command {
+
+// }
+
 func TestXrayAuditNpmJson(t *testing.T) {
 	output := testAuditNpm(t, string(format.Json))
 	securityTestUtils.VerifyJsonScanResults(t, output, 1, 0, 1)

--- a/audit_test.go
+++ b/audit_test.go
@@ -443,7 +443,10 @@ func TestXrayAuditNotEntitledForJas(t *testing.T) {
 	cliToRun, cleanUp := securityTestUtils.InitTestWithMockCommandOrParams(t, getNoJasAuditMockCommand)
 	defer cleanUp()
 	output := testXrayAuditJas(t, cliToRun, filepath.Join("jas", "jas"), "3")
-	securityTestUtils.VerifySimpleJsonJasResults(t, output, 1, 9, 6, 3, 0, 2, 2)
+	// Verify that scan results are printed
+	securityTestUtils.VerifySimpleJsonScanResults(t, output, 0, 35, 0)
+	// Verify that JAS results are not printed
+	securityTestUtils.VerifySimpleJsonJasResults(t, output, 0, 0, 0, 0, 0, 0, 0)
 }
 
 func getNoJasAuditMockCommand(t *testing.T) components.Command {

--- a/audit_test.go
+++ b/audit_test.go
@@ -437,7 +437,7 @@ func addDummyPackageDescriptor(t *testing.T, hasPackageJson bool) {
 	assert.NoError(t, dummyFile.Close())
 }
 
-//
+// JAS
 
 func TestXrayAuditNotEntitledForJas(t *testing.T) {
 	cliToRun, cleanUp := securityTestUtils.InitTestWithMockCommandOrParams(t, getNoJasAuditMockCommand)

--- a/cli/docs/flags.go
+++ b/cli/docs/flags.go
@@ -228,11 +228,11 @@ var flagsMap = map[string]components.Flag{
 	),
 	RequirementsFile: components.NewStringFlag(RequirementsFile, "[Pip] Defines pip requirements file name. For example: 'requirements.txt'."),
 	CurationOutput:   components.NewStringFlag(OutputFormat, "Defines the output format of the command. Acceptable values are: table, json.", components.WithStrDefaultValue("table")),
-	Sca:              components.NewBoolFlag(Sca, "Set to true to request audit to only preform SCA sub scan."),
-	Iac:              components.NewBoolFlag(Iac, "Set to true to request audit to only preform IAC sub scan."),
-	Sast:             components.NewBoolFlag(Sast, "Set to true to request audit to only preform SAST sub scan."),
-	Secrets:          components.NewBoolFlag(Secrets, "Set to true to request audit to only preform Secrets sub scan."),
-	WithoutCA:        components.NewBoolFlag(WithoutCA, fmt.Sprintf("Set to true to skip the Contextual Analysis scan. This flag is only relevant when using the --%s flag.", Sca)),
+	Sca:              components.NewBoolFlag(Sca, fmt.Sprintf("Selective scanners mode: Execute SCA (Software Composition Analysis) sub-scan. By default, runs both SCA and Contextual Analysis. Can be combined with --%s, --%s, --%s, and --%s.", Secrets, Sast, Iac, WithoutCA)),
+	Iac:              components.NewBoolFlag(Iac, fmt.Sprintf("Selective scanners mode: Execute IaC sub-scan. Can be combined with --%s, --%s and --%s.", Sca, Secrets, Sast)),
+	Sast:             components.NewBoolFlag(Sast, fmt.Sprintf("Selective scanners mode: Execute SAST sub-scan. Can be combined with --%s, --%s and --%s.", Sca, Secrets, Iac)),
+	Secrets:          components.NewBoolFlag(Secrets, fmt.Sprintf("Selective scanners mode: Execute Secrets sub-scan. Can be combined with --%s, --%s and --%s.", Sca, Sast, Iac)),
+	WithoutCA:        components.NewBoolFlag(WithoutCA, fmt.Sprintf("Selective scanners mode: Disable Contextual Analysis scanner after SCA. Relevant only with --%s flag.", Sca)),
 }
 
 func GetCommandFlags(cmdKey string) []components.Flag {

--- a/cli/scancommands.go
+++ b/cli/scancommands.go
@@ -310,7 +310,7 @@ func BuildScan(c *components.Context) error {
 }
 
 func AuditCmd(c *components.Context) error {
-	auditCmd, err := createAuditCmd(c)
+	auditCmd, err := CreateAuditCmd(c)
 	if err != nil {
 		return err
 	}
@@ -357,7 +357,7 @@ func reportErrorIfExists(err error, auditCmd *audit.AuditCommand) {
 	}
 }
 
-func createAuditCmd(c *components.Context) (*audit.AuditCommand, error) {
+func CreateAuditCmd(c *components.Context) (*audit.AuditCommand, error) {
 	auditCmd := audit.NewGenericAuditCommand()
 	serverDetails, err := createServerDetailsWithConfigOffer(c)
 	if err != nil {
@@ -419,7 +419,7 @@ func logNonGenericAuditCommandDeprecation(cmdName string) {
 
 func AuditSpecificCmd(c *components.Context, technology techutils.Technology) error {
 	logNonGenericAuditCommandDeprecation(c.CommandName)
-	auditCmd, err := createAuditCmd(c)
+	auditCmd, err := CreateAuditCmd(c)
 	if err != nil {
 		return err
 	}

--- a/cli/scancommands.go
+++ b/cli/scancommands.go
@@ -397,6 +397,7 @@ func createAuditCmd(c *components.Context) (*audit.AuditCommand, error) {
 	auditCmd.SetServerDetails(serverDetails).
 		SetExcludeTestDependencies(c.GetBoolFlagValue(flags.ExcludeTestDeps)).
 		SetOutputFormat(format).
+		SetUseJas(true).
 		SetUseWrapper(c.GetBoolFlagValue(flags.UseWrapper)).
 		SetInsecureTls(c.GetBoolFlagValue(flags.InsecureTls)).
 		SetNpmScope(c.GetStringFlagValue(flags.DepType)).

--- a/commands/audit/audit.go
+++ b/commands/audit/audit.go
@@ -191,7 +191,7 @@ func RunAudit(auditParams *AuditParams) (results *xrayutils.Results, err error) 
 		return
 	}
 	results.XrayVersion = auditParams.xrayVersion
-	results.ExtendedScanResults.EntitledForJas, err = jas.IsEntitledForJas(xrayManager, auditParams.xrayVersion)
+	results.ExtendedScanResults.EntitledForJas, err = isEntitledForJas(xrayManager, auditParams)
 	if err != nil {
 		return
 	}
@@ -224,7 +224,9 @@ func RunAudit(auditParams *AuditParams) (results *xrayutils.Results, err error) 
 		// Wait for all jas scanners to complete before cleaning up scanners temp dir
 		auditParallelRunner.JasScannersWg.Wait()
 		cleanup := jasScanner.ScannerDirCleanupFunc
-		auditParallelRunner.AddErrorToChan(cleanup())
+		if cleanup != nil {
+			auditParallelRunner.AddErrorToChan(cleanup())
+		}
 		close(auditParallelRunner.ErrorsQueue)
 		auditParallelRunner.Runner.Done()
 	}()
@@ -241,6 +243,14 @@ func RunAudit(auditParams *AuditParams) (results *xrayutils.Results, err error) 
 	auditParallelRunner.Runner.Run()
 	auditParallelRunner.ErrWg.Wait()
 	return
+}
+
+func isEntitledForJas(xrayManager *xray.XrayServicesManager, auditParams *AuditParams) (entitled bool, err error) {
+	if !auditParams.UseJas() {
+		// Dry run without JAS
+		return false, nil
+	}
+	return jas.IsEntitledForJas(xrayManager, auditParams.xrayVersion)
 }
 
 func downloadAnalyzerManagerAndRunScanners(auditParallelRunner *utils.SecurityParallelRunner, scanResults *utils.Results,

--- a/scans_test.go
+++ b/scans_test.go
@@ -130,18 +130,6 @@ func initNativeDockerWithXrayTest(t *testing.T) (mockCli *coreTests.JfrogCli, cl
 		t.Skip("Skipping Docker scan test. To run Xray Docker test add the '-test.dockerScan=true' and '-test.security=true' options.")
 	}
 	return securityTestUtils.InitTestWithMockCommandOrParams(t, dockerScanMockCommand)
-
-	// oldHomeDir := os.Getenv(coreutils.HomeDir)
-	// securityTestUtils.ValidateXrayVersion(t, scan.DockerScanMinXrayVersion)
-	// // Create server config to use with the command.
-	// securityTestUtils.CreateJfrogHomeConfig(t, true)
-	// // Add docker scan mock command
-	// securityTests.TestApplication.Commands = append(securityTests.TestApplication.Commands, dockerScanMockCommand(t))
-	// return func() {
-	// 	clientTestUtils.SetEnvAndAssert(t, coreutils.HomeDir, oldHomeDir)
-	// 	// remove docker scan mock command
-	// 	securityTests.TestApplication.Commands = securityTests.TestApplication.Commands[:len(securityTests.TestApplication.Commands)-1]
-	// }
 }
 
 func dockerScanMockCommand(t *testing.T) components.Command {

--- a/scans_test.go
+++ b/scans_test.go
@@ -130,7 +130,6 @@ func initNativeDockerWithXrayTest(t *testing.T) (mockCli *coreTests.JfrogCli, cl
 		t.Skip("Skipping Docker scan test. To run Xray Docker test add the '-test.dockerScan=true' and '-test.security=true' options.")
 	}
 	return securityTestUtils.InitTestWithMockCommandOrParams(t, dockerScanMockCommand)
-	
 
 	// oldHomeDir := os.Getenv(coreutils.HomeDir)
 	// securityTestUtils.ValidateXrayVersion(t, scan.DockerScanMinXrayVersion)

--- a/tests/utils/test_config.go
+++ b/tests/utils/test_config.go
@@ -13,6 +13,7 @@ import (
 	"github.com/jfrog/jfrog-cli-security/cli"
 	configTests "github.com/jfrog/jfrog-cli-security/tests"
 
+	"github.com/jfrog/jfrog-cli-core/v2/plugins/components"
 	"github.com/jfrog/jfrog-cli-core/v2/artifactory/commands/repository"
 	artifactoryUtils "github.com/jfrog/jfrog-cli-core/v2/artifactory/utils"
 	commonCommands "github.com/jfrog/jfrog-cli-core/v2/common/commands"
@@ -48,13 +49,17 @@ func CreateJfrogHomeConfig(t *testing.T, encryptPassword bool) {
 }
 
 func InitTestCliDetails() {
-	creds := authenticateXray()
 	testApplication := cli.GetJfrogCliSecurityApp()
 
 	configTests.TestApplication = &testApplication
 	if configTests.PlatformCli == nil {
-		configTests.PlatformCli = coreTests.NewJfrogCli(func() error { return plugins.RunCliWithPlugin(*configTests.TestApplication)() }, "", creds)
+		configTests.PlatformCli = GetTestCli(testApplication)
 	}
+}
+
+func GetTestCli(testApplication components.App) (testCli *coreTests.JfrogCli) {
+	creds := authenticateXray()
+	return coreTests.NewJfrogCli(func() error { return plugins.RunCliWithPlugin(testApplication)() }, "", creds)
 }
 
 func authenticateXray() string {

--- a/tests/utils/test_config.go
+++ b/tests/utils/test_config.go
@@ -13,12 +13,12 @@ import (
 	"github.com/jfrog/jfrog-cli-security/cli"
 	configTests "github.com/jfrog/jfrog-cli-security/tests"
 
-	"github.com/jfrog/jfrog-cli-core/v2/plugins/components"
 	"github.com/jfrog/jfrog-cli-core/v2/artifactory/commands/repository"
 	artifactoryUtils "github.com/jfrog/jfrog-cli-core/v2/artifactory/utils"
 	commonCommands "github.com/jfrog/jfrog-cli-core/v2/common/commands"
 	commonTests "github.com/jfrog/jfrog-cli-core/v2/common/tests"
 	"github.com/jfrog/jfrog-cli-core/v2/plugins"
+	"github.com/jfrog/jfrog-cli-core/v2/plugins/components"
 	"github.com/jfrog/jfrog-cli-core/v2/utils/config"
 	"github.com/jfrog/jfrog-cli-core/v2/utils/coreutils"
 	coreTests "github.com/jfrog/jfrog-cli-core/v2/utils/tests"

--- a/utils/auditbasicparams.go
+++ b/utils/auditbasicparams.go
@@ -46,7 +46,7 @@ type AuditBasicParams struct {
 	serverDetails                    *config.ServerDetails
 	outputFormat                     format.OutputFormat
 	progress                         ioUtils.ProgressMgr
-	useJas                       bool
+	useJas                           bool
 	excludeTestDependencies          bool
 	useWrapper                       bool
 	insecureTls                      bool

--- a/utils/auditbasicparams.go
+++ b/utils/auditbasicparams.go
@@ -46,6 +46,7 @@ type AuditBasicParams struct {
 	serverDetails                    *config.ServerDetails
 	outputFormat                     format.OutputFormat
 	progress                         ioUtils.ProgressMgr
+	useJas                       bool
 	excludeTestDependencies          bool
 	useWrapper                       bool
 	insecureTls                      bool
@@ -89,6 +90,15 @@ func (abp *AuditBasicParams) SetInstallCommandArgs(installCommandArgs []string) 
 func (abp *AuditBasicParams) SetInstallCommandName(installCommandName string) *AuditBasicParams {
 	abp.installCommandName = installCommandName
 	return abp
+}
+
+func (abp *AuditBasicParams) SetUseJas(useJas bool) *AuditBasicParams {
+	abp.useJas = useJas
+	return abp
+}
+
+func (abp *AuditBasicParams) UseJas() bool {
+	return abp.useJas
 }
 
 func (abp *AuditBasicParams) PipRequirementsFile() string {


### PR DESCRIPTION
- [x] The pull request is targeting the `dev` branch.
- [x] The code has been validated to compile successfully by running `go vet ./...`.
- [x] The code has been formatted properly using `go fmt ./...`.
- [x] All [static analysis checks](https://github.com/jfrog/jfrog-cli-security/actions/workflows/analysis.yml) passed.
- [x] All [tests](https://github.com/jfrog/jfrog-cli-security/actions/workflows/test.yml) have passed. If this feature is not already covered by the tests, new tests have been added.
- [x] All changes are detailed at the description. if not already covered at [JFrog Documentation](https://github.com/jfrog/documentation), new documentation have been added.

-----