### PR TITLE
Validate xray url

### DIFF
--- a/audit_test.go
+++ b/audit_test.go
@@ -753,9 +753,7 @@ func TestXrayAuditNotEntitledForJasWithXrayUrl(t *testing.T) {
 }
 
 func TestXrayAuditJasSimpleJsonWithXrayUrl(t *testing.T) {
-	cliToRun, cleanUp := securityTestUtils.InitTestWithMockCommandOrParams(t, true, getNoJasAuditMockCommand)
-	defer cleanUp()
-	output := testXrayAuditJas(t, cliToRun, filepath.Join("jas", "jas"), "3", false, false)
+	output := testXrayAuditJas(t, securityTests.PlatformCli, filepath.Join("jas", "jas"), "3", false, false)
 	validations.VerifySimpleJsonResults(t, output, validations.ValidationParams{Vulnerabilities: 8})
 	validations.VerifySimpleJsonResults(t, output, validations.ValidationParams{
 		Sast:    1,

--- a/audit_test.go
+++ b/audit_test.go
@@ -745,7 +745,7 @@ func TestAuditOnEmptyProject(t *testing.T) {
 func TestXrayAuditNotEntitledForJasWithXrayUrl(t *testing.T) {
 	cliToRun, cleanUp := securityTestUtils.InitTestWithMockCommandOrParams(t, true, getNoJasAuditMockCommand)
 	defer cleanUp()
-	output := testXrayAuditJas(t, cliToRun, filepath.Join("jas", "jas"), "3", false)
+	output := testXrayAuditJas(t, cliToRun, filepath.Join("jas", "jas"), "3", false, false)
 	// Verify that scan results are printed
 	securityTestUtils.VerifySimpleJsonScanResults(t, output, 0, 8, 0)
 	// Verify that JAS results are not printed
@@ -755,7 +755,7 @@ func TestXrayAuditNotEntitledForJasWithXrayUrl(t *testing.T) {
 func TestXrayAuditJasSimpleJsonWithXrayUrl(t *testing.T) {
 	cliToRun, cleanUp := securityTestUtils.InitTestWithMockCommandOrParams(t, true, getNoJasAuditMockCommand)
 	defer cleanUp()
-	output := testXrayAuditJas(t, cliToRun, filepath.Join("jas", "jas"), "3", false)
+	output := testXrayAuditJas(t, cliToRun, filepath.Join("jas", "jas"), "3", false, false)
 	securityTestUtils.VerifySimpleJsonScanResults(t, output, 0, 8, 0)
 	securityTestUtils.VerifySimpleJsonJasResults(t, output, 1, 9, 6, 3, 1, 1, 2, 0, 0)
 }

--- a/audit_test.go
+++ b/audit_test.go
@@ -747,15 +747,25 @@ func TestXrayAuditNotEntitledForJasWithXrayUrl(t *testing.T) {
 	defer cleanUp()
 	output := testXrayAuditJas(t, cliToRun, filepath.Join("jas", "jas"), "3", false, false)
 	// Verify that scan results are printed
-	securityTestUtils.VerifySimpleJsonScanResults(t, output, 0, 8, 0)
+	securityTestUtils.VerifySimpleJsonScanResults(t, output, validations.ValidationParams{Vulnerabilities: 8})
 	// Verify that JAS results are not printed
-	securityTestUtils.VerifySimpleJsonJasResults(t, output, 0, 0, 0, 0, 0, 0, 0, 0, 0)
+	securityTestUtils.VerifySimpleJsonJasResults(t, output, validations.ValidationParams{})
 }
 
 func TestXrayAuditJasSimpleJsonWithXrayUrl(t *testing.T) {
 	cliToRun, cleanUp := securityTestUtils.InitTestWithMockCommandOrParams(t, true, getNoJasAuditMockCommand)
 	defer cleanUp()
 	output := testXrayAuditJas(t, cliToRun, filepath.Join("jas", "jas"), "3", false, false)
-	securityTestUtils.VerifySimpleJsonScanResults(t, output, 0, 8, 0)
-	securityTestUtils.VerifySimpleJsonJasResults(t, output, 1, 9, 6, 3, 1, 1, 2, 0, 0)
+	securityTestUtils.VerifySimpleJsonScanResults(t, output, 0, validations.ValidationParams{Vulnerabilities: 8})
+	securityTestUtils.VerifySimpleJsonJasResults(t, output, 1, validations.ValidationParams{
+		Sast:    1,
+		Iac:     9,
+		Secrets: 6,
+
+		Vulnerabilities: 8,
+		Applicable:      3,
+		Undetermined:    1,
+		NotCovered:      1,
+		NotApplicable:   2,
+	})
 }

--- a/audit_test.go
+++ b/audit_test.go
@@ -740,7 +740,7 @@ func TestAuditOnEmptyProject(t *testing.T) {
 	validations.VerifySimpleJsonResults(t, output, validations.ValidationParams{})
 }
 
-//xray-url only
+// xray-url only
 
 func TestXrayAuditNotEntitledForJasWithXrayUrl(t *testing.T) {
 	cliToRun, cleanUp := securityTestUtils.InitTestWithMockCommandOrParams(t, true, getNoJasAuditMockCommandWithXrayUrl)

--- a/audit_test.go
+++ b/audit_test.go
@@ -747,17 +747,17 @@ func TestXrayAuditNotEntitledForJasWithXrayUrl(t *testing.T) {
 	defer cleanUp()
 	output := testXrayAuditJas(t, cliToRun, filepath.Join("jas", "jas"), "3", false, false)
 	// Verify that scan results are printed
-	securityTestUtils.VerifySimpleJsonScanResults(t, output, validations.ValidationParams{Vulnerabilities: 8})
+	validations.VerifySimpleJsonResults(t, output, validations.ValidationParams{Vulnerabilities: 8})
 	// Verify that JAS results are not printed
-	securityTestUtils.VerifySimpleJsonJasResults(t, output, validations.ValidationParams{})
+	validations.VerifySimpleJsonResults(t, output, validations.ValidationParams{})
 }
 
 func TestXrayAuditJasSimpleJsonWithXrayUrl(t *testing.T) {
 	cliToRun, cleanUp := securityTestUtils.InitTestWithMockCommandOrParams(t, true, getNoJasAuditMockCommand)
 	defer cleanUp()
 	output := testXrayAuditJas(t, cliToRun, filepath.Join("jas", "jas"), "3", false, false)
-	securityTestUtils.VerifySimpleJsonScanResults(t, output, 0, validations.ValidationParams{Vulnerabilities: 8})
-	securityTestUtils.VerifySimpleJsonJasResults(t, output, 1, validations.ValidationParams{
+	validations.VerifySimpleJsonResults(t, output, validations.ValidationParams{Vulnerabilities: 8})
+	validations.VerifySimpleJsonResults(t, output, validations.ValidationParams{
 		Sast:    1,
 		Iac:     9,
 		Secrets: 6,

--- a/audit_test.go
+++ b/audit_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/jfrog/jfrog-cli-security/utils/formats"
 	"github.com/jfrog/jfrog-cli-security/utils/validations"
 
+	testsUtils "github.com/jfrog/jfrog-cli-security/tests/utils"
 	xrayUtils "github.com/jfrog/jfrog-client-go/xray/services/utils"
 
 	"github.com/stretchr/testify/assert"
@@ -753,8 +754,7 @@ func TestXrayAuditNotEntitledForJasWithXrayUrl(t *testing.T) {
 }
 
 func TestXrayAuditJasSimpleJsonWithXrayUrl(t *testing.T) {
-	cliToRun, cleanUp := securityTestUtils.InitTestWithMockCommandOrParams(t, true, getRealAuditCommand)
-	defer cleanUp()
+	cliToRun := testsUtils.GetTestCli(cli.GetJfrogCliSecurityApp(), true)
 	output := testXrayAuditJas(t, cliToRun, filepath.Join("jas", "jas"), "3", false, false)
 	validations.VerifySimpleJsonResults(t, output, validations.ValidationParams{
 		Sast:    1,
@@ -768,20 +768,3 @@ func TestXrayAuditJasSimpleJsonWithXrayUrl(t *testing.T) {
 		NotApplicable:   2,
 	})
 }
-
-func getRealAuditCommand() components.Command {
-	return components.Command{
-		Name:     docs.Audit,
-		Flags:    docs.GetCommandFlags(docs.Audit),
-		Category: "Security",
-		Action:   cli.AuditCmd,
-	}
-}
-
-//func getRealAuditCommand() []components.Command {
-//	var cmds []components.Command
-//	for i := range cli.GetJfrogCliSecurityApp().Subcommands {
-//		cmds = append(cmds, cli.GetJfrogCliSecurityApp().Subcommands[i].Commands...)
-//	}
-//	return cmds
-//}

--- a/audit_test.go
+++ b/audit_test.go
@@ -753,8 +753,9 @@ func TestXrayAuditNotEntitledForJasWithXrayUrl(t *testing.T) {
 }
 
 func TestXrayAuditJasSimpleJsonWithXrayUrl(t *testing.T) {
-	output := testXrayAuditJas(t, securityTests.PlatformCli, filepath.Join("jas", "jas"), "3", false, false)
-	validations.VerifySimpleJsonResults(t, output, validations.ValidationParams{Vulnerabilities: 8})
+	cliToRun, cleanUp := securityTestUtils.InitTestWithMockCommandOrParams(t, true, getRealAuditCommand)
+	defer cleanUp()
+	output := testXrayAuditJas(t, cliToRun, filepath.Join("jas", "jas"), "3", false, false)
 	validations.VerifySimpleJsonResults(t, output, validations.ValidationParams{
 		Sast:    1,
 		Iac:     9,
@@ -767,3 +768,20 @@ func TestXrayAuditJasSimpleJsonWithXrayUrl(t *testing.T) {
 		NotApplicable:   2,
 	})
 }
+
+func getRealAuditCommand() components.Command {
+	return components.Command{
+		Name:     docs.Audit,
+		Flags:    docs.GetCommandFlags(docs.Audit),
+		Category: "Security",
+		Action:   cli.AuditCmd,
+	}
+}
+
+//func getRealAuditCommand() []components.Command {
+//	var cmds []components.Command
+//	for i := range cli.GetJfrogCliSecurityApp().Subcommands {
+//		cmds = append(cmds, cli.GetJfrogCliSecurityApp().Subcommands[i].Commands...)
+//	}
+//	return cmds
+//}

--- a/audit_test.go
+++ b/audit_test.go
@@ -740,10 +740,10 @@ func TestAuditOnEmptyProject(t *testing.T) {
 	validations.VerifySimpleJsonResults(t, output, validations.ValidationParams{})
 }
 
-// xray-url only
+// xray-url only - the following tests check the case of adding "xray-url", instead of "url", which is the more common one
 
 func TestXrayAuditNotEntitledForJasWithXrayUrl(t *testing.T) {
-	cliToRun, cleanUp := securityTestUtils.InitTestWithMockCommandOrParams(t, true, getNoJasAuditMockCommandWithXrayUrl)
+	cliToRun, cleanUp := securityTestUtils.InitTestWithMockCommandOrParams(t, true, getNoJasAuditMockCommand)
 	defer cleanUp()
 	output := testXrayAuditJas(t, cliToRun, filepath.Join("jas", "jas"), "3", false)
 	// Verify that scan results are printed
@@ -752,24 +752,10 @@ func TestXrayAuditNotEntitledForJasWithXrayUrl(t *testing.T) {
 	securityTestUtils.VerifySimpleJsonJasResults(t, output, 0, 0, 0, 0, 0, 0, 0, 0, 0)
 }
 
-func getNoJasAuditMockCommandWithXrayUrl() components.Command {
-	return components.Command{
-		Name:  docs.Audit,
-		Flags: docs.GetCommandFlags(docs.Audit),
-		Action: func(c *components.Context) error {
-			auditCmd, err := cli.CreateAuditCmd(c)
-			if err != nil {
-				return err
-			}
-			// Disable Jas for this test
-			auditCmd.SetUseJas(false)
-			return progressbar.ExecWithProgress(auditCmd)
-		},
-	}
-}
-
 func TestXrayAuditJasSimpleJsonWithXrayUrl(t *testing.T) {
-	output := testXrayAuditJas(t, securityTests.PlatformCli, filepath.Join("jas", "jas"), "3", false)
+	cliToRun, cleanUp := securityTestUtils.InitTestWithMockCommandOrParams(t, true, getNoJasAuditMockCommand)
+	defer cleanUp()
+	output := testXrayAuditJas(t, cliToRun, filepath.Join("jas", "jas"), "3", false)
 	securityTestUtils.VerifySimpleJsonScanResults(t, output, 0, 8, 0)
 	securityTestUtils.VerifySimpleJsonJasResults(t, output, 1, 9, 6, 3, 1, 1, 2, 0, 0)
 }

--- a/jas/analyzermanager.go
+++ b/jas/analyzermanager.go
@@ -33,6 +33,7 @@ const (
 	jfPasswordEnvVariable                     = "JF_PASS"
 	jfTokenEnvVariable                        = "JF_TOKEN"
 	jfPlatformUrlEnvVariable                  = "JF_PLATFORM_URL"
+	jfPlatformXrayUrlEnvVariable              = "JF_PLATFORM_XRAY_URL"
 	logDirEnvVariable                         = "AM_LOG_DIRECTORY"
 	notEntitledExitCode                       = 31
 	unsupportedCommandExitCode                = 13
@@ -138,10 +139,11 @@ func GetAnalyzerManagerExecutableName() string {
 
 func GetAnalyzerManagerEnvVariables(serverDetails *config.ServerDetails) (envVars map[string]string, err error) {
 	envVars = map[string]string{
-		jfUserEnvVariable:        serverDetails.User,
-		jfPasswordEnvVariable:    serverDetails.Password,
-		jfPlatformUrlEnvVariable: serverDetails.Url,
-		jfTokenEnvVariable:       serverDetails.AccessToken,
+		jfUserEnvVariable:            serverDetails.User,
+		jfPasswordEnvVariable:        serverDetails.Password,
+		jfPlatformUrlEnvVariable:     serverDetails.Url,
+		jfPlatformXrayUrlEnvVariable: serverDetails.XrayUrl,
+		jfTokenEnvVariable:           serverDetails.AccessToken,
 	}
 	if !utils.IsCI() {
 		analyzerManagerLogFolder, err := coreutils.CreateDirInJfrogHome(filepath.Join(coreutils.JfrogLogsDirName, analyzerManagerLogDirName))

--- a/jas/analyzermanager.go
+++ b/jas/analyzermanager.go
@@ -24,7 +24,7 @@ import (
 const (
 	ApplicabilityFeatureId                    = "contextual_analysis"
 	AnalyzerManagerZipName                    = "analyzerManager.zip"
-	defaultAnalyzerManagerVersion             = "1.10.1"
+	defaultAnalyzerManagerVersion             = "1.10.2"
 	analyzerManagerDownloadPath               = "xsc-gen-exe-analyzer-manager-local/v1"
 	analyzerManagerDirName                    = "analyzerManager"
 	analyzerManagerExecutableName             = "analyzerManager"

--- a/jas/analyzermanager.go
+++ b/jas/analyzermanager.go
@@ -24,7 +24,7 @@ import (
 const (
 	ApplicabilityFeatureId                    = "contextual_analysis"
 	AnalyzerManagerZipName                    = "analyzerManager.zip"
-	defaultAnalyzerManagerVersion             = "1.9.11"
+	defaultAnalyzerManagerVersion             = "1.10.0"
 	analyzerManagerDownloadPath               = "xsc-gen-exe-analyzer-manager-local/v1"
 	analyzerManagerDirName                    = "analyzerManager"
 	analyzerManagerExecutableName             = "analyzerManager"

--- a/jas/analyzermanager.go
+++ b/jas/analyzermanager.go
@@ -24,7 +24,7 @@ import (
 const (
 	ApplicabilityFeatureId                    = "contextual_analysis"
 	AnalyzerManagerZipName                    = "analyzerManager.zip"
-	defaultAnalyzerManagerVersion             = "1.10.0"
+	defaultAnalyzerManagerVersion             = "1.10.1"
 	analyzerManagerDownloadPath               = "xsc-gen-exe-analyzer-manager-local/v1"
 	analyzerManagerDirName                    = "analyzerManager"
 	analyzerManagerExecutableName             = "analyzerManager"

--- a/jas/common.go
+++ b/jas/common.go
@@ -55,12 +55,12 @@ func CreateJasScanner(serverDetails *config.ServerDetails, validateSecrets bool,
 		if len(serverDetails.XrayUrl) != 0 {
 			log.Debug("Xray URL provided without platform URL")
 		} else {
+			if len(serverDetails.ArtifactoryUrl) != 0 {
+				log.Debug("Artifactory URL provided without platform URL")
+			}
 			log.Warn(NoServerUrlWarn)
+			return
 		}
-		if len(serverDetails.ArtifactoryUrl) != 0 {
-			log.Debug("Artifactory URL provided without platform URL")
-		}
-		return
 	}
 	scanner = &JasScanner{}
 	if scanner.EnvVars, err = getJasEnvVars(serverDetails, validateSecrets, envVars); err != nil {

--- a/jas/common.go
+++ b/jas/common.go
@@ -81,6 +81,7 @@ func CreateJasScanner(serverDetails *config.ServerDetails, validateSecrets bool,
 
 func getJasEnvVars(serverDetails *config.ServerDetails, validateSecrets bool, vars map[string]string) (map[string]string, error) {
 	amBasicVars, err := GetAnalyzerManagerEnvVariables(serverDetails)
+	log.Debug("Adding the following environment variables to the analyzer manager", amBasicVars)
 	if err != nil {
 		return nil, err
 	}

--- a/jas/common.go
+++ b/jas/common.go
@@ -54,11 +54,12 @@ func CreateJasScanner(serverDetails *config.ServerDetails, validateSecrets bool,
 	if len(serverDetails.Url) == 0 {
 		if len(serverDetails.XrayUrl) != 0 {
 			log.Debug("Xray URL provided without platform URL")
+		} else {
+			log.Warn(NoServerUrlWarn)
 		}
 		if len(serverDetails.ArtifactoryUrl) != 0 {
 			log.Debug("Artifactory URL provided without platform URL")
 		}
-		log.Warn(NoServerUrlWarn)
 		return
 	}
 	scanner = &JasScanner{}

--- a/jas/common_test.go
+++ b/jas/common_test.go
@@ -157,6 +157,40 @@ func TestGetJasEnvVars(t *testing.T) {
 				"test":                        "testValue",
 			},
 		},
+		{
+			name: "Valid server details xray only",
+			serverDetails: &config.ServerDetails{
+				Url:         "",
+				XrayUrl:     "url/xray",
+				User:        "user",
+				Password:    "password",
+				AccessToken: "token",
+			},
+			expectedOutput: map[string]string{
+				jfPlatformUrlEnvVariable:     "",
+				jfPlatformXrayUrlEnvVariable: "url/xray",
+				jfUserEnvVariable:            "user",
+				jfPasswordEnvVariable:        "password",
+				jfTokenEnvVariable:           "token",
+			},
+		},
+		{
+			name: "Valid server details both url and xray",
+			serverDetails: &config.ServerDetails{
+				Url:         "url",
+				XrayUrl:     "url/xray",
+				User:        "user",
+				Password:    "password",
+				AccessToken: "token",
+			},
+			expectedOutput: map[string]string{
+				jfPlatformUrlEnvVariable:     "url",
+				jfPlatformXrayUrlEnvVariable: "url/xray",
+				jfUserEnvVariable:            "user",
+				jfPasswordEnvVariable:        "password",
+				jfTokenEnvVariable:           "token",
+			},
+		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {

--- a/scans_test.go
+++ b/scans_test.go
@@ -162,7 +162,7 @@ func initNativeDockerWithXrayTest(t *testing.T) (mockCli *coreTests.JfrogCli, cl
 	if !*securityTests.TestDockerScan || !*securityTests.TestSecurity {
 		t.Skip("Skipping Docker scan test. To run Xray Docker test add the '-test.dockerScan=true' and '-test.security=true' options.")
 	}
-	return securityTestUtils.InitTestWithMockCommandOrParams(t, cli.DockerScanMockCommand)
+	return securityTestUtils.InitTestWithMockCommandOrParams(t, false, cli.DockerScanMockCommand)
 }
 
 func runDockerScan(t *testing.T, testCli *coreTests.JfrogCli, imageName, watchName string, minViolations, minVulnerabilities, minLicenses int, minInactives int, validateSecrets bool) {

--- a/tests/utils/test_config.go
+++ b/tests/utils/test_config.go
@@ -61,12 +61,13 @@ func GetTestCli(testApplication components.App, xrayUrlOnly bool) (testCli *core
 
 func authenticateXray(xrayUrlOnly bool) string {
 	*configTests.JfrogUrl = clientUtils.AddTrailingSlashIfNeeded(*configTests.JfrogUrl)
+	cred := fmt.Sprintf("--url=%s", *configTests.JfrogUrl)
 	if xrayUrlOnly {
+		cred = fmt.Sprintf("--xray-url=%s", configTests.XrDetails.XrayUrl)
 		configTests.XrDetails = &config.ServerDetails{XrayUrl: *configTests.JfrogUrl + configTests.XrayEndpoint}
 	} else {
 		configTests.XrDetails = &config.ServerDetails{Url: *configTests.JfrogUrl, ArtifactoryUrl: *configTests.JfrogUrl + configTests.ArtifactoryEndpoint, XrayUrl: *configTests.JfrogUrl + configTests.XrayEndpoint}
 	}
-	cred := fmt.Sprintf("--url=%s", configTests.XrDetails.XrayUrl)
 	if *configTests.JfrogAccessToken != "" {
 		configTests.XrDetails.AccessToken = *configTests.JfrogAccessToken
 		cred += fmt.Sprintf(" --access-token=%s", configTests.XrDetails.AccessToken)

--- a/tests/utils/test_config.go
+++ b/tests/utils/test_config.go
@@ -50,18 +50,22 @@ func CreateJfrogHomeConfig(t *testing.T, encryptPassword bool) {
 func InitTestCliDetails(testApplication components.App) {
 	configTests.TestApplication = &testApplication
 	if configTests.PlatformCli == nil {
-		configTests.PlatformCli = GetTestCli(testApplication)
+		configTests.PlatformCli = GetTestCli(testApplication, false)
 	}
 }
 
-func GetTestCli(testApplication components.App) (testCli *coreTests.JfrogCli) {
-	creds := authenticateXray()
+func GetTestCli(testApplication components.App, xrayUrlOnly bool) (testCli *coreTests.JfrogCli) {
+	creds := authenticateXray(xrayUrlOnly)
 	return coreTests.NewJfrogCli(func() error { return plugins.RunCliWithPlugin(testApplication)() }, "", creds)
 }
 
-func authenticateXray() string {
+func authenticateXray(xrayUrlOnly bool) string {
 	*configTests.JfrogUrl = clientUtils.AddTrailingSlashIfNeeded(*configTests.JfrogUrl)
-	configTests.XrDetails = &config.ServerDetails{Url: *configTests.JfrogUrl, ArtifactoryUrl: *configTests.JfrogUrl + configTests.ArtifactoryEndpoint, XrayUrl: *configTests.JfrogUrl + configTests.XrayEndpoint}
+	if xrayUrlOnly {
+		configTests.XrDetails = &config.ServerDetails{XrayUrl: *configTests.JfrogUrl + configTests.XrayEndpoint}
+	} else {
+		configTests.XrDetails = &config.ServerDetails{Url: *configTests.JfrogUrl, ArtifactoryUrl: *configTests.JfrogUrl + configTests.ArtifactoryEndpoint, XrayUrl: *configTests.JfrogUrl + configTests.XrayEndpoint}
+	}
 	cred := fmt.Sprintf("--url=%s", configTests.XrDetails.XrayUrl)
 	if *configTests.JfrogAccessToken != "" {
 		configTests.XrDetails.AccessToken = *configTests.JfrogAccessToken

--- a/tests/utils/test_config.go
+++ b/tests/utils/test_config.go
@@ -61,12 +61,13 @@ func GetTestCli(testApplication components.App, xrayUrlOnly bool) (testCli *core
 
 func authenticateXray(xrayUrlOnly bool) string {
 	*configTests.JfrogUrl = clientUtils.AddTrailingSlashIfNeeded(*configTests.JfrogUrl)
-	cred := fmt.Sprintf("--url=%s", *configTests.JfrogUrl)
+	var cred string
 	if xrayUrlOnly {
-		cred = fmt.Sprintf("--xray-url=%s", configTests.XrDetails.XrayUrl)
 		configTests.XrDetails = &config.ServerDetails{XrayUrl: *configTests.JfrogUrl + configTests.XrayEndpoint}
+		cred = fmt.Sprintf("--xray-url=%s", configTests.XrDetails.XrayUrl)
 	} else {
 		configTests.XrDetails = &config.ServerDetails{Url: *configTests.JfrogUrl, ArtifactoryUrl: *configTests.JfrogUrl + configTests.ArtifactoryEndpoint, XrayUrl: *configTests.JfrogUrl + configTests.XrayEndpoint}
+		cred = fmt.Sprintf("--url=%s", configTests.XrDetails.XrayUrl)
 	}
 	if *configTests.JfrogAccessToken != "" {
 		configTests.XrDetails.AccessToken = *configTests.JfrogAccessToken

--- a/tests/utils/test_utils.go
+++ b/tests/utils/test_utils.go
@@ -78,7 +78,7 @@ func ValidateXscVersion(t *testing.T, minVersion string) {
 	}
 }
 
-func InitTestWithMockCommandOrParams(t *testing.T, mockCommands ...func() components.Command) (mockCli *coreTests.JfrogCli, cleanUp func()) {
+func InitTestWithMockCommandOrParams(t *testing.T, xrayUrlOnly bool, mockCommands ...func() components.Command) (mockCli *coreTests.JfrogCli, cleanUp func()) {
 	oldHomeDir := os.Getenv(coreutils.HomeDir)
 	// Create server config to use with the command.
 	CreateJfrogHomeConfig(t, true)
@@ -87,7 +87,7 @@ func InitTestWithMockCommandOrParams(t *testing.T, mockCommands ...func() compon
 	for _, mockCommand := range mockCommands {
 		commands = append(commands, mockCommand())
 	}
-	return GetTestCli(components.CreateEmbeddedApp("security", commands)), func() {
+	return GetTestCli(components.CreateEmbeddedApp("security", commands), xrayUrlOnly), func() {
 		clientTests.SetEnvAndAssert(t, coreutils.HomeDir, oldHomeDir)
 	}
 }


### PR DESCRIPTION
- [x] The pull request is targeting the `dev` branch.
- [x] The code has been validated to compile successfully by running `go vet ./...`.
- [x] The code has been formatted properly using `go fmt ./...`.
- [ ] All [static analysis checks](https://github.com/jfrog/jfrog-cli-security/actions/workflows/analysis.yml) passed.
- [ ] All [tests](https://github.com/jfrog/jfrog-cli-security/actions/workflows/test.yml) have passed. If this feature is not already covered by the tests, new tests have been added.
- [x] All changes are detailed at the description. if not already covered at [JFrog Documentation](https://github.com/jfrog/documentation), new documentation have been added.

-----

When configuring `xray-url` only, without the `url` - the audit command didn't recognize them, and couldn't set JAS scanners:

> I keep getting this warning  “To include 'Advanced Security' scan as part of the audit output, please run the 'jf c add' command before running this command.“ when running the `jf audit`.
>
> The command I use to reproduce the issue:
> jf c add "test" --xray-url="PLATFORM_URL" --interactive=false --access-token="access-token*****"
> 
> I was able to solve it using the following cmd:
> jf c add "test" --url="PLATFORM_URL" --interactive=false --access-token="access-token******"
> 