### PR TITLE
Add a warning to indicate wrong usage in 'jf scan' command

### DIFF
--- a/cli/scancommands.go
+++ b/cli/scancommands.go
@@ -197,6 +197,13 @@ func ScanCmd(c *components.Context) error {
 	if len(c.Arguments) == 0 && !c.IsFlagSet(flags.SpecFlag) {
 		return pluginsCommon.PrintHelpAndReturnError("providing either a <source pattern> argument or the 'spec' option is mandatory", c)
 	}
+
+	if len(c.Arguments) > 1 {
+		log.Warn(fmt.Sprintf("Too many arguments provided (%d in total).\n"+
+			"Some flags might be mistaken as arguments and ignored, which could prevent them from affecting the command as intended.\n"+
+			"Please ensure all provided flags are valid and provided correct order. For more details: 'jf %s --help'", len(c.Arguments), c.CommandName))
+	}
+
 	serverDetails, err := createServerDetailsWithConfigOffer(c)
 	if err != nil {
 		return err


### PR DESCRIPTION
- [ ] The pull request is targeting the `dev` branch.
- [ ] The code has been validated to compile successfully by running `go vet ./...`.
- [ ] The code has been formatted properly using `go fmt ./...`.
- [ ] All [static analysis checks](https://github.com/jfrog/jfrog-cli-security/actions/workflows/analysis.yml) passed.
- [ ] All [tests](https://github.com/jfrog/jfrog-cli-security/actions/workflows/test.yml) have passed. If this feature is not already covered by the tests, new tests have been added.
- [ ] All changes are detailed at the description. if not already covered at [JFrog Documentation](https://github.com/jfrog/documentation), new documentation have been added.

-----
The 'jf scan' command should be executed in the following manner: jf scan [command options] <source pattern> OR jf scan [command options] --spec=<value>.
If the command was written in a different order: jf scan <source pattern> [command options], it may lead that some flags are mistaken as arguments and are not going through the command's flags verifications. Therefore, if a wrong flag was provided in this manner - it will get skipped completely without informing the customer.
I added a warning to indicate the wrong usage and what it may cause.
The indication comes in a Warning form and not error in order to not breaking customers.