### PR TITLE
Disable generating SARIF for GitHub advance security tab if not entitled for JAS

### DIFF
--- a/utils/securityJobSummary.go
+++ b/utils/securityJobSummary.go
@@ -178,6 +178,10 @@ func RecordSarifOutput(cmdResults *Results) (err error) {
 	if err != nil || manager == nil {
 		return
 	}
+	if cmdResults.ExtendedScanResults == nil || !cmdResults.ExtendedScanResults.EntitledForJas {
+		// If no JAS no GHAS
+		return
+	}
 	extended := true
 	if !extended && !commandsummary.StaticMarkdownConfig.IsExtendedSummary() {
 		log.Info("Results can be uploaded to Github security tab automatically by upgrading your JFrog subscription.")

--- a/utils/securityJobSummary_test.go
+++ b/utils/securityJobSummary_test.go
@@ -8,9 +8,12 @@ import (
 	"testing"
 
 	"github.com/jfrog/jfrog-cli-core/v2/artifactory/utils/commandsummary"
+	coreUtils "github.com/jfrog/jfrog-cli-core/v2/utils/coreutils"
 	coreTests "github.com/jfrog/jfrog-cli-core/v2/utils/tests"
 	"github.com/jfrog/jfrog-cli-security/formats"
 	"github.com/jfrog/jfrog-cli-security/utils/jasutils"
+	"github.com/jfrog/jfrog-client-go/utils/io/fileutils"
+	clientTests "github.com/jfrog/jfrog-client-go/utils/tests"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -36,6 +39,51 @@ var (
 		SecretsResults: &formats.ResultSummary{"Medium": map[string]int{formats.NoStatus: 3}},
 	}
 )
+
+func TestSaveSarifOutputOnlyForJasEntitled(t *testing.T) {
+	testCases := []struct {
+		name          string
+		isJasEntitled bool
+	}{
+		{
+			name:          "JAS entitled",
+			isJasEntitled: true,
+		},
+		{
+			name:          "JAS not entitled",
+			isJasEntitled: false,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			tempDir, cleanUpDir := coreTests.CreateTempDirWithCallbackAndAssert(t)
+			defer cleanUpDir()
+			cleanUp := clientTests.SetEnvWithCallbackAndAssert(t, coreUtils.SummaryOutputDirPathEnv, tempDir)
+			defer cleanUp()
+
+			assert.NoError(t, RecordSarifOutput(createDummyJasResult(testCase.isJasEntitled)))
+			assert.Equal(t, testCase.isJasEntitled, hasFilesInDir(t, filepath.Join(tempDir, commandsummary.OutputDirName, "security", string(commandsummary.SarifReport))))
+		})
+	}
+}
+
+func createDummyJasResult(entitled bool) *Results {
+	return &Results{
+		ExtendedScanResults: &ExtendedScanResults{EntitledForJas: entitled},
+	}
+}
+
+func hasFilesInDir(t *testing.T, dir string) bool {
+	exists, err := fileutils.IsDirExists(dir, false)
+	assert.NoError(t, err)
+	if !exists {
+		return false
+	}
+	files, err := os.ReadDir(dir)
+	assert.NoError(t, err)
+	return len(files) > 0
+}
 
 func TestSaveLoadData(t *testing.T) {
 	testDockerScanSummary := ScanCommandResultSummary{


### PR DESCRIPTION
- [x] The pull request is targeting the `dev` branch.
- [x] The code has been validated to compile successfully by running `go vet ./...`.
- [x] The code has been formatted properly using `go fmt ./...`.
- [x] All [static analysis checks](https://github.com/jfrog/jfrog-cli-security/actions/workflows/analysis.yml) passed.
- [x] All [tests](https://github.com/jfrog/jfrog-cli-security/actions/workflows/test.yml) have passed. If this feature is not already covered by the tests, new tests have been added.
- [x] All changes are detailed at the description. if not already covered at [JFrog Documentation](https://github.com/jfrog/documentation), new documentation have been added.

-----

disable generating SARIF for GitHub advance security tab if not entitled for JAS