### PR TITLE
Added Risk reason and other violations fields to on-demand scan

### DIFF
--- a/utils/resultstable.go
+++ b/utils/resultstable.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"reflect"
 	"sort"
 	"strconv"
 	"strings"
@@ -773,7 +772,27 @@ func simplifyViolations(scanViolations []services.Violation, multipleRoots bool)
 				}
 				continue
 			}
-			uniqueViolations[packageKey] = copyViolationWithComponentId(violation, vulnerableComponentId)
+			uniqueViolations[packageKey] = &services.Violation{
+				Summary:             violation.Summary,
+				Severity:            violation.Severity,
+				ViolationType:       violation.ViolationType,
+				Components:          map[string]services.Component{vulnerableComponentId: violation.Components[vulnerableComponentId]},
+				WatchName:           violation.WatchName,
+				IssueId:             violation.IssueId,
+				Cves:                violation.Cves,
+				LicenseKey:          violation.LicenseKey,
+				LicenseName:         violation.LicenseName,
+				RiskReason:          violation.RiskReason,
+				IsEol:               violation.IsEol,
+				EolMessage:          violation.EolMessage,
+				LatestVersion:       violation.LatestVersion,
+				NewerVersions:       violation.NewerVersions,
+				Cadence:             violation.Cadence,
+				Commits:             violation.Commits,
+				Committers:          violation.Committers,
+				ExtendedInformation: violation.ExtendedInformation,
+				Technology:          violation.Technology,
+			}
 		}
 	}
 	// convert map to slice
@@ -782,22 +801,6 @@ func simplifyViolations(scanViolations []services.Violation, multipleRoots bool)
 		result = append(result, *v)
 	}
 	return result
-}
-
-func copyViolationWithComponentId(violation services.Violation, vulnerableComponentId string) *services.Violation {
-	newViolation := services.Violation{}
-	v := reflect.ValueOf(&violation).Elem()
-	nv := reflect.ValueOf(&newViolation).Elem()
-
-	for i := 0; i < v.NumField(); i++ {
-		field := v.Field(i)
-		nv.Field(i).Set(field)
-	}
-
-	// Handle the Components field separately
-	newViolation.Components = map[string]services.Component{vulnerableComponentId: violation.Components[vulnerableComponentId]}
-
-	return &newViolation
 }
 
 // appendImpactPathsWithoutDuplicates appends the elements of a source [][]ImpactPathNode struct to a target [][]ImpactPathNode, without adding any duplicate elements.

--- a/utils/resultstable.go
+++ b/utils/resultstable.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"reflect"
 	"sort"
 	"strconv"
 	"strings"
@@ -772,18 +773,7 @@ func simplifyViolations(scanViolations []services.Violation, multipleRoots bool)
 				}
 				continue
 			}
-			uniqueViolations[packageKey] = &services.Violation{
-				Summary:       violation.Summary,
-				Severity:      violation.Severity,
-				ViolationType: violation.ViolationType,
-				Components:    map[string]services.Component{vulnerableComponentId: violation.Components[vulnerableComponentId]},
-				WatchName:     violation.WatchName,
-				IssueId:       violation.IssueId,
-				Cves:          violation.Cves,
-				LicenseKey:    violation.LicenseKey,
-				LicenseName:   violation.LicenseName,
-				Technology:    violation.Technology,
-			}
+			uniqueViolations[packageKey] = copyViolationWithComponentId(violation, vulnerableComponentId)
 		}
 	}
 	// convert map to slice
@@ -792,6 +782,22 @@ func simplifyViolations(scanViolations []services.Violation, multipleRoots bool)
 		result = append(result, *v)
 	}
 	return result
+}
+
+func copyViolationWithComponentId(violation services.Violation, vulnerableComponentId string) *services.Violation {
+	newViolation := services.Violation{}
+	v := reflect.ValueOf(&violation).Elem()
+	nv := reflect.ValueOf(&newViolation).Elem()
+
+	for i := 0; i < v.NumField(); i++ {
+		field := v.Field(i)
+		nv.Field(i).Set(field)
+	}
+
+	// Handle the Components field separately
+	newViolation.Components = map[string]services.Component{vulnerableComponentId: violation.Components[vulnerableComponentId]}
+
+	return &newViolation
 }
 
 // appendImpactPathsWithoutDuplicates appends the elements of a source [][]ImpactPathNode struct to a target [][]ImpactPathNode, without adding any duplicate elements.

--- a/utils/resultstable_test.go
+++ b/utils/resultstable_test.go
@@ -92,7 +92,7 @@ func TestSimplifyViolation(t *testing.T) {
 	}
 	simpliedViolations := simplifyViolations(violations, true)
 
-	//assert that the length of simplified violations is length of violation without the similar componentID
+	// assert that the length of simplified violations is length of violation without the similar componentID
 	assert.Equal(t, len(violations)-1, len(simpliedViolations))
 }
 

--- a/utils/resultstable_test.go
+++ b/utils/resultstable_test.go
@@ -132,13 +132,46 @@ func TestGetOperationalRiskReadableData(t *testing.T) {
 			&operationalRiskViolationReadableData{"true", "3.5", "55", "10", "no maintainers", "EOL", "1.2.3", "5"},
 		},
 	}
-	simplifiedViolations := simplifyViolations([]services.Violation{tests[0].violation, tests[1].violation}, true)
 
-	for i, test := range tests {
-		results := getOperationalRiskViolationReadableData(test.violation)
-		simplifiedResults := getOperationalRiskViolationReadableData(simplifiedViolations[i])
-		assert.Equal(t, test.expectedResults, results)
-		assert.Equal(t, test.expectedResults, simplifiedResults)
+	for _, test := range tests {
+		t.Run(test.testName, func(t *testing.T) {
+			results := getOperationalRiskViolationReadableData(test.violation)
+			assert.Equal(t, test.expectedResults, results)
+		})
+	}
+}
+
+// Test Simplified Violations as this is the data we eventually parse in the tables
+func TestGetOpertionalRiskSimplifiedViolations(t *testing.T) {
+	violations := []services.Violation{
+		{Components: map[string]services.Component{"gav://antparent:ant:1.6.4": {}}, IsEol: nil, LatestVersion: "", NewerVersions: nil,
+			Cadence: nil, Commits: nil, Committers: nil, RiskReason: "", EolMessage: ""},
+		{Components: map[string]services.Component{"gav://antparent:ant:1.6.5": {}}, IsEol: newBoolPtr(true), LatestVersion: "1.2.3", NewerVersions: newIntPtr(5),
+			Cadence: newFloat64Ptr(3.5), Commits: newInt64Ptr(55), Committers: newIntPtr(10), EolMessage: "no maintainers", RiskReason: "EOL"},
+	}
+	simplifiedViolations := simplifyViolations(violations, true)
+	tests := []struct {
+		testName        string
+		violation       services.Violation
+		expectedResults *operationalRiskViolationReadableData
+	}{
+		{
+			"Empty Operational Risk Violation",
+			simplifiedViolations[0],
+			&operationalRiskViolationReadableData{"N/A", "N/A", "N/A", "N/A", "", "", "N/A", "N/A"},
+		},
+		{
+			"Detailed Operational Risk Violation with all fields",
+			simplifiedViolations[1],
+			&operationalRiskViolationReadableData{"true", "3.5", "55", "10", "no maintainers", "EOL", "1.2.3", "5"},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.testName, func(t *testing.T) {
+			results := getOperationalRiskViolationReadableData(test.violation)
+			assert.Equal(t, test.expectedResults, results)
+		})
 	}
 }
 

--- a/utils/resultstable_test.go
+++ b/utils/resultstable_test.go
@@ -83,6 +83,21 @@ func TestGetDirectComponents(t *testing.T) {
 	}
 }
 
