### PR TITLE
Add option to run locally docker scan in the repo

### DIFF
--- a/audit_test.go
+++ b/audit_test.go
@@ -448,7 +448,7 @@ func TestXrayAuditNotEntitledForJas(t *testing.T) {
 	securityTestUtils.VerifySimpleJsonJasResults(t, output, 0, 0, 0, 0, 0, 0, 0)
 }
 
-func getNoJasAuditMockCommand(t *testing.T) components.Command {
+func getNoJasAuditMockCommand() components.Command {
 	return components.Command{
 		Name:  docs.Audit,
 		Flags: docs.GetCommandFlags(docs.Audit),

--- a/cli/scancommands.go
+++ b/cli/scancommands.go
@@ -532,6 +532,34 @@ func CurationCmd(c *components.Context) error {
 	return progressbar.ExecWithProgress(curationAuditCommand)
 }
 
+func DockerScanMockCommand() components.Command {
+	// Mock how the CLI handles docker commands:
+	// https://github.com/jfrog/jfrog-cli/blob/v2/buildtools/cli.go#L691
+	return components.Command{
+		Name:  "docker",
+		Flags: flags.GetCommandFlags(flags.DockerScan),
+		Action: func(c *components.Context) error {
+			args := pluginsCommon.ExtractArguments(c)
+			var cmd, image string
+			// We may have prior flags before push/pull commands for the docker client.
+			for _, arg := range args {
+				if !strings.HasPrefix(arg, "-") {
+					if cmd == "" {
+						cmd = arg
+					} else {
+						image = arg
+						break
+					}
+				}
+			}
+			if cmd != "scan" {
+				return fmt.Errorf("unsupported command: %s", cmd)
+			}
+			return DockerScan(c, image)
+		},
+	}
+}
+
 func DockerScan(c *components.Context, image string) error {
 	// Since this command is not registered normally, we need to handle printing 'help' here by ourselves.
 	c.CommandName = dockerScanCmdHiddenName

--- a/jfrogclisecurity.go
+++ b/jfrogclisecurity.go
@@ -6,5 +6,8 @@ import (
 )
 
 func main() {
-	plugins.PluginMain(cli.GetJfrogCliSecurityApp())
+	app := cli.GetJfrogCliSecurityApp()
+	// Add docker scan command
+	app.Commands = append(app.Commands, cli.DockerScanMockCommand())
+	plugins.PluginMain(app)
 }

--- a/scans_test.go
+++ b/scans_test.go
@@ -13,22 +13,18 @@ import (
 	"testing"
 
 	biutils "github.com/jfrog/build-info-go/utils"
+	"github.com/jfrog/jfrog-cli-security/cli"
+	"github.com/jfrog/jfrog-cli-security/commands/curation"
+	"github.com/jfrog/jfrog-cli-security/commands/scan"
 	"github.com/jfrog/jfrog-cli-security/formats"
+	securityTests "github.com/jfrog/jfrog-cli-security/tests"
+	securityTestUtils "github.com/jfrog/jfrog-cli-security/tests/utils"
 	"github.com/jfrog/jfrog-cli-security/utils/jasutils"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/jfrog/jfrog-cli-security/cli"
-	"github.com/jfrog/jfrog-cli-security/cli/docs"
-	"github.com/jfrog/jfrog-cli-security/commands/curation"
-	"github.com/jfrog/jfrog-cli-security/commands/scan"
-	securityTests "github.com/jfrog/jfrog-cli-security/tests"
-	securityTestUtils "github.com/jfrog/jfrog-cli-security/tests/utils"
-
 	"github.com/jfrog/jfrog-cli-core/v2/artifactory/commands/container"
 	containerUtils "github.com/jfrog/jfrog-cli-core/v2/artifactory/utils/container"
-	pluginsCommon "github.com/jfrog/jfrog-cli-core/v2/plugins/common"
-	"github.com/jfrog/jfrog-cli-core/v2/plugins/components"
 
 	"github.com/jfrog/jfrog-cli-core/v2/common/build"
 	commonCommands "github.com/jfrog/jfrog-cli-core/v2/common/commands"
@@ -130,33 +126,7 @@ func initNativeDockerWithXrayTest(t *testing.T) (mockCli *coreTests.JfrogCli, cl
 	if !*securityTests.TestDockerScan || !*securityTests.TestSecurity {
 		t.Skip("Skipping Docker scan test. To run Xray Docker test add the '-test.dockerScan=true' and '-test.security=true' options.")
 	}
-	return securityTestUtils.InitTestWithMockCommandOrParams(t, dockerScanMockCommand)
-}
-
-func dockerScanMockCommand(t *testing.T) components.Command {
-	// Mock how the CLI handles docker commands:
-	// https://github.com/jfrog/jfrog-cli/blob/v2/buildtools/cli.go#L691
-	return components.Command{
-		Name:  "docker",
-		Flags: docs.GetCommandFlags(docs.DockerScan),
-		Action: func(c *components.Context) error {
-			args := pluginsCommon.ExtractArguments(c)
-			var cmd, image string
-			// We may have prior flags before push/pull commands for the docker client.
-			for _, arg := range args {
-				if !strings.HasPrefix(arg, "-") {
-					if cmd == "" {
-						cmd = arg
-					} else {
-						image = arg
-						break
-					}
-				}
-			}
-			assert.Equal(t, "scan", cmd)
-			return cli.DockerScan(c, image)
-		},
-	}
+	return securityTestUtils.InitTestWithMockCommandOrParams(t, cli.DockerScanMockCommand)
 }
 
 func runDockerScan(t *testing.T, testCli *coreTests.JfrogCli, imageName, watchName string, minViolations, minVulnerabilities, minLicenses int) {

--- a/tests/utils/test_utils.go
+++ b/tests/utils/test_utils.go
@@ -50,14 +50,14 @@ func InitSecurityTest(t *testing.T, xrayMinVersion string) {
 	ValidateXrayVersion(t, xrayMinVersion)
 }
 
-func InitTestWithMockCommandOrParams(t *testing.T, mockCommands ...func(t *testing.T) components.Command) (mockCli *coreTests.JfrogCli, cleanUp func()) {
+func InitTestWithMockCommandOrParams(t *testing.T, mockCommands ...func() components.Command) (mockCli *coreTests.JfrogCli, cleanUp func()) {
 	oldHomeDir := os.Getenv(coreutils.HomeDir)
 	// Create server config to use with the command.
 	CreateJfrogHomeConfig(t, true)
 	// Create mock cli with the mock commands.
 	commands := []components.Command{}
 	for _, mockCommand := range mockCommands {
-		commands = append(commands, mockCommand(t))
+		commands = append(commands, mockCommand())
 	}
 	return GetTestCli(components.CreateEmbeddedApp("security", commands)), func() {
 		clientTests.SetEnvAndAssert(t, coreutils.HomeDir, oldHomeDir)


### PR DESCRIPTION
- [x] The pull request is targeting the `dev` branch.
- [x] The code has been validated to compile successfully by running `go vet ./...`.
- [x] The code has been formatted properly using `go fmt ./...`.
- [x] All [static analysis checks](https://github.com/jfrog/jfrog-cli-security/actions/workflows/analysis.yml) passed.
- [x] All [tests](https://github.com/jfrog/jfrog-cli-security/actions/workflows/test.yml) have passed. If this feature is not already covered by the tests, new tests have been added.
- [x] All changes are detailed at the description. if not already covered at [JFrog Documentation](https://github.com/jfrog/documentation), new documentation have been added.

-----

You can now run local `docker scan` cmd using this repo and not only from the CLI repo