### PR TITLE
Fix curation Github Summary

### DIFF
--- a/commands/curation/curationaudit.go
+++ b/commands/curation/curationaudit.go
@@ -269,7 +269,7 @@ func convertBlocked(pkgStatus []*PackageStatus) formats.TwoLevelSummaryCount {
 			if _, ok := blocked[polAndCond]; !ok {
 				blocked[polAndCond] = formats.SummaryCount{}
 			}
-			uniqId := uniqPkgAppearanceId(pkg.ParentName, pkg.ParentVersion, pkg.PackageName, pkg.PackageVersion)
+			uniqId := getPackageId(pkg.PackageName, pkg.PackageVersion)
 			blocked[polAndCond][uniqId]++
 		}
 	}
@@ -281,9 +281,8 @@ func formatPolicyAndCond(policy, cond string) string {
 }
 
 // The unique identifier of a package includes both the package name with its version and the parent package with its version
-func uniqPkgAppearanceId(parentName, parentVersion, packageName, packageVersion string) string {
-	return fmt.Sprintf("%s:%s-%s:%s",
-		parentName, parentVersion, packageName, packageVersion)
+func getPackageId(packageName, packageVersion string) string {
+	return fmt.Sprintf("%s:%s", packageName, packageVersion)
 }
 
 func (ca *CurationAuditCommand) doCurateAudit(results map[string]*CurationReport) error {

--- a/commands/curation/curationaudit.go
+++ b/commands/curation/curationaudit.go
@@ -280,7 +280,7 @@ func formatPolicyAndCond(policy, cond string) string {
 	return fmt.Sprintf("Policy: %s, Condition: %s", policy, cond)
 }
 
-// The unique identifier of a package includes both the package name with its version and the parent package with its version
+// The unique identifier of a package includes the package name with its version
 func getPackageId(packageName, packageVersion string) string {
 	return fmt.Sprintf("%s:%s", packageName, packageVersion)
 }

--- a/commands/curation/curationaudit_test.go
+++ b/commands/curation/curationaudit_test.go
@@ -889,7 +889,7 @@ func Test_convertResultsToSummary(t *testing.T) {
 						CuratedPackages: &formats.CuratedPackages{
 							Blocked: formats.TwoLevelSummaryCount{
 								formatPolicyAndCond("policy1", "cond1"): formats.SummaryCount{
-									uniqPkgAppearanceId("parent-test1", "1.0.0", "test1", "1.0.0"): 1,
+									getPackageId("test1", "1.0.0"): 1,
 								},
 							},
 							Approved: 4,
@@ -960,12 +960,12 @@ func Test_convertResultsToSummary(t *testing.T) {
 						CuratedPackages: &formats.CuratedPackages{
 							Blocked: formats.TwoLevelSummaryCount{
 								formatPolicyAndCond("policy1", "cond1"): formats.SummaryCount{
-									uniqPkgAppearanceId("parent-test1", "1.0.0", "test1", "1.0.0"): 1,
+									getPackageId("test1", "1.0.0"): 1,
 								},
 								formatPolicyAndCond("policy2", "cond2"): formats.SummaryCount{
-									uniqPkgAppearanceId("parent-test1", "1.0.0", "test1", "1.0.0"): 1,
-									uniqPkgAppearanceId("parent-test2", "2.0.0", "test2", "2.0.0"): 1,
-									uniqPkgAppearanceId("parent-test3", "3.0.0", "test3", "3.0.0"): 1,
+									getPackageId("test1", "1.0.0"): 1,
+									getPackageId("test2", "2.0.0"): 1,
+									getPackageId("test3", "3.0.0"): 1,
 								},
 							},
 							Approved: 2,

--- a/formats/summary.go
+++ b/formats/summary.go
@@ -95,7 +95,7 @@ func (s *ScanVulnerabilitiesSummary) GetTotalIssueCount() (total int) {
 }
 
 func (s *CuratedPackages) GetTotalPackages() int {
-	return s.Approved + s.Blocked.GetTotal()
+	return s.Approved + s.Blocked.GetCountOfKeys(false)
 }
 
 func (s *ScanVulnerabilitiesSummary) getTotalIssueCount(unique bool) (total int) {

--- a/tests/testdata/other/jobSummary/multi_command_job.md
+++ b/tests/testdata/other/jobSummary/multi_command_job.md
@@ -17,5 +17,5 @@
 #### Curation
 | Status | Id | Details |
 |--------|----|---------|
-| ❌ | /application1 | <pre>Total number of packages: <b>6</b><br>🟢 Total Number of Approved: <b>4</b><br>🔴 Total Number of Blocked: <b>2</b><br>├── Policy: cvss_score, Condition:cvss score higher than 4.0 (1)<br>└── Policy: Malicious, Condition: Malicious package (1)</pre> |
-| ❌ | /application2 | <pre>Total number of packages: <b>6</b><br>🟢 Total Number of Approved: <b>4</b><br>🔴 Total Number of Blocked: <b>2</b><br>├── Policy: License, Condition: GPL (1)<br>└── Policy: Aged, Condition: Package is aged (1)</pre> |
+| ❌ | /application1 | <pre>Total Number of Packages: <b>6</b><br>🟢 Total Number of Approved Packages: <b>4</b><br>🔴 Total Number of Blocked Packages: <b>2</b><br>├── Policy: cvss_score, Condition:cvss score higher than 4.0 (1)<br>└── Policy: Malicious, Condition: Malicious package (1)</pre> |
+| ❌ | /application2 | <pre>Total Number of Packages: <b>6</b><br>🟢 Total Number of Approved Packages: <b>4</b><br>🔴 Total Number of Blocked Packages: <b>2</b><br>├── Policy: License, Condition: GPL (1)<br>└── Policy: Aged, Condition: Package is aged (1)</pre> |

--- a/utils/securityJobSummary.go
+++ b/utils/securityJobSummary.go
@@ -206,9 +206,9 @@ func getBlockedCurationSummaryString(summary formats.ScanSummaryResult) (content
 	if !summary.HasBlockedCuration() {
 		return
 	}
-	content += fmt.Sprintf("Total number of packages: <b>%d</b>", summary.CuratedPackages.GetTotalPackages())
-	content += fmt.Sprintf("<br>🟢 Total Number of Approved: <b>%d</b>", summary.CuratedPackages.Approved)
-	content += fmt.Sprintf("<br>🔴 Total Number of Blocked: <b>%d</b>", summary.CuratedPackages.Blocked.GetTotal())
+	content += fmt.Sprintf("Total Number of Packages: <b>%d</b>", summary.CuratedPackages.GetTotalPackages())
+	content += fmt.Sprintf("<br>🟢 Total Number of Approved Packages: <b>%d</b>", summary.CuratedPackages.Approved)
+	content += fmt.Sprintf("<br>🔴 Total Number of Blocked Packages: <b>%d</b>", summary.CuratedPackages.Blocked.GetCountOfKeys(false))
 	if summary.CuratedPackages.Blocked.GetTotal() > 0 {
 		var blocked []struct {
 			BlockedName  string


### PR DESCRIPTION
- [X] The pull request is targeting the `dev` branch.
- [X] The code has been validated to compile successfully by running `go vet ./...`.
- [X] The code has been formatted properly using `go fmt ./...`.
- [X] All [static analysis checks](https://github.com/jfrog/jfrog-cli-security/actions/workflows/analysis.yml) passed.
- [X] All [tests](https://github.com/jfrog/jfrog-cli-security/actions/workflows/test.yml) have passed. If this feature is not already covered by the tests, new tests have been added.
- [X] All changes are detailed at the description. if not already covered at [JFrog Documentation](https://github.com/jfrog/documentation), new documentation have been added.

-----
Description:
Fix the counting of Curation findings summary.
In some cases one package can exist in multiple paths in project, and can be blocked by many policies,
in this case we still want to count this package as 1 blocked, while the count on the policy will include all its appearance.

Output Example:
![image](https://github.com/user-attachments/assets/c0a8840e-4765-409b-b347-a3e8d61de4d5)