+func TestSimplifyVulnerabily(t *testing.T) {
+	vulnerabilities := []services.Vulnerability{
+		{Components: map[string]services.Component{"gav://jfrogpack:1.0.0": {}}},
+		{Components: map[string]services.Component{"gav://jfrogpack:1.0.1": {}}},
+		{Components: map[string]services.Component{"gav://jfrogpack:1.0.0": {}}},
+		{Components: map[string]services.Component{"gav://jfrogpack:1.0.2": {}}},
+	}
+	simpliedViolationsRootsFalse := simplifyVulnerabilities(vulnerabilities, false)
+	simpliedViolationsRootsTrue := simplifyVulnerabilities(vulnerabilities, true)
+
+	// assert that the length of simplified vulnerabilities is length of vulnerabilities without the similar componentID
+	assert.Equal(t, len(vulnerabilities)-1, len(simpliedViolationsRootsFalse))
+	assert.Equal(t, len(vulnerabilities)-1, len(simpliedViolationsRootsTrue))
+}
+
 func TestSimplifyViolation(t *testing.T) {
 	violations := []services.Violation{
 		{Components: map[string]services.Component{"gav://jfrogpack:1.0.0": {}}, FailBuild: true},
@@ -90,23 +105,28 @@ func TestSimplifyViolation(t *testing.T) {
 		{Components: map[string]services.Component{"gav://jfrogpack:1.0.0": {}}, FailBuild: true},
 		{Components: map[string]services.Component{"gav://jfrogpack:1.0.2": {}}, FailBuild: true},
 	}
-	simpliedViolations := simplifyViolations(violations, true)
+	simpliedViolationsRootsFalse := simplifyViolations(violations, false)
+	simpliedViolationsRootsTrue := simplifyViolations(violations, true)
 
 	// assert that the length of simplified violations is length of violation without the similar componentID
-	assert.Equal(t, len(violations)-1, len(simpliedViolations))
+	assert.Equal(t, len(violations)-1, len(simpliedViolationsRootsFalse))
+	assert.Equal(t, len(violations)-1, len(simpliedViolationsRootsTrue))
 }
 
 func TestGetOperationalRiskReadableData(t *testing.T) {
 	tests := []struct {
+		testName        string
 		violation       services.Violation
 		expectedResults *operationalRiskViolationReadableData
 	}{
 		{
+			"Empty Operational Risk Violation",
 			services.Violation{Components: map[string]services.Component{"gav://antparent:ant:1.6.4": {}}, IsEol: nil, LatestVersion: "", NewerVersions: nil,
 				Cadence: nil, Commits: nil, Committers: nil, RiskReason: "", EolMessage: ""},
 			&operationalRiskViolationReadableData{"N/A", "N/A", "N/A", "N/A", "", "", "N/A", "N/A"},
 		},
 		{
+			"Detailed Operational Risk Violation with all fields",
 			services.Violation{Components: map[string]services.Component{"gav://antparent:ant:1.6.5": {}}, IsEol: newBoolPtr(true), LatestVersion: "1.2.3", NewerVersions: newIntPtr(5),
 				Cadence: newFloat64Ptr(3.5), Commits: newInt64Ptr(55), Committers: newIntPtr(10), EolMessage: "no maintainers", RiskReason: "EOL"},
 			&operationalRiskViolationReadableData{"true", "3.5", "55", "10", "no maintainers", "EOL", "1.2.3", "5"},


### PR DESCRIPTION
- [x] The pull request is targeting the `dev` branch.
- [x] The code has been validated to compile successfully by running `go vet ./...`.
- [x] The code has been formatted properly using `go fmt ./...`.
- [ ] All [static analysis checks](https://github.com/jfrog/jfrog-cli-security/actions/workflows/analysis.yml) passed.
- [ ] All [tests](https://github.com/jfrog/jfrog-cli-security/actions/workflows/test.yml) have passed. If this feature is not already covered by the tests, new tests have been added.
- [ ] All changes are detailed at the description. if not already covered at [JFrog Documentation](https://github.com/jfrog/documentation), new documentation have been added.

-----

Some fields of violation were dropped when inserting the violation to simplify violation function. 
Added a function to include all violation fields to simplify violations function to fix the print table results.

<img width="1426" alt="op-risk-table" src="https://github.com/user-attachments/assets/8848bb30-dd1f-47af-ad4d-a5bdc7dbfcfb">
