### PR TITLE
Audit - fix using DepsRepo if already provided

### DIFF
--- a/commands/audit/scarunner.go
+++ b/commands/audit/scarunner.go
@@ -299,6 +299,9 @@ func getCurationCacheFolderAndLogMsg(params xrayutils.AuditParams, tech techutil
 }
 
 func SetResolutionRepoIfExists(params utils.AuditParams, tech techutils.Technology) (serverDetails *config.ServerDetails, err error) {
+	if serverDetails, err = params.ServerDetails(); err != nil {
+		return
+	}
 	if params.DepsRepo() != "" || params.IgnoreConfigFile() {
 		// If the depsRepo is already set or the configuration file is ignored, there is no need to search for the configuration file.
 		return


### PR DESCRIPTION
- [ ] The pull request is targeting the `dev` branch.
- [ ] The code has been validated to compile successfully by running `go vet ./...`.
- [ ] The code has been formatted properly using `go fmt ./...`.
- [ ] All [static analysis checks](https://github.com/jfrog/jfrog-cli-security/actions/workflows/analysis.yml) passed.
- [ ] All [tests](https://github.com/jfrog/jfrog-cli-security/actions/workflows/test.yml) have passed. If this feature is not already covered by the tests, new tests have been added.
- [ ] All changes are detailed at the description. if not already covered at [JFrog Documentation](https://github.com/jfrog/documentation), new documentation have been added.

-----

When `if params.DepsRepo() != "" || params.IgnoreConfigFile()` we returned nil for the `serverConfig`