### PR TITLE
Apply Min-Severity filter on Jas results

### DIFF
--- a/commands/audit/audit.go
+++ b/commands/audit/audit.go
@@ -248,7 +248,7 @@ func RunJasScans(auditParallelRunner *utils.SecurityParallelRunner, auditParams 
 		err = fmt.Errorf("failed to get server details: %s", err.Error())
 		return
 	}
-	jasScanner, err = jas.CreateJasScanner(jfrogAppsConfig, serverDetails, jas.GetAnalyzerManagerXscEnvVars(auditParams.commonGraphScanParams.MultiScanId, results.ExtendedScanResults.SecretValidation, results.GetScaScannedTechnologies()...), auditParams.Exclusions()...)
+	jasScanner, err = jas.CreateJasScanner(jfrogAppsConfig, serverDetails, auditParams.minSeverityFilter, jas.GetAnalyzerManagerXscEnvVars(auditParams.commonGraphScanParams.MultiScanId, results.ExtendedScanResults.SecretValidation, results.GetScaScannedTechnologies()...), auditParams.Exclusions()...)
 	if err != nil {
 		err = fmt.Errorf("failed to create jas scanner: %s", err.Error())
 		return

--- a/commands/scan/scan.go
+++ b/commands/scan/scan.go
@@ -451,7 +451,7 @@ func (scanCmd *ScanCommand) createIndexerHandlerFunc(file *spec.File, entitledFo
 						log.Error(fmt.Sprintf("failed to create JFrogAppsConfig: %s", err.Error()))
 						indexedFileErrors[threadId] = append(indexedFileErrors[threadId], formats.SimpleJsonError{FilePath: filePath, ErrorMessage: err.Error()})
 					}
-					scanner, err := jas.CreateJasScanner(jfrogAppsConfig, scanCmd.serverDetails, jas.GetAnalyzerManagerXscEnvVars(scanResults.MultiScanId, validateSecrets, techutils.Technology(graphScanResults.ScannedPackageType)))
+					scanner, err := jas.CreateJasScanner(jfrogAppsConfig, scanCmd.serverDetails, scanCmd.minSeverityFilter, jas.GetAnalyzerManagerXscEnvVars(scanResults.MultiScanId, validateSecrets, techutils.Technology(graphScanResults.ScannedPackageType)))
 					if err != nil {
 						log.Error(fmt.Sprintf("failed to create jas scanner: %s", err.Error()))
 						indexedFileErrors[threadId] = append(indexedFileErrors[threadId], formats.SimpleJsonError{FilePath: filePath, ErrorMessage: err.Error()})

--- a/jas/applicability/applicabilitymanager.go
+++ b/jas/applicability/applicabilitymanager.go
@@ -135,7 +135,7 @@ func (asm *ApplicabilityScanManager) Run(module jfrogappsconfig.Module) (err err
 	if err = asm.runAnalyzerManager(); err != nil {
 		return
 	}
-	workingDirResults, err := jas.ReadJasScanRunsFromFile(asm.resultsFileName, module.SourceRoot, applicabilityDocsUrlSuffix)
+	workingDirResults, err := jas.ReadJasScanRunsFromFile(asm.resultsFileName, module.SourceRoot, applicabilityDocsUrlSuffix, asm.scanner.MinSeverity)
 	if err != nil {
 		return
 	}

--- a/jas/applicability/applicabilitymanager_test.go
+++ b/jas/applicability/applicabilitymanager_test.go
@@ -310,7 +310,7 @@ func TestParseResults_NewApplicabilityStatuses(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			applicabilityManager.resultsFileName = filepath.Join(jas.GetTestDataPath(), "applicability-scan", tc.fileName)
 			var err error
-			applicabilityManager.applicabilityScanResults, err = jas.ReadJasScanRunsFromFile(applicabilityManager.resultsFileName, scanner.JFrogAppsConfig.Modules[0].SourceRoot, applicabilityDocsUrlSuffix)
+			applicabilityManager.applicabilityScanResults, err = jas.ReadJasScanRunsFromFile(applicabilityManager.resultsFileName, scanner.JFrogAppsConfig.Modules[0].SourceRoot, applicabilityDocsUrlSuffix, scanner.MinSeverity)
 			if assert.NoError(t, err) && assert.NotNil(t, applicabilityManager.applicabilityScanResults) {
 				assert.Len(t, applicabilityManager.applicabilityScanResults, 1)
 				assert.Len(t, applicabilityManager.applicabilityScanResults[0].Results, tc.expectedResults)

--- a/jas/iac/iacscanner.go
+++ b/jas/iac/iacscanner.go
@@ -67,7 +67,7 @@ func (iac *IacScanManager) Run(module jfrogappsconfig.Module) (err error) {
 	if err = iac.runAnalyzerManager(); err != nil {
 		return
 	}
-	workingDirResults, err := jas.ReadJasScanRunsFromFile(iac.resultsFileName, module.SourceRoot, iacDocsUrlSuffix)
+	workingDirResults, err := jas.ReadJasScanRunsFromFile(iac.resultsFileName, module.SourceRoot, iacDocsUrlSuffix, iac.scanner.MinSeverity)
 	if err != nil {
 		return
 	}

--- a/jas/iac/iacscanner_test.go
+++ b/jas/iac/iacscanner_test.go
@@ -65,7 +65,7 @@ func TestIacParseResults_EmptyResults(t *testing.T) {
 
 	// Act
 	var err error
-	iacScanManager.iacScannerResults, err = jas.ReadJasScanRunsFromFile(iacScanManager.resultsFileName, scanner.JFrogAppsConfig.Modules[0].SourceRoot, iacDocsUrlSuffix)
+	iacScanManager.iacScannerResults, err = jas.ReadJasScanRunsFromFile(iacScanManager.resultsFileName, scanner.JFrogAppsConfig.Modules[0].SourceRoot, iacDocsUrlSuffix, scanner.MinSeverity)
 	if assert.NoError(t, err) && assert.NotNil(t, iacScanManager.iacScannerResults) {
 		assert.Len(t, iacScanManager.iacScannerResults, 1)
 		assert.Empty(t, iacScanManager.iacScannerResults[0].Results)
@@ -81,7 +81,7 @@ func TestIacParseResults_ResultsContainIacViolations(t *testing.T) {
 
 	// Act
 	var err error
-	iacScanManager.iacScannerResults, err = jas.ReadJasScanRunsFromFile(iacScanManager.resultsFileName, scanner.JFrogAppsConfig.Modules[0].SourceRoot, iacDocsUrlSuffix)
+	iacScanManager.iacScannerResults, err = jas.ReadJasScanRunsFromFile(iacScanManager.resultsFileName, scanner.JFrogAppsConfig.Modules[0].SourceRoot, iacDocsUrlSuffix, scanner.MinSeverity)
 	if assert.NoError(t, err) && assert.NotNil(t, iacScanManager.iacScannerResults) {
 		assert.Len(t, iacScanManager.iacScannerResults, 1)
 		assert.Len(t, iacScanManager.iacScannerResults[0].Results, 4)

--- a/jas/runner/jasrunner_test.go
+++ b/jas/runner/jasrunner_test.go
@@ -26,7 +26,7 @@ func TestJasRunner_AnalyzerManagerNotExist(t *testing.T) {
 	defer func() {
 		assert.NoError(t, os.Unsetenv(coreutils.HomeDir))
 	}()
-	scanner, err := jas.CreateJasScanner(nil, &jas.FakeServerDetails, jas.GetAnalyzerManagerXscEnvVars("", false))
+	scanner, err := jas.CreateJasScanner(nil, &jas.FakeServerDetails, "", jas.GetAnalyzerManagerXscEnvVars("", false))
 	assert.NoError(t, err)
 	if scanner.AnalyzerManager.AnalyzerManagerFullPath, err = jas.GetAnalyzerManagerExecutable(); err != nil {
 		return
@@ -42,7 +42,7 @@ func TestJasRunner(t *testing.T) {
 
 	jfrogAppsConfigForTest, err := jas.CreateJFrogAppsConfig(nil)
 	assert.NoError(t, err)
-	jasScanner, err := jas.CreateJasScanner(jfrogAppsConfigForTest, &jas.FakeServerDetails, jas.GetAnalyzerManagerXscEnvVars("", false, scanResults.GetScaScannedTechnologies()...))
+	jasScanner, err := jas.CreateJasScanner(jfrogAppsConfigForTest, &jas.FakeServerDetails, "", jas.GetAnalyzerManagerXscEnvVars("", false, scanResults.GetScaScannedTechnologies()...))
 	assert.NoError(t, err)
 	err = AddJasScannersTasks(securityParallelRunnerForTest, scanResults, &[]string{"issueId_1_direct_dependency", "issueId_2_direct_dependency"}, false, jasScanner, applicability.ApplicabilityScannerType, secrets.SecretsScannerType, securityParallelRunnerForTest.AddErrorToChan, utils.GetAllSupportedScans(), nil, "")
 	assert.NoError(t, err)
@@ -52,7 +52,7 @@ func TestJasRunner_AnalyzerManagerReturnsError(t *testing.T) {
 	assert.NoError(t, jas.DownloadAnalyzerManagerIfNeeded(0))
 
 	jfrogAppsConfigForTest, _ := jas.CreateJFrogAppsConfig(nil)
-	scanner, _ := jas.CreateJasScanner(nil, &jas.FakeServerDetails, jas.GetAnalyzerManagerXscEnvVars("", false))
+	scanner, _ := jas.CreateJasScanner(nil, &jas.FakeServerDetails, "", jas.GetAnalyzerManagerXscEnvVars("", false))
 	_, err := applicability.RunApplicabilityScan(jas.FakeBasicXrayResults, []string{"issueId_2_direct_dependency", "issueId_1_direct_dependency"},
 		scanner, false, applicability.ApplicabilityScannerType, jfrogAppsConfigForTest.Modules[0], 0)
 	// Expect error:

--- a/jas/sast/sastscanner.go
+++ b/jas/sast/sastscanner.go
@@ -60,7 +60,7 @@ func (ssm *SastScanManager) Run(module jfrogappsconfig.Module) (err error) {
 	if err = ssm.runAnalyzerManager(filepath.Dir(ssm.scanner.AnalyzerManager.AnalyzerManagerFullPath)); err != nil {
 		return
 	}
-	workingDirRuns, err := jas.ReadJasScanRunsFromFile(ssm.resultsFileName, module.SourceRoot, sastDocsUrlSuffix)
+	workingDirRuns, err := jas.ReadJasScanRunsFromFile(ssm.resultsFileName, module.SourceRoot, sastDocsUrlSuffix, ssm.scanner.MinSeverity)
 	if err != nil {
 		return
 	}

--- a/jas/sast/sastscanner_test.go
+++ b/jas/sast/sastscanner_test.go
@@ -36,7 +36,7 @@ func TestSastParseResults_EmptyResults(t *testing.T) {
 
 	// Act
 	var err error
-	sastScanManager.sastScannerResults, err = jas.ReadJasScanRunsFromFile(sastScanManager.resultsFileName, scanner.JFrogAppsConfig.Modules[0].SourceRoot, sastDocsUrlSuffix)
+	sastScanManager.sastScannerResults, err = jas.ReadJasScanRunsFromFile(sastScanManager.resultsFileName, scanner.JFrogAppsConfig.Modules[0].SourceRoot, sastDocsUrlSuffix, scanner.MinSeverity)
 
 	// Assert
 	if assert.NoError(t, err) && assert.NotNil(t, sastScanManager.sastScannerResults) {
@@ -57,7 +57,7 @@ func TestSastParseResults_ResultsContainIacViolations(t *testing.T) {
 
 	// Act
 	var err error
-	sastScanManager.sastScannerResults, err = jas.ReadJasScanRunsFromFile(sastScanManager.resultsFileName, scanner.JFrogAppsConfig.Modules[0].SourceRoot, sastDocsUrlSuffix)
+	sastScanManager.sastScannerResults, err = jas.ReadJasScanRunsFromFile(sastScanManager.resultsFileName, scanner.JFrogAppsConfig.Modules[0].SourceRoot, sastDocsUrlSuffix, scanner.MinSeverity)
 
 	// Assert
 	if assert.NoError(t, err) && assert.NotNil(t, sastScanManager.sastScannerResults) {

--- a/jas/secrets/secretsscanner.go
+++ b/jas/secrets/secretsscanner.go
@@ -74,7 +74,7 @@ func (ssm *SecretScanManager) Run(module jfrogappsconfig.Module) (err error) {
 	if err = ssm.runAnalyzerManager(); err != nil {
 		return
 	}
-	workingDirRuns, err := jas.ReadJasScanRunsFromFile(ssm.resultsFileName, module.SourceRoot, secretsDocsUrlSuffix)
+	workingDirRuns, err := jas.ReadJasScanRunsFromFile(ssm.resultsFileName, module.SourceRoot, secretsDocsUrlSuffix, ssm.scanner.MinSeverity)
 	if err != nil {
 		return
 	}

--- a/jas/secrets/secretsscanner_test.go
+++ b/jas/secrets/secretsscanner_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/jfrog/jfrog-cli-security/utils/jasutils"
+	"github.com/jfrog/jfrog-cli-security/utils/severityutils"
 	"github.com/stretchr/testify/require"
 
 	jfrogappsconfig "github.com/jfrog/jfrog-apps-config/go"
@@ -72,7 +73,7 @@ func TestParseResults_EmptyResults(t *testing.T) {
 
 	// Act
 	var err error
-	secretScanManager.secretsScannerResults, err = jas.ReadJasScanRunsFromFile(secretScanManager.resultsFileName, scanner.JFrogAppsConfig.Modules[0].SourceRoot, secretsDocsUrlSuffix)
+	secretScanManager.secretsScannerResults, err = jas.ReadJasScanRunsFromFile(secretScanManager.resultsFileName, scanner.JFrogAppsConfig.Modules[0].SourceRoot, secretsDocsUrlSuffix, scanner.MinSeverity)
 
 	// Assert
 	if assert.NoError(t, err) && assert.NotNil(t, secretScanManager.secretsScannerResults) {
@@ -95,7 +96,7 @@ func TestParseResults_ResultsContainSecrets(t *testing.T) {
 
 	// Act
 	var err error
-	secretScanManager.secretsScannerResults, err = jas.ReadJasScanRunsFromFile(secretScanManager.resultsFileName, scanner.JFrogAppsConfig.Modules[0].SourceRoot, secretsDocsUrlSuffix)
+	secretScanManager.secretsScannerResults, err = jas.ReadJasScanRunsFromFile(secretScanManager.resultsFileName, scanner.JFrogAppsConfig.Modules[0].SourceRoot, secretsDocsUrlSuffix, severityutils.Medium)
 
 	// Assert
 	if assert.NoError(t, err) && assert.NotNil(t, secretScanManager.secretsScannerResults) {
@@ -103,7 +104,7 @@ func TestParseResults_ResultsContainSecrets(t *testing.T) {
 		assert.NotEmpty(t, secretScanManager.secretsScannerResults[0].Results)
 		secretScanManager.secretsScannerResults = processSecretScanRuns(secretScanManager.secretsScannerResults)
 		assert.Len(t, secretScanManager.secretsScannerResults, 1)
-		assert.Len(t, secretScanManager.secretsScannerResults[0].Results, 7)
+		assert.Len(t, secretScanManager.secretsScannerResults[0].Results, 6)
 	}
 	assert.NoError(t, err)
 

--- a/tests/testdata/other/secrets-scan/contain-secrets.sarif
+++ b/tests/testdata/other/secrets-scan/contain-secrets.sarif
@@ -177,6 +177,7 @@
           "message": {
             "text": "Hardcoded secrets were found in source files"
           },
+          "level": "note",
           "locations": [
             {
               "physicalLocation": {


### PR DESCRIPTION
- [x] The pull request is targeting the `dev` branch.
- [x] The code has been validated to compile successfully by running `go vet ./...`.
- [x] The code has been formatted properly using `go fmt ./...`.
- [x] All [static analysis checks](https://github.com/jfrog/jfrog-cli-security/actions/workflows/analysis.yml) passed.
- [x] All [tests](https://github.com/jfrog/jfrog-cli-security/actions/workflows/test.yml) have passed. If this feature is not already covered by the tests, new tests have been added.
- [x] All changes are detailed at the description. if not already covered at [JFrog Documentation](https://github.com/jfrog/documentation), new documentation have been added.

-----

The minimum severity filter (supplied using the `--min-severity` flag) was not applied to the JAS results.
This PR fixes this issue