### PR TITLE
Scan - Wait for AnalyzerManager to finish download before scan

### DIFF
--- a/commands/scan/scan.go
+++ b/commands/scan/scan.go
@@ -250,7 +250,10 @@ func (scanCmd *ScanCommand) RunAndRecordResults(recordResFunc func(scanResults *
 	if scanCmd.threads > 1 {
 		threads = scanCmd.threads
 	}
-
+	// Wait for the Download of the AnalyzerManager to complete.
+	if err = errGroup.Wait(); err != nil {
+		err = errors.New("failed while trying to get Analyzer Manager: " + err.Error())
+	}
 	// resultsArr is a two-dimensional array. Each array in it contains a list of ScanResponses that were requested and collected by a specific thread.
 	resultsArr := make([][]*ScanInfo, threads)
 	fileProducerConsumer := parallel.NewRunner(scanCmd.threads, 20000, false)
@@ -293,11 +296,6 @@ func (scanCmd *ScanCommand) RunAndRecordResults(recordResFunc func(scanResults *
 	scanErrors = appendErrorSlice(scanErrors, jasScanProducerErrors)
 
 	scanResults.ScaResults = flatResults
-
-	// Wait for the Download of the AnalyzerManager to complete.
-	if err = errGroup.Wait(); err != nil {
-		err = errors.New("failed while trying to get Analyzer Manager: " + err.Error())
-	}
 
 	if err = utils.NewResultsWriter(scanResults).
 		SetOutputFormat(scanCmd.outputFormat).


### PR DESCRIPTION
- [x] The pull request is targeting the `dev` branch.
- [x] The code has been validated to compile successfully by running `go vet ./...`.
- [x] The code has been formatted properly using `go fmt ./...`.
- [x] All [static analysis checks](https://github.com/jfrog/jfrog-cli-security/actions/workflows/analysis.yml) passed.
- [x] All [tests](https://github.com/jfrog/jfrog-cli-security/actions/workflows/test.yml) have passed. If this feature is not already covered by the tests, new tests have been added.
- [x] All changes are detailed at the description. if not already covered at [JFrog Documentation](https://github.com/jfrog/documentation), new documentation have been added.

-----

In `jf docker scan` we are not waiting for AM to finish downloading before using it (race conditions fix)