### PR TITLE
Fixed wrong root identification in module detection

### DIFF
--- a/utils/techutils/techutils.go
+++ b/utils/techutils/techutils.go
@@ -510,9 +510,14 @@ func hasCompletePathPrefix(root, wd string) bool {
 	if !strings.HasPrefix(root, wd) {
 		return false
 	}
+	log.Info(fmt.Sprintf("ERAN TEST - root path: %s", root))
+	log.Info(fmt.Sprintf("ERAN TEST - wd path: %s", root))
 	rootParts := strings.Split(root, string(filepath.Separator))
 	wdParts := strings.Split(wd, string(filepath.Separator))
+	log.Info(fmt.Sprintf("ERAN TEST - root slice: %s", rootParts))
+	log.Info(fmt.Sprintf("ERAN TEST - wd parts: %s", wdParts))
 	idxToCheck := len(wdParts) - 1
+	log.Info(fmt.Sprintf("ERAN TEST - idx to check: %d", idxToCheck))
 	return rootParts[idxToCheck] == wdParts[idxToCheck]
 }
 

--- a/utils/techutils/techutils.go
+++ b/utils/techutils/techutils.go
@@ -485,11 +485,22 @@ func getExistingRootDir(path string, workingDirectoryToIndicators map[string][]s
 	for wd := range workingDirectoryToIndicators {
 		parentWd := filepath.Dir(wd)
 		parentRoot := filepath.Dir(root)
-		if parentRoot != parentWd && strings.HasPrefix(root, wd) {
+		if parentRoot != parentWd && hasCompletePathPrefix(root, wd) {
 			root = wd
 		}
 	}
 	return
+}
+
+func hasCompletePathPrefix(root, wd string) bool {
+	if strings.HasPrefix(root, wd) {
+		amountOfSkippedChars := len(wd)
+		partialRoot := root[amountOfSkippedChars:]
+		if partialRoot == "" || partialRoot[0] == filepath.Separator {
+			return true
+		}
+	}
+	return false
 }
 
 // DetectedTechnologiesToSlice returns a string slice that includes all the names of the detected technologies.

--- a/utils/techutils/techutils.go
+++ b/utils/techutils/techutils.go
@@ -510,14 +510,9 @@ func hasCompletePathPrefix(root, wd string) bool {
 	if !strings.HasPrefix(root, wd) {
 		return false
 	}
-	log.Info(fmt.Sprintf("ERAN TEST - root path: %s", root))
-	log.Info(fmt.Sprintf("ERAN TEST - wd path: %s", root))
 	rootParts := strings.Split(root, string(filepath.Separator))
 	wdParts := strings.Split(wd, string(filepath.Separator))
-	log.Info(fmt.Sprintf("ERAN TEST - root slice: %s", rootParts))
-	log.Info(fmt.Sprintf("ERAN TEST - wd parts: %s", wdParts))
 	idxToCheck := len(wdParts) - 1
-	log.Info(fmt.Sprintf("ERAN TEST - idx to check: %d", idxToCheck))
 	return rootParts[idxToCheck] == wdParts[idxToCheck]
 }
 

--- a/utils/techutils/techutils.go
+++ b/utils/techutils/techutils.go
@@ -492,15 +492,17 @@ func getExistingRootDir(path string, workingDirectoryToIndicators map[string][]s
 	return
 }
 
+// This functions checks if wd is a PATH prefix for root. Examples:
+// root = dir1/dir2/dir3 | wd = dir1/dir --> false (wd is prefix to root, but is not actually a valid part of its path)
+// root = dir1/dir2/dir3 | wd = dir1/dir2 --> true
 func hasCompletePathPrefix(root, wd string) bool {
-	if strings.HasPrefix(root, wd) {
-		amountOfSkippedChars := len(wd)
-		partialRoot := root[amountOfSkippedChars:]
-		if partialRoot == "" || partialRoot[0] == filepath.Separator {
-			return true
-		}
+	if !strings.HasPrefix(root, wd) {
+		return false
 	}
-	return false
+	rootParts := strings.Split(root, string(filepath.Separator))
+	wdParts := strings.Split(wd, string(filepath.Separator))
+	idxToCheck := len(wdParts) - 1
+	return rootParts[idxToCheck] == wdParts[idxToCheck]
 }
 
 // DetectedTechnologiesToSlice returns a string slice that includes all the names of the detected technologies.

--- a/utils/techutils/techutils_test.go
+++ b/utils/techutils/techutils_test.go
@@ -318,19 +318,19 @@ func TestHasCompletePathPrefix(t *testing.T) {
 	}{
 		{
 			name:     "no prefix",
-			root:     "dir1/dir2",
-			wd:       "some/other/project",
+			root:     filepath.Join("dir1", "dir2"),
+			wd:       filepath.Join("some", "other", "project"),
 			expected: false,
 		},
 		{
 			name:     "prefix but not a path prefix",
-			root:     "dir1/dir2",
+			root:     filepath.Join("dir1", "dir2"),
 			wd:       "dir",
 			expected: false,
 		},
 		{
 			name:     "path prefix",
-			root:     "dir1/dir2",
+			root:     filepath.Join("dir1", "dir2"),
 			wd:       "dir1",
 			expected: true,
 		},

--- a/utils/techutils/techutils_test.go
+++ b/utils/techutils/techutils_test.go
@@ -277,6 +277,17 @@ func TestGetExistingRootDir(t *testing.T) {
 			},
 			expected: "directory",
 		},
+		{
+			// This test case checks that we capture the correct root when sub is a prefix to root, but not an actual path prefix
+			// Example: root = "dir1/dir2", sub = "dir" -> root indeed starts with 'dir' but 'dir' is not a path prefix to the root
+			name: "match root when root's letters start with sub's letters",
+			path: filepath.Join("dir3", "dir"),
+			workingDirectoryToIndicators: map[string][]string{
+				filepath.Join("dir3", "dir"): {filepath.Join("dir3", "dir", "package.json")},
+				"dir":                        {filepath.Join("dir", "package.json")},
+			},
+			expected: filepath.Join("dir3", "dir"),
+		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {

--- a/utils/techutils/techutils_test.go
+++ b/utils/techutils/techutils_test.go
@@ -536,6 +536,7 @@ func TestGetTechInformationFromWorkingDir(t *testing.T) {
 			requestedDescriptors: map[Technology][]string{},
 			expected:             map[string][]string{"dir": {filepath.Join("dir", "project.sln"), filepath.Join("dir", "sub1", "project.csproj")}},
 		},
+		// todo paste here the code section from the bug
 	}
 
 	for _, test := range tests {

--- a/utils/techutils/techutils_test.go
+++ b/utils/techutils/techutils_test.go
@@ -296,6 +296,39 @@ func TestGetExistingRootDir(t *testing.T) {
 	}
 }
 
+func TestHasCompletePathPrefix(t *testing.T) {
+	tests := []struct {
+		name     string
+		root     string
+		wd       string
+		expected bool
+	}{
+		{
+			name:     "no prefix",
+			root:     "dir1/dir2",
+			wd:       "some/other/project",
+			expected: false,
+		},
+		{
+			name:     "prefix but not a path prefix",
+			root:     "dir1/dir2",
+			wd:       "dir",
+			expected: false,
+		},
+		{
+			name:     "path prefix",
+			root:     "dir1/dir2",
+			wd:       "dir1",
+			expected: true,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			assert.Equal(t, test.expected, hasCompletePathPrefix(test.root, test.wd))
+		})
+	}
+}
+
 func TestCleanSubDirectories(t *testing.T) {
 	tests := []struct {
 		name                    string

--- a/utils/techutils/techutils_test.go
+++ b/utils/techutils/techutils_test.go
@@ -575,6 +575,17 @@ func TestGetTechInformationFromWorkingDir(t *testing.T) {
 				"dir4": {filepath.Join("dir4", "package.json")},
 			},
 		},
+		{
+			name:                 "pnpmTestWithProvidedTechFromUser",
+			tech:                 Pnpm,
+			requestedDescriptors: make(map[Technology][]string),
+			techProvidedByUser:   true,
+			expected: map[string][]string{
+				filepath.Join("dir3", "dir"): {filepath.Join("dir3", "dir", "package.json")},
+				"dir":                        {filepath.Join("dir", "package.json")},
+				"dir4":                       {filepath.Join("dir4", "package.json")},
+			},
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
- [x] The pull request is targeting the `dev` branch.
- [x] The code has been validated to compile successfully by running `go vet ./...`.
- [x] The code has been formatted properly using `go fmt ./...`.
- [x] All [static analysis checks](https://github.com/jfrog/jfrog-cli-security/actions/workflows/analysis.yml) passed.
- [x] All [tests](https://github.com/jfrog/jfrog-cli-security/actions/workflows/test.yml) have passed. If this feature is not already covered by the tests, new tests have been added.
- [x] All changes are detailed at the description. if not already covered at [JFrog Documentation](https://github.com/jfrog/documentation), new documentation have been added.

-----
In getExistingRootDir we find the highest common ancestor for every descriptor, and refer this descriptor to this common ancestor rather then its original working dir.
As part of the process we check under some condition, if the current wd is a prefix to the current root, and if so - wd is the new root.
We encountered a wrong identification in the following scenario: if wd is indeed a prefix to root but **not a path prefix**, we wrongfully take wd as the new root.
Example:
root = "dir1/dir2"
wd = "dir"

wd is indeed a prefix to root (by characters) but is not actually a path prefix since the path prefix to root is "dir1" and not "dir"

This PR adds fix for this issue so we identify if wd is a **path prefix** to the root

Also, this PR added a test case to TestGetTechInformationFromWorkingDir, that have failed due to the build, and is now added after the fix