### PR TITLE
Add sast flag if sarif - AM 1.9.8

### DIFF
--- a/audit_test.go
+++ b/audit_test.go
@@ -621,6 +621,8 @@ func TestXrayAuditJasSarif(t *testing.T) {
 		Undetermined:    1,
 		NotCovered:      1,
 		NotApplicable:   2,
+
+		SastDescSuffix: "JFrog SAST",
 	})
 }
 

--- a/commands/audit/audit.go
+++ b/commands/audit/audit.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	jfrogappsconfig "github.com/jfrog/jfrog-apps-config/go"
+	"github.com/jfrog/jfrog-cli-core/v2/common/format"
 	"github.com/jfrog/jfrog-cli-core/v2/utils/config"
 	"github.com/jfrog/jfrog-cli-core/v2/utils/coreutils"
 	"github.com/jfrog/jfrog-cli-security/commands/audit/sca"
@@ -303,6 +304,7 @@ func downloadAnalyzerManagerAndRunScanners(auditParallelRunner *utils.SecurityPa
 			DirectDependencies:          auditParams.DirectDependencies(),
 			ThirdPartyApplicabilityScan: auditParams.thirdPartyApplicabilityScan,
 			ApplicableScanType:          applicability.ApplicabilityScannerType,
+			SignedDescriptions:          auditParams.OutputFormat() == format.Sarif,
 			ScanResults:                 scan,
 			TargetOutputDir:             auditParams.scanResultsOutputDir,
 		}

--- a/jas/analyzermanager.go
+++ b/jas/analyzermanager.go
@@ -24,7 +24,7 @@ import (
 const (
 	ApplicabilityFeatureId                    = "contextual_analysis"
 	AnalyzerManagerZipName                    = "analyzerManager.zip"
-	defaultAnalyzerManagerVersion             = "1.9.7"
+	defaultAnalyzerManagerVersion             = "1.9.8"
 	analyzerManagerDownloadPath               = "xsc-gen-exe-analyzer-manager-local/v1"
 	analyzerManagerDirName                    = "analyzerManager"
 	analyzerManagerExecutableName             = "analyzerManager"

--- a/jas/analyzermanager.go
+++ b/jas/analyzermanager.go
@@ -24,7 +24,7 @@ import (
 const (
 	ApplicabilityFeatureId                    = "contextual_analysis"
 	AnalyzerManagerZipName                    = "analyzerManager.zip"
-	defaultAnalyzerManagerVersion             = "1.9.8"
+	defaultAnalyzerManagerVersion             = "1.9.9"
 	analyzerManagerDownloadPath               = "xsc-gen-exe-analyzer-manager-local/v1"
 	analyzerManagerDirName                    = "analyzerManager"
 	analyzerManagerExecutableName             = "analyzerManager"

--- a/jas/sast/sastscanner.go
+++ b/jas/sast/sastscanner.go
@@ -23,16 +23,17 @@ const (
 type SastScanManager struct {
 	sastScannerResults []*sarif.Run
 	scanner            *jas.JasScanner
+	signedDescriptions bool
 	configFileName     string
 	resultsFileName    string
 }
 
-func RunSastScan(scanner *jas.JasScanner, module jfrogappsconfig.Module, threadId int) (results []*sarif.Run, err error) {
+func RunSastScan(scanner *jas.JasScanner, module jfrogappsconfig.Module, signedDescriptions bool, threadId int) (results []*sarif.Run, err error) {
 	var scannerTempDir string
 	if scannerTempDir, err = jas.CreateScannerTempDirectory(scanner, jasutils.Sast.String()); err != nil {
 		return
 	}
-	sastScanManager := newSastScanManager(scanner, scannerTempDir)
+	sastScanManager := newSastScanManager(scanner, scannerTempDir, signedDescriptions)
 	log.Info(clientutils.GetLogMsgPrefix(threadId, false) + "Running SAST scan...")
 	if err = sastScanManager.scanner.Run(sastScanManager, module); err != nil {
 		err = jas.ParseAnalyzerManagerError(jasutils.Sast, err)
@@ -45,16 +46,17 @@ func RunSastScan(scanner *jas.JasScanner, module jfrogappsconfig.Module, threadI
 	return
 }
 
-func newSastScanManager(scanner *jas.JasScanner, scannerTempDir string) (manager *SastScanManager) {
+func newSastScanManager(scanner *jas.JasScanner, scannerTempDir string, signedDescriptions bool) (manager *SastScanManager) {
 	return &SastScanManager{
 		sastScannerResults: []*sarif.Run{},
 		scanner:            scanner,
+		signedDescriptions: signedDescriptions,
 		configFileName:     filepath.Join(scannerTempDir, "config.yaml"),
 		resultsFileName:    filepath.Join(scannerTempDir, "results.sarif")}
 }
 
 func (ssm *SastScanManager) Run(module jfrogappsconfig.Module) (err error) {
-	if err = ssm.createConfigFile(module, ssm.scanner.Exclusions...); err != nil {
+	if err = ssm.createConfigFile(module, ssm.signedDescriptions, ssm.scanner.Exclusions...); err != nil {
 		return
 	}
 	if err = ssm.runAnalyzerManager(filepath.Dir(ssm.scanner.AnalyzerManager.AnalyzerManagerFullPath)); err != nil {
@@ -74,14 +76,15 @@ type sastScanConfig struct {
 }
 
 type scanConfiguration struct {
-	Roots           []string `yaml:"roots,omitempty"`
-	Type            string   `yaml:"type,omitempty"`
-	Language        string   `yaml:"language,omitempty"`
-	ExcludePatterns []string `yaml:"exclude_patterns,omitempty"`
-	ExcludedRules   []string `yaml:"excluded-rules,omitempty"`
+	Roots              []string `yaml:"roots,omitempty"`
+	Type               string   `yaml:"type,omitempty"`
+	Language           string   `yaml:"language,omitempty"`
+	ExcludePatterns    []string `yaml:"exclude_patterns,omitempty"`
+	ExcludedRules      []string `yaml:"excluded-rules,omitempty"`
+	SignedDescriptions bool     `yaml:"signed_descriptions,omitempty"`
 }
 
-func (ssm *SastScanManager) createConfigFile(module jfrogappsconfig.Module, exclusions ...string) error {
+func (ssm *SastScanManager) createConfigFile(module jfrogappsconfig.Module, signedDescriptions bool, exclusions ...string) error {
 	sastScanner := module.Scanners.Sast
 	if sastScanner == nil {
 		sastScanner = &jfrogappsconfig.SastScanner{}
@@ -93,11 +96,12 @@ func (ssm *SastScanManager) createConfigFile(module jfrogappsconfig.Module, excl
 	configFileContent := sastScanConfig{
 		Scans: []scanConfiguration{
 			{
-				Type:            sastScannerType,
-				Roots:           roots,
-				Language:        sastScanner.Language,
-				ExcludedRules:   sastScanner.ExcludedRules,
-				ExcludePatterns: jas.GetExcludePatterns(module, &sastScanner.Scanner, exclusions...),
+				Type:               sastScannerType,
+				Roots:              roots,
+				Language:           sastScanner.Language,
+				ExcludedRules:      sastScanner.ExcludedRules,
+				SignedDescriptions: signedDescriptions,
+				ExcludePatterns:    jas.GetExcludePatterns(module, &sastScanner.Scanner, exclusions...),
 			},
 		},
 	}

--- a/jas/sast/sastscanner.go
+++ b/jas/sast/sastscanner.go
@@ -76,12 +76,16 @@ type sastScanConfig struct {
 }
 
 type scanConfiguration struct {
-	Roots              []string `yaml:"roots,omitempty"`
-	Type               string   `yaml:"type,omitempty"`
-	Language           string   `yaml:"language,omitempty"`
-	ExcludePatterns    []string `yaml:"exclude_patterns,omitempty"`
-	ExcludedRules      []string `yaml:"excluded-rules,omitempty"`
-	SignedDescriptions bool     `yaml:"signed_descriptions,omitempty"`
+	Roots           []string       `yaml:"roots,omitempty"`
+	Type            string         `yaml:"type,omitempty"`
+	Language        string         `yaml:"language,omitempty"`
+	ExcludePatterns []string       `yaml:"exclude_patterns,omitempty"`
+	ExcludedRules   []string       `yaml:"excluded-rules,omitempty"`
+	SastParameters  sastParameters `yaml:"sast_parameters,omitempty"`
+}
+
+type sastParameters struct {
+	SignedDescriptions bool `yaml:"signed_descriptions,omitempty"`
 }
 
 func (ssm *SastScanManager) createConfigFile(module jfrogappsconfig.Module, signedDescriptions bool, exclusions ...string) error {
@@ -96,12 +100,12 @@ func (ssm *SastScanManager) createConfigFile(module jfrogappsconfig.Module, sign
 	configFileContent := sastScanConfig{
 		Scans: []scanConfiguration{
 			{
-				Type:               sastScannerType,
-				Roots:              roots,
-				Language:           sastScanner.Language,
-				ExcludedRules:      sastScanner.ExcludedRules,
-				SignedDescriptions: signedDescriptions,
-				ExcludePatterns:    jas.GetExcludePatterns(module, &sastScanner.Scanner, exclusions...),
+				Type:            sastScannerType,
+				Roots:           roots,
+				Language:        sastScanner.Language,
+				ExcludedRules:   sastScanner.ExcludedRules,
+				SastParameters:  sastParameters{SignedDescriptions: signedDescriptions},
+				ExcludePatterns: jas.GetExcludePatterns(module, &sastScanner.Scanner, exclusions...),
 			},
 		},
 	}

--- a/jas/sast/sastscanner_test.go
+++ b/jas/sast/sastscanner_test.go
@@ -17,11 +17,12 @@ func TestNewSastScanManager(t *testing.T) {
 	jfrogAppsConfigForTest, err := jas.CreateJFrogAppsConfig([]string{"currentDir"})
 	assert.NoError(t, err)
 	// Act
-	sastScanManager := newSastScanManager(scanner, "temoDirPath")
+	sastScanManager := newSastScanManager(scanner, "temoDirPath", true)
 
 	// Assert
 	if assert.NotNil(t, sastScanManager) {
 		assert.NotEmpty(t, sastScanManager.configFileName)
+		assert.True(t, sastScanManager.signedDescriptions)
 		assert.NotEmpty(t, sastScanManager.resultsFileName)
 		assert.NotEmpty(t, jfrogAppsConfigForTest.Modules[0].SourceRoot)
 		assert.Equal(t, &jas.FakeServerDetails, sastScanManager.scanner.ServerDetails)
@@ -35,7 +36,7 @@ func TestSastParseResults_EmptyResults(t *testing.T) {
 	assert.NoError(t, err)
 
 	// Arrange
-	sastScanManager := newSastScanManager(scanner, "temoDirPath")
+	sastScanManager := newSastScanManager(scanner, "temoDirPath", true)
 	sastScanManager.resultsFileName = filepath.Join(jas.GetTestDataPath(), "sast-scan", "no-violations.sarif")
 
 	// Act
@@ -57,7 +58,7 @@ func TestSastParseResults_ResultsContainIacViolations(t *testing.T) {
 	jfrogAppsConfigForTest, err := jas.CreateJFrogAppsConfig([]string{})
 	assert.NoError(t, err)
 	// Arrange
-	sastScanManager := newSastScanManager(scanner, "temoDirPath")
+	sastScanManager := newSastScanManager(scanner, "temoDirPath", false)
 	sastScanManager.resultsFileName = filepath.Join(jas.GetTestDataPath(), "sast-scan", "contains-sast-violations.sarif")
 
 	// Act

--- a/tests/testdata/other/sast-scan/contains-sast-violations.sarif
+++ b/tests/testdata/other/sast-scan/contains-sast-violations.sarif
@@ -3,7 +3,7 @@
         {
             "tool": {
                 "driver": {
-                    "name": "USAF",
+                    "name": "🐸 JFrog SAST",
                     "rules": [
                         {
                             "id": "python-command-injection",

--- a/tests/testdata/other/sast-scan/no-violations.sarif
+++ b/tests/testdata/other/sast-scan/no-violations.sarif
@@ -3,7 +3,7 @@
         {
             "tool": {
                 "driver": {
-                    "name": "USAF",
+                    "name": "🐸 JFrog SAST",
                     "rules": []
                 }
             },

--- a/tests/testdata/output/audit/audit_results.json
+++ b/tests/testdata/output/audit/audit_results.json
@@ -2204,7 +2204,7 @@
             "tool": {
               "driver": {
                 "informationUri": "https://docs.jfrog-applications.jfrog.io/jfrog-security-features/sast",
-                "name": "USAF",
+                "name": "🐸 JFrog SAST",
                 "rules": [
                   {
                     "id": "js-express-without-helmet",

--- a/tests/testdata/output/audit/audit_sarif.json
+++ b/tests/testdata/output/audit/audit_sarif.json
@@ -231,7 +231,7 @@
       "tool": {
         "driver": {
           "informationUri": "https://docs.jfrog-applications.jfrog.io/jfrog-security-features/sast",
-          "name": "USAF",
+          "name": "🐸 JFrog SAST",
           "rules": [
             {
               "id": "js-express-without-helmet",

--- a/tests/testdata/projects/jas/jas-config/sast/result.sarif
+++ b/tests/testdata/projects/jas/jas-config/sast/result.sarif
@@ -3,7 +3,7 @@
         {
             "tool": {
                 "driver": {
-                    "name": "USAF",
+                    "name": "🐸 JFrog SAST",
                     "rules": [
                         {
                             "id": "python-flask-debug",

--- a/tests/testdata/projects/jas/jas/sast/result.sarif
+++ b/tests/testdata/projects/jas/jas/sast/result.sarif
@@ -3,7 +3,7 @@
         {
             "tool": {
                 "driver": {
-                    "name": "USAF",
+                    "name": "🐸 JFrog SAST",
                     "rules": [
                         {
                             "id": "python-flask-debug",

--- a/utils/validations/test_validate_sarif.go
+++ b/utils/validations/test_validate_sarif.go
@@ -15,7 +15,7 @@ import (
 )
 
 const (
-	//TODO: Validate if we need a frog emoji before the name
+	//SastToolName has a 🐸 in the beginning - but the stdout of the IDE doesn't show it - so removed 🐸 for tests
 	SastToolName = " JFrog SAST"
 	IacToolName  = "JFrog Terraform scanner"
 	// #nosec G101 -- Not credentials.
@@ -93,9 +93,11 @@ func ValidateSarifIssuesCount(t *testing.T, params ValidationParams, report *sar
 
 	for _, run := range sastRuns {
 		for _, rule := range run.Tool.Driver.Rules {
-			ValidateContent(t, false,
-				StringValidation{Expected: params.SastDescSuffix, Actual: *rule.ShortDescription.Text, Msg: "rule description does not contain expected substring"},
-			)
+			if params.SastDescSuffix != "" {
+				ValidateContent(t, false,
+					StringValidation{Expected: params.SastDescSuffix, Actual: *rule.ShortDescription.Text, Msg: "rule description does not contain expected substring"},
+				)
+			}
 		}
 	}
 	ValidateContent(t, params.ExactResultsMatch,

--- a/utils/validations/test_validate_sarif.go
+++ b/utils/validations/test_validate_sarif.go
@@ -15,7 +15,7 @@ import (
 )
 
 const (
-	//SastToolName has a 🐸 in the beginning - but the stdout of the IDE doesn't show it - so removed 🐸 for tests
+	// SastToolName has a 🐸 in the beginning - but the stdout of the IDE doesn't show it - so removed 🐸 for tests
 	SastToolName = " JFrog SAST"
 	IacToolName  = "JFrog Terraform scanner"
 	// #nosec G101 -- Not credentials.

--- a/utils/validations/test_validation.go
+++ b/utils/validations/test_validation.go
@@ -28,6 +28,8 @@ type ValidationParams struct {
 	Expected interface{}
 	// If provided, the test will check exact values and not only the minimum values / existence.
 	ExactResultsMatch bool
+	// The Sast scanner addition to the description.
+	SastDescSuffix string
 	// Expected issues for each type to check if the content has the correct amount of issues.
 	Vulnerabilities       int
 	Licenses              int


### PR DESCRIPTION
- [ ] The pull request is targeting the `dev` branch.
- [ ] The code has been validated to compile successfully by running `go vet ./...`.
- [ ] The code has been formatted properly using `go fmt ./...`.
- [ ] All [static analysis checks](https://github.com/jfrog/jfrog-cli-security/actions/workflows/analysis.yml) passed.
- [ ] All [tests](https://github.com/jfrog/jfrog-cli-security/actions/workflows/test.yml) have passed. If this feature is not already covered by the tests, new tests have been added.
- [ ] All changes are detailed at the description. if not already covered at [JFrog Documentation](https://github.com/jfrog/documentation), new documentation have been added.

-----

Based on [PR by @attiasas ](https://github.com/jfrog/jfrog-cli-security/pull/206) - added the AM to support the addition of "JFrog SAST" when using sarif format