### PR TITLE
Print both vulnerabilities and violations tables if needed

### DIFF
--- a/commands/audit/audit.go
+++ b/commands/audit/audit.go
@@ -134,6 +134,7 @@ func (auditCmd *AuditCommand) Run() (err error) {
 	}
 	if err = utils.NewResultsWriter(auditResults).
 		SetIsMultipleRootProject(auditResults.IsMultipleProject()).
+		SetHasViolationContext(auditCmd.HasViolationContext()).
 		SetIncludeVulnerabilities(auditCmd.IncludeVulnerabilities).
 		SetIncludeLicenses(auditCmd.IncludeLicenses).
 		SetOutputFormat(auditCmd.OutputFormat()).
@@ -158,6 +159,10 @@ func (auditCmd *AuditCommand) Run() (err error) {
 
 func (auditCmd *AuditCommand) CommandName() string {
 	return "generic_audit"
+}
+
+func (auditCmd *AuditCommand) HasViolationContext() bool {
+	return len(auditCmd.watches) > 0 || auditCmd.projectKey != "" || auditCmd.targetRepoPath != ""
 }
 
 // Runs an audit scan based on the provided auditParams.

--- a/commands/scan/buildscan.go
+++ b/commands/scan/buildscan.go
@@ -155,6 +155,7 @@ func (bsc *BuildScanCommand) runBuildScanAndPrintResults(xrayManager *xray.XrayS
 
 	resultsPrinter := utils.NewResultsWriter(scanResults).
 		SetOutputFormat(bsc.outputFormat).
+		SetHasViolationContext(bsc.hasViolationContext()).
 		SetIncludeVulnerabilities(bsc.includeVulnerabilities).
 		SetIncludeLicenses(false).
 		SetIsMultipleRootProject(true).
@@ -187,7 +188,7 @@ func (bsc *BuildScanCommand) runBuildScanAndPrintResults(xrayManager *xray.XrayS
 		scanResults,
 		bsc.serverDetails,
 		bsc.includeVulnerabilities,
-		bsc.buildConfiguration.GetProject() != "",
+		bsc.hasViolationContext(),
 		params.BuildName, params.BuildNumber,
 	))
 	return
@@ -195,6 +196,10 @@ func (bsc *BuildScanCommand) runBuildScanAndPrintResults(xrayManager *xray.XrayS
 
 func (bsc *BuildScanCommand) CommandName() string {
 	return "xr_build_scan"
+}
+
+func (bsc *BuildScanCommand) hasViolationContext() bool {
+	return bsc.buildConfiguration.GetProject() != ""
 }
 
 // There are two cases. when serverDetails.Url is configured and when serverDetails.XrayUrl and serverDetails.ArtifactoryUrl are configured

--- a/commands/scan/dockerscan.go
+++ b/commands/scan/dockerscan.go
@@ -106,7 +106,7 @@ func (dsc *DockerScanCommand) Run() (err error) {
 			scanResults,
 			dsc.ScanCommand.serverDetails,
 			dsc.ScanCommand.includeVulnerabilities,
-			hasViolationContext(dsc.ScanCommand.watches, dsc.ScanCommand.projectKey),
+			dsc.ScanCommand.hasViolationContext(),
 			dsc.imageTag,
 		))
 	})

--- a/commands/scan/scan.go
+++ b/commands/scan/scan.go
@@ -161,6 +161,10 @@ func (scanCmd *ScanCommand) SetAnalyticsMetricsService(analyticsMetricsService *
 	return scanCmd
 }
 
+func (scanCmd *ScanCommand) hasViolationContext() bool {
+	return len(scanCmd.watches) > 0 || scanCmd.projectKey != ""
+}
+
 func (scanCmd *ScanCommand) indexFile(filePath string) (*xrayUtils.BinaryGraphNode, error) {
 	var indexerResults xrayUtils.BinaryGraphNode
 	indexerCmd := exec.Command(scanCmd.indexerPath, indexingCommand, filePath, "--temp-dir", scanCmd.indexerTempDir)
@@ -195,13 +199,9 @@ func (scanCmd *ScanCommand) Run() (err error) {
 			scanResults,
 			scanCmd.serverDetails,
 			scanCmd.includeVulnerabilities,
-			hasViolationContext(scanCmd.watches, scanCmd.projectKey),
+			scanCmd.hasViolationContext(),
 		))
 	})
-}
-
-func hasViolationContext(watches []string, projectKey string) bool {
-	return len(watches) > 0 || projectKey != ""
 }
 
 func (scanCmd *ScanCommand) RunAndRecordResults(recordResFunc func(scanResults *utils.Results) error) (err error) {
@@ -318,6 +318,7 @@ func (scanCmd *ScanCommand) RunAndRecordResults(recordResFunc func(scanResults *
 
 	if err = utils.NewResultsWriter(scanResults).
 		SetOutputFormat(scanCmd.outputFormat).
+		SetHasViolationContext(scanCmd.hasViolationContext()).
 		SetIncludeVulnerabilities(scanCmd.includeVulnerabilities).
 		SetIncludeLicenses(scanCmd.includeLicenses).
 		SetPrintExtendedTable(scanCmd.printExtendedTable).


### PR DESCRIPTION
- [x] The pull request is targeting the `dev` branch.
- [x] The code has been validated to compile successfully by running `go vet ./...`.
- [x] The code has been formatted properly using `go fmt ./...`.
- [x] All [static analysis checks](https://github.com/jfrog/jfrog-cli-security/actions/workflows/analysis.yml) passed.
- [x] All [tests](https://github.com/jfrog/jfrog-cli-security/actions/workflows/test.yml) have passed. If this feature is not already covered by the tests, new tests have been added.
- [x] All changes are detailed at the description. if not already covered at [JFrog Documentation](https://github.com/jfrog/documentation), new documentation have been added.

-----

If `--vuln` flag was provided in `table` format. we only printed the vulnerabilities and not both