### PR TITLE
Use exclusions flag for JAS scans

### DIFF
--- a/commands/audit/audit.go
+++ b/commands/audit/audit.go
@@ -252,7 +252,7 @@ func downloadAnalyzerManagerAndRunScanners(auditParallelRunner *utils.SecurityPa
 	if err = xrayutils.DownloadAnalyzerManagerIfNeeded(threadId); err != nil {
 		return fmt.Errorf("%s failed to download analyzer manager: %s", clientutils.GetLogMsgPrefix(threadId, false), err.Error())
 	}
-	scanner, err = jas.CreateJasScanner(scanner, jfrogAppsConfig, serverDetails)
+	scanner, err = jas.CreateJasScanner(scanner, jfrogAppsConfig, serverDetails, auditParams.Exclusions()...)
 	if err != nil {
 		return fmt.Errorf("failed to create jas scanner: %s", err.Error())
 	}

--- a/jas/applicability/applicabilitymanager.go
+++ b/jas/applicability/applicabilitymanager.go
@@ -126,7 +126,7 @@ func isDirectComponents(components []string, directDependencies []string) bool {
 }
 
 func (asm *ApplicabilityScanManager) Run(module jfrogappsconfig.Module) (err error) {
-	if err = asm.createConfigFile(module); err != nil {
+	if err = asm.createConfigFile(module, asm.scanner.Exclusions...); err != nil {
 		return
 	}
 	if err = asm.runAnalyzerManager(); err != nil {
@@ -159,12 +159,12 @@ type scanConfiguration struct {
 	ScanType             string   `yaml:"scantype"`
 }
 
-func (asm *ApplicabilityScanManager) createConfigFile(module jfrogappsconfig.Module) error {
+func (asm *ApplicabilityScanManager) createConfigFile(module jfrogappsconfig.Module, exclusions ...string) error {
 	roots, err := jas.GetSourceRoots(module, nil)
 	if err != nil {
 		return err
 	}
-	excludePatterns := jas.GetExcludePatterns(module, nil)
+	excludePatterns := jas.GetExcludePatterns(module, nil, exclusions...)
 	if asm.thirdPartyScan {
 		log.Info("Including node modules folder in applicability scan")
 		excludePatterns = removeElementFromSlice(excludePatterns, jas.NodeModulesPattern)

--- a/jas/common.go
+++ b/jas/common.go
@@ -53,9 +53,10 @@ type JasScanner struct {
 	ServerDetails         *config.ServerDetails
 	JFrogAppsConfig       *jfrogappsconfig.JFrogAppsConfig
 	ScannerDirCleanupFunc func() error
+	Exclusions            []string
 }
 
-func CreateJasScanner(scanner *JasScanner, jfrogAppsConfig *jfrogappsconfig.JFrogAppsConfig, serverDetails *config.ServerDetails) (*JasScanner, error) {
+func CreateJasScanner(scanner *JasScanner, jfrogAppsConfig *jfrogappsconfig.JFrogAppsConfig, serverDetails *config.ServerDetails, exclusions ...string) (*JasScanner, error) {
 	var err error
 	if scanner.AnalyzerManager.AnalyzerManagerFullPath, err = utils.GetAnalyzerManagerExecutable(); err != nil {
 		return scanner, err
@@ -70,6 +71,7 @@ func CreateJasScanner(scanner *JasScanner, jfrogAppsConfig *jfrogappsconfig.JFro
 	}
 	scanner.ServerDetails = serverDetails
 	scanner.JFrogAppsConfig = jfrogAppsConfig
+	scanner.Exclusions = exclusions
 	return scanner, err
 }
 
@@ -254,7 +256,10 @@ func GetSourceRoots(module jfrogappsconfig.Module, scanner *jfrogappsconfig.Scan
 	return roots, nil
 }
 
-func GetExcludePatterns(module jfrogappsconfig.Module, scanner *jfrogappsconfig.Scanner) []string {
+func GetExcludePatterns(module jfrogappsconfig.Module, scanner *jfrogappsconfig.Scanner, exclusions ...string) []string {
+	if len(exclusions) > 0 {
+		return exclusions
+	}
 	excludePatterns := module.ExcludePatterns
 	if scanner != nil {
 		excludePatterns = append(excludePatterns, scanner.ExcludePatterns...)

--- a/jas/iac/iacscanner.go
+++ b/jas/iac/iacscanner.go
@@ -59,7 +59,7 @@ func newIacScanManager(scanner *jas.JasScanner, scannerTempDir string) (manager 
 }
 
 func (iac *IacScanManager) Run(module jfrogappsconfig.Module) (err error) {
-	if err = iac.createConfigFile(module); err != nil {
+	if err = iac.createConfigFile(module, iac.scanner.Exclusions...); err != nil {
 		return
 	}
 	if err = iac.runAnalyzerManager(); err != nil {
@@ -84,7 +84,7 @@ type iacScanConfiguration struct {
 	SkippedDirs []string `yaml:"skipped-folders"`
 }
 
-func (iac *IacScanManager) createConfigFile(module jfrogappsconfig.Module) error {
+func (iac *IacScanManager) createConfigFile(module jfrogappsconfig.Module, exclusions ...string) error {
 	roots, err := jas.GetSourceRoots(module, module.Scanners.Iac)
 	if err != nil {
 		return err
@@ -95,7 +95,7 @@ func (iac *IacScanManager) createConfigFile(module jfrogappsconfig.Module) error
 				Roots:       roots,
 				Output:      iac.resultsFileName,
 				Type:        iacScannerType,
-				SkippedDirs: jas.GetExcludePatterns(module, module.Scanners.Iac),
+				SkippedDirs: jas.GetExcludePatterns(module, module.Scanners.Iac, exclusions...),
 			},
 		},
 	}

--- a/jas/sast/sastscanner.go
+++ b/jas/sast/sastscanner.go
@@ -52,7 +52,7 @@ func newSastScanManager(scanner *jas.JasScanner, scannerTempDir string) (manager
 }
 
 func (ssm *SastScanManager) Run(module jfrogappsconfig.Module) (err error) {
-	if err = ssm.createConfigFile(module); err != nil {
+	if err = ssm.createConfigFile(module, ssm.scanner.Exclusions...); err != nil {
 		return
 	}
 	if err = ssm.runAnalyzerManager(filepath.Dir(ssm.scanner.AnalyzerManager.AnalyzerManagerFullPath)); err != nil {
@@ -79,7 +79,7 @@ type scanConfiguration struct {
 	ExcludedRules   []string `yaml:"excluded-rules,omitempty"`
 }
 
-func (ssm *SastScanManager) createConfigFile(module jfrogappsconfig.Module) error {
+func (ssm *SastScanManager) createConfigFile(module jfrogappsconfig.Module, exclusions ...string) error {
 	sastScanner := module.Scanners.Sast
 	if sastScanner == nil {
 		sastScanner = &jfrogappsconfig.SastScanner{}
@@ -95,7 +95,7 @@ func (ssm *SastScanManager) createConfigFile(module jfrogappsconfig.Module) erro
 				Roots:           roots,
 				Language:        sastScanner.Language,
 				ExcludedRules:   sastScanner.ExcludedRules,
-				ExcludePatterns: jas.GetExcludePatterns(module, &sastScanner.Scanner),
+				ExcludePatterns: jas.GetExcludePatterns(module, &sastScanner.Scanner, exclusions...),
 			},
 		},
 	}

--- a/jas/secrets/secretsscanner.go
+++ b/jas/secrets/secretsscanner.go
@@ -66,7 +66,7 @@ func newSecretsScanManager(scanner *jas.JasScanner, scanType SecretsScanType, sc
 }
 
 func (ssm *SecretScanManager) Run(module jfrogappsconfig.Module) (err error) {
-	if err = ssm.createConfigFile(module); err != nil {
+	if err = ssm.createConfigFile(module, ssm.scanner.Exclusions...); err != nil {
 		return
 	}
 	if err = ssm.runAnalyzerManager(); err != nil {
@@ -91,7 +91,7 @@ type secretsScanConfiguration struct {
 	SkippedDirs []string `yaml:"skipped-folders"`
 }
 
-func (s *SecretScanManager) createConfigFile(module jfrogappsconfig.Module) error {
+func (s *SecretScanManager) createConfigFile(module jfrogappsconfig.Module, exclusions ...string) error {
 	roots, err := jas.GetSourceRoots(module, module.Scanners.Secrets)
 	if err != nil {
 		return err
@@ -102,7 +102,7 @@ func (s *SecretScanManager) createConfigFile(module jfrogappsconfig.Module) erro
 				Roots:       roots,
 				Output:      s.resultsFileName,
 				Type:        string(s.scanType),
-				SkippedDirs: jas.GetExcludePatterns(module, module.Scanners.Secrets),
+				SkippedDirs: jas.GetExcludePatterns(module, module.Scanners.Secrets, exclusions...),
 			},
 		},
 	}


### PR DESCRIPTION
- [ ] The pull request is targeting the `dev` branch.
- [ ] The code has been validated to compile successfully by running `go vet ./...`.
- [ ] The code has been formatted properly using `go fmt ./...`.
- [ ] All [static analysis checks](https://github.com/jfrog/jfrog-cli-security/actions/workflows/analysis.yml) passed.
- [ ] All [tests](https://github.com/jfrog/jfrog-cli-security/actions/workflows/test.yml) have passed. If this feature is not already covered by the tests, new tests have been added.
- [ ] All changes are detailed at the description. if not already covered at [JFrog Documentation](https://github.com/jfrog/documentation), new documentation have been added.

-----

Extend the usage of the `--exclusions` flag to also affect JAS scans and not only SCA and detection