### PR TITLE
Curation summary Fix - The count of blocked policies has changed.

### DIFF
--- a/utils/securityJobSummary.go
+++ b/utils/securityJobSummary.go
@@ -228,7 +228,8 @@ func getBlockedCurationSummaryString(summary formats.ScanSummaryResult) (content
 		for index, blockStruct := range blocked {
 			subScanPrefix := fmt.Sprintf("<br>%s", getListItemPrefix(index, len(blocked)))
 			subScanPrefix += blockStruct.BlockedName
-			content += fmt.Sprintf("%s (%d)", subScanPrefix, blockStruct.BlockedValue.GetTotal())
+			// a single package can be blocked in multiple paths, which is why we count the keys instead of the occurrences.
+			content += fmt.Sprintf("%s (%d)", subScanPrefix, len(blockStruct.BlockedValue))
 		}
 	}
 	return


### PR DESCRIPTION
- [x] The pull request is targeting the `dev` branch.
- [x] The code has been validated to compile successfully by running `go vet ./...`.
- [x] The code has been formatted properly using `go fmt ./...`.
- [x] All [static analysis checks](https://github.com/jfrog/jfrog-cli-security/actions/workflows/analysis.yml) passed.
- [x] All [tests](https://github.com/jfrog/jfrog-cli-security/actions/workflows/test.yml) have passed. If this feature is not already covered by the tests, new tests have been added.
- [x] All changes are detailed at the description. if not already covered at [JFrog Documentation](https://github.com/jfrog/documentation), new documentation have been added.

-----
Description:
A single package can be blocked in multiple paths, which is why we changed it to count the keys instead of the occurrences.
This will promise that the count number on each policy wont be greater than the total number of packages which is calculate by the package name and not by package name + parent name.