### PR TITLE
Fix sorting table results when no JAS scan

### DIFF
--- a/utils/resultwriter_test.go
+++ b/utils/resultwriter_test.go
@@ -242,7 +242,7 @@ func TestConvertXrayScanToSimpleJson(t *testing.T) {
 			Summary: "summary-1",
 			IssueId: "XRAY-1",
 			ImpactedDependencyDetails: formats.ImpactedDependencyDetails{
-				SeverityDetails:        formats.SeverityDetails{Severity: "High"},
+				SeverityDetails:        formats.SeverityDetails{Severity: "High", SeverityNumValue: 15},
 				ImpactedDependencyName: "component-A",
 			},
 		},
@@ -250,7 +250,7 @@ func TestConvertXrayScanToSimpleJson(t *testing.T) {
 			Summary: "summary-1",
 			IssueId: "XRAY-1",
 			ImpactedDependencyDetails: formats.ImpactedDependencyDetails{
-				SeverityDetails:        formats.SeverityDetails{Severity: "High"},
+				SeverityDetails:        formats.SeverityDetails{Severity: "High", SeverityNumValue: 15},
 				ImpactedDependencyName: "component-B",
 			},
 		},
@@ -258,7 +258,7 @@ func TestConvertXrayScanToSimpleJson(t *testing.T) {
 			Summary: "summary-2",
 			IssueId: "XRAY-2",
 			ImpactedDependencyDetails: formats.ImpactedDependencyDetails{
-				SeverityDetails:        formats.SeverityDetails{Severity: "Low"},
+				SeverityDetails:        formats.SeverityDetails{Severity: "Low", SeverityNumValue: 9},
 				ImpactedDependencyName: "component-B",
 			},
 		},
@@ -288,7 +288,7 @@ func TestConvertXrayScanToSimpleJson(t *testing.T) {
 			Summary: "summary-1",
 			IssueId: "XRAY-1",
 			ImpactedDependencyDetails: formats.ImpactedDependencyDetails{
-				SeverityDetails:        formats.SeverityDetails{Severity: "High"},
+				SeverityDetails:        formats.SeverityDetails{Severity: "High", SeverityNumValue: 15},
 				ImpactedDependencyName: "component-A",
 			},
 		},
@@ -296,7 +296,7 @@ func TestConvertXrayScanToSimpleJson(t *testing.T) {
 			Summary: "summary-1",
 			IssueId: "XRAY-1",
 			ImpactedDependencyDetails: formats.ImpactedDependencyDetails{
-				SeverityDetails:        formats.SeverityDetails{Severity: "High"},
+				SeverityDetails:        formats.SeverityDetails{Severity: "High", SeverityNumValue: 15},
 				ImpactedDependencyName: "component-B",
 			},
 		},
@@ -305,7 +305,7 @@ func TestConvertXrayScanToSimpleJson(t *testing.T) {
 		{
 			LicenseKey: "license-1",
 			ImpactedDependencyDetails: formats.ImpactedDependencyDetails{
-				SeverityDetails:        formats.SeverityDetails{Severity: "Low"},
+				SeverityDetails:        formats.SeverityDetails{Severity: "Low", SeverityNumValue: 9},
 				ImpactedDependencyName: "component-B",
 			},
 		},

--- a/utils/severityutils/severity.go
+++ b/utils/severityutils/severity.go
@@ -235,7 +235,7 @@ func ParseToSeverityDetails(severity string, sarifSeverity, pretty bool, applica
 
 func GetAsDetails(severity Severity, applicabilityStatus jasutils.ApplicabilityStatus, pretty bool) formats.SeverityDetails {
 	if applicabilityStatus == jasutils.NotScanned {
-		// Pass 'NotCovered' as default value to get priority
+		// Pass 'NotCovered' as default value to get priority, since 'NotScanned' returns 0 priority for all severities
 		applicabilityStatus = jasutils.NotCovered
 	}
 	return GetSeverityDetails(severity, applicabilityStatus).ToDetails(severity, pretty)

--- a/utils/severityutils/severity.go
+++ b/utils/severityutils/severity.go
@@ -234,6 +234,10 @@ func ParseToSeverityDetails(severity string, sarifSeverity, pretty bool, applica
 // -- Getters functions (With default values) --
 
 func GetAsDetails(severity Severity, applicabilityStatus jasutils.ApplicabilityStatus, pretty bool) formats.SeverityDetails {
+	if applicabilityStatus == jasutils.NotScanned {
+		// Pass 'NotCovered' as default value to get priority
+		applicabilityStatus = jasutils.NotCovered
+	}
 	return GetSeverityDetails(severity, applicabilityStatus).ToDetails(severity, pretty)
 }
 


### PR DESCRIPTION
- [x] The pull request is targeting the `dev` branch.
- [x] The code has been validated to compile successfully by running `go vet ./...`.
- [x] The code has been formatted properly using `go fmt ./...`.
- [x] All [static analysis checks](https://github.com/jfrog/jfrog-cli-security/actions/workflows/analysis.yml) passed.
- [x] All [tests](https://github.com/jfrog/jfrog-cli-security/actions/workflows/test.yml) have passed. If this feature is not already covered by the tests, new tests have been added.
- [x] All changes are detailed at the description. if not already covered at [JFrog Documentation](https://github.com/jfrog/documentation), new documentation have been added.

-----

When the applicable status was NotScanned, priority was not provided.

Before:
![image](https://github.com/user-attachments/assets/5c49de1f-f184-4543-a6fd-07bae0e6a677)

After:
![image](https://github.com/user-attachments/assets/b71542e6-a099-4997-91f0-3655e31647c4)
