### PR TITLE
fix SARIF format security-severity attribute

### DIFF
--- a/jas/common.go
+++ b/jas/common.go
@@ -171,7 +171,7 @@ func addScoreToRunRules(sarifRun *sarif.Run) {
 			if rule.Properties == nil {
 				rule.WithProperties(sarif.NewPropertyBag().Properties)
 			}
-			rule.Properties[severityutils.SarifSeverityRuleProperty] = score
+			rule.Properties[severityutils.SarifSeverityRuleProperty] = fmt.Sprintf("%f", score)
 		}
 	}
 }

--- a/jas/common.go
+++ b/jas/common.go
@@ -171,7 +171,7 @@ func addScoreToRunRules(sarifRun *sarif.Run) {
 			if rule.Properties == nil {
 				rule.WithProperties(sarif.NewPropertyBag().Properties)
 			}
-			rule.Properties[severityutils.SarifSeverityRuleProperty] = fmt.Sprintf("%f", score)
+			rule.Properties[severityutils.SarifSeverityRuleProperty] = fmt.Sprintf("%.1f", score)
 		}
 	}
 }

--- a/jas/common_test.go
+++ b/jas/common_test.go
@@ -65,8 +65,8 @@ func TestAddScoreToRunRules(t *testing.T) {
 				sarifutils.CreateResultWithOneLocation("file", 0, 0, 0, 0, "snippet", "rule2", "warning"),
 			),
 			expectedOutput: []*sarif.ReportingDescriptor{
-				sarif.NewRule("rule1").WithProperties(sarif.Properties{"security-severity": float32(6.9)}),
-				sarif.NewRule("rule2").WithProperties(sarif.Properties{"security-severity": float32(6.9)}),
+				sarif.NewRule("rule1").WithProperties(sarif.Properties{"security-severity": "6.9"}),
+				sarif.NewRule("rule2").WithProperties(sarif.Properties{"security-severity": "6.9"}),
 			},
 		},
 		{
@@ -78,11 +78,11 @@ func TestAddScoreToRunRules(t *testing.T) {
 				sarifutils.CreateResultWithOneLocation("file", 0, 0, 0, 0, "snippet", "rule5", "error"),
 			),
 			expectedOutput: []*sarif.ReportingDescriptor{
-				sarif.NewRule("rule1").WithProperties(sarif.Properties{"security-severity": float32(0.0)}),
-				sarif.NewRule("rule2").WithProperties(sarif.Properties{"security-severity": float32(3.9)}),
-				sarif.NewRule("rule3").WithProperties(sarif.Properties{"security-severity": float32(6.9)}),
-				sarif.NewRule("rule4").WithProperties(sarif.Properties{"security-severity": float32(6.9)}),
-				sarif.NewRule("rule5").WithProperties(sarif.Properties{"security-severity": float32(8.9)}),
+				sarif.NewRule("rule1").WithProperties(sarif.Properties{"security-severity": "0.0"}),
+				sarif.NewRule("rule2").WithProperties(sarif.Properties{"security-severity": "3.9"}),
+				sarif.NewRule("rule3").WithProperties(sarif.Properties{"security-severity": "6.9"}),
+				sarif.NewRule("rule4").WithProperties(sarif.Properties{"security-severity": "6.9"}),
+				sarif.NewRule("rule5").WithProperties(sarif.Properties{"security-severity": "8.9"}),
 			},
 		},
 	}


### PR DESCRIPTION
- [x] The pull request is targeting the `dev` branch.
- [x] The code has been validated to compile successfully by running `go vet ./...`.
- [x] The code has been formatted properly using `go fmt ./...`.
- [x] All [static analysis checks](https://github.com/jfrog/jfrog-cli-security/actions/workflows/analysis.yml) passed.
- [x] All [tests](https://github.com/jfrog/jfrog-cli-security/actions/workflows/test.yml) have passed. If this feature is not already covered by the tests, new tests have been added.
- [x] All changes are detailed at the description. if not already covered at [JFrog Documentation](https://github.com/jfrog/documentation), new documentation have been added.

-----

When generating the SARIF format, the added rule attribute `security-severity` was added as float but should have been set as string