### PR TITLE
Convert file exclusion for directory exclusion for JAS scanners

### DIFF
--- a/cli/docs/flags.go
+++ b/cli/docs/flags.go
@@ -208,7 +208,7 @@ var flagsMap = map[string]components.Flag{
 	ExclusionsAudit: components.NewStringFlag(
 		Exclusions,
 		"List of exclusions separated by semicolons, utilized to skip sub-projects from undergoing an audit. These exclusions may incorporate the * and ? wildcards.",
-		components.WithStrDefaultValue(strings.Join(sca.DefaultExcludePatterns, ";")),
+		components.WithStrDefaultValue(strings.Join(sca.DefaultScaExcludePatterns, ";")),
 	),
 	Mvn:     components.NewBoolFlag(Mvn, "Set to true to request audit for a Maven project."),
 	Gradle:  components.NewBoolFlag(Gradle, "Set to true to request audit for a Gradle project."),

--- a/commands/audit/sca/common.go
+++ b/commands/audit/sca/common.go
@@ -19,7 +19,8 @@ import (
 	xrayUtils "github.com/jfrog/jfrog-client-go/xray/services/utils"
 )
 
-var DefaultExcludePatterns = []string{"*.git*", "*node_modules*", "*target*", "*venv*", "*test*"}
+// Exclude pattern for directories.
+var DefaultScaExcludePatterns = []string{"*.git*", "*node_modules*", "*target*", "*venv*", "*test*"}
 
 var CurationErrorMsgToUserTemplate = "Failed to retrieve the dependencies tree for the %s project. Please contact your " +
 	"Artifactory administrator to verify pass-through for Curation audit is enabled for your project"
@@ -27,7 +28,7 @@ var CurationErrorMsgToUserTemplate = "Failed to retrieve the dependencies tree f
 func GetExcludePattern(params utils.AuditParams) string {
 	exclusions := params.Exclusions()
 	if len(exclusions) == 0 {
-		exclusions = append(exclusions, DefaultExcludePatterns...)
+		exclusions = append(exclusions, DefaultScaExcludePatterns...)
 	}
 	return fspatterns.PrepareExcludePathPattern(exclusions, clientutils.WildCardPattern, params.IsRecursiveScan())
 }

--- a/jas/common.go
+++ b/jas/common.go
@@ -274,7 +274,7 @@ func GetExcludePatterns(module jfrogappsconfig.Module, scanner *jfrogappsconfig.
 func convertToFilesExcludePatterns(excludePatterns []string) []string {
 	patterns := []string{}
 	for _, excludePattern := range excludePatterns {
-		patterns = append(patterns, excludePattern+"/**")
+		patterns = append(patterns, "**/"+excludePattern+"/**")
 	}
 	return patterns
 }

--- a/jas/common.go
+++ b/jas/common.go
@@ -274,19 +274,7 @@ func GetExcludePatterns(module jfrogappsconfig.Module, scanner *jfrogappsconfig.
 func convertToFilesExcludePatterns(excludePatterns []string) []string {
 	patterns := []string{}
 	for _, excludePattern := range excludePatterns {
-		bracketOpeningIndex := strings.Index(excludePattern, "{")
-		bracketClosingIndex := strings.Index(excludePattern, "}")
-		if bracketOpeningIndex >= 0 && bracketClosingIndex > bracketOpeningIndex {
-			// Convert <PREFIX>{option1,option2,...}<SUFFIX> to [<PREFIX>option1<SUFFIX>/** ,<PREFIX>option2<SUFFIX>/**, ...]
-			prefix := excludePattern[:bracketOpeningIndex]
-			suffix := excludePattern[bracketClosingIndex+1:]
-			options := strings.Split(excludePattern[bracketOpeningIndex+1:bracketClosingIndex], ",")
-			for _, option := range options {
-				patterns = append(patterns, prefix+option+suffix+"/**")
-			}
-		} else {
-			patterns = append(patterns, excludePattern+"/**")
-		}
+		patterns = append(patterns, excludePattern+"/**")
 	}
 	return patterns
 }

--- a/jas/common_test.go
+++ b/jas/common_test.go
@@ -91,6 +91,27 @@ func TestAddScoreToRunRules(t *testing.T) {
 	}
 }
 
+func TestConvertToFilesExcludePatterns(t *testing.T) {
+	tests := []struct {
+		name            string
+		excludePatterns []string
+		expectedOutput  []string
+	}{
+		{
+			excludePatterns: []string{},
+			expectedOutput:  []string{},
+		},
+		{
+			excludePatterns: []string{"*.git*", "*node_modules*", "*target*", "*venv*", "*test*"},
+			expectedOutput:  []string{"*.git*/**", "*node_modules*/**", "*target*/**", "*venv*/**", "*test*/**"},
+		},
+	}
+
+	for _, test := range tests {
+		assert.Equal(t, test.expectedOutput, convertToFilesExcludePatterns(test.excludePatterns))
+	}
+}
+
 func TestSetAnalyticsMetricsDataForAnalyzerManager(t *testing.T) {
 	type args struct {
 		msi          string

--- a/jas/common_test.go
+++ b/jas/common_test.go
@@ -103,7 +103,7 @@ func TestConvertToFilesExcludePatterns(t *testing.T) {
 		},
 		{
 			excludePatterns: []string{"*.git*", "*node_modules*", "*target*", "*venv*", "*test*"},
-			expectedOutput:  []string{"*.git*/**", "*node_modules*/**", "*target*/**", "*venv*/**", "*test*/**"},
+			expectedOutput:  []string{"**/*.git*/**", "**/*node_modules*/**", "**/*target*/**", "**/*venv*/**", "**/*test*/**"},
 		},
 	}
 


### PR DESCRIPTION
- [x] The pull request is targeting the `dev` branch.
- [x] The code has been validated to compile successfully by running `go vet ./...`.
- [x] The code has been formatted properly using `go fmt ./...`.
- [x] All [static analysis checks](https://github.com/jfrog/jfrog-cli-security/actions/workflows/analysis.yml) passed.
- [x] All [tests](https://github.com/jfrog/jfrog-cli-security/actions/workflows/test.yml) have passed. If this feature is not already covered by the tests, new tests have been added.
- [x] All changes are detailed at the description. if not already covered at [JFrog Documentation](https://github.com/jfrog/documentation), new documentation have been added.

-----

When using exclusion pattern from the flags, we need to convert it to file patterns that the JAS scanners work with instead of the directory pattern we ask at the flag (for sca exclusions)

### Transformation:
`pattern` --> `**/pattern/**`