### PR TITLE
Apply allow-partial-results to JAS scans

### DIFF
--- a/commands/audit/audit.go
+++ b/commands/audit/audit.go
@@ -181,7 +181,7 @@ func RunAudit(auditParams *AuditParams) (cmdResults *results.SecurityCommandResu
 	}
 	jfrogAppsConfig, err := jas.CreateJFrogAppsConfig(cmdResults.GetTargetsPaths())
 	if err != nil {
-		return cmdResults.AddGeneralError(fmt.Errorf("failed to create JFrogAppsConfig: %s", err.Error()))
+		return cmdResults.AddGeneralError(fmt.Errorf("failed to create JFrogAppsConfig: %s", err.Error()), false)
 	}
 	// Initialize the parallel runner
 	auditParallelRunner := utils.CreateSecurityParallelRunner(auditParams.threads)
@@ -189,14 +189,14 @@ func RunAudit(auditParams *AuditParams) (cmdResults *results.SecurityCommandResu
 	var jasScanner *jas.JasScanner
 	var generalJasScanErr error
 	if jasScanner, generalJasScanErr = RunJasScans(auditParallelRunner, auditParams, cmdResults, jfrogAppsConfig); generalJasScanErr != nil {
-		cmdResults.AddGeneralError(fmt.Errorf("An error has occurred during JAS scan process. JAS scan is skipped for the following directories: %s\n%s", strings.Join(cmdResults.GetTargetsPaths(), ","), generalJasScanErr.Error()))
+		cmdResults.AddGeneralError(fmt.Errorf("An error has occurred during JAS scan process. JAS scan is skipped for the following directories: %s\n%s", strings.Join(cmdResults.GetTargetsPaths(), ","), generalJasScanErr.Error()), auditParams.AllowPartialResults())
 	}
 	if auditParams.Progress() != nil {
 		auditParams.Progress().SetHeadlineMsg("Scanning for issues")
 	}
 	// The sca scan doesn't require the analyzer manager, so it can run separately from the analyzer manager download routine.
 	if generalScaScanError := buildDepTreeAndRunScaScan(auditParallelRunner, auditParams, cmdResults); generalScaScanError != nil {
-		cmdResults.AddGeneralError(fmt.Errorf("An error has occurred during SCA scan process. SCA scan is skipped for the following directories: %s\n%s", strings.Join(cmdResults.GetTargetsPaths(), ","), generalScaScanError.Error()))
+		cmdResults.AddGeneralError(fmt.Errorf("An error has occurred during SCA scan process. SCA scan is skipped for the following directories: %s\n%s", strings.Join(cmdResults.GetTargetsPaths(), ","), generalScaScanError.Error()), auditParams.AllowPartialResults())
 	}
 	go func() {
 		auditParallelRunner.ScaScansWg.Wait()
@@ -204,7 +204,7 @@ func RunAudit(auditParams *AuditParams) (cmdResults *results.SecurityCommandResu
 		// Wait for all jas scanners to complete before cleaning up scanners temp dir
 		auditParallelRunner.JasScannersWg.Wait()
 		if jasScanner != nil && jasScanner.ScannerDirCleanupFunc != nil {
-			cmdResults.AddGeneralError(jasScanner.ScannerDirCleanupFunc())
+			cmdResults.AddGeneralError(jasScanner.ScannerDirCleanupFunc(), false)
 		}
 		auditParallelRunner.Runner.Done()
 	}()
@@ -242,7 +242,8 @@ func RunJasScans(auditParallelRunner *utils.SecurityParallelRunner, auditParams 
 	}
 	auditParallelRunner.JasWg.Add(1)
 	if _, jasErr := auditParallelRunner.Runner.AddTaskWithError(createJasScansTasks(auditParallelRunner, scanResults, serverDetails, auditParams, jasScanner, jfrogAppsConfig), func(taskErr error) {
-		generalError = errors.Join(generalError, fmt.Errorf("failed while adding JAS scan tasks: %s", taskErr.Error()))
+		// TODO this change was for capturing a missed error that is coming from the threads
+		scanResults.AddGeneralError(fmt.Errorf("failed while adding JAS scan tasks: %s", taskErr.Error()), auditParams.AllowPartialResults())
 	}); jasErr != nil {
 		generalError = fmt.Errorf("failed to create JAS task: %s", jasErr.Error())
 	}
@@ -281,9 +282,13 @@ func createJasScansTasks(auditParallelRunner *utils.SecurityParallelRunner, scan
 				SignedDescriptions:          auditParams.OutputFormat() == format.Sarif,
 				ScanResults:                 targetResult,
 				TargetOutputDir:             auditParams.scanResultsOutputDir,
+				AllowPartialResults:         auditParams.AllowPartialResults(),
 			}
-			if generalError := runner.AddJasScannersTasks(params); generalError != nil {
+			if generalError = runner.AddJasScannersTasks(params); generalError != nil {
+				// TODO this fix was in order to avoid capturing the error twice when using partial-results. if this is disables the error is collected twice - once from the target error and once from general error
 				_ = targetResult.AddTargetError(fmt.Errorf("%s failed to add JAS scan tasks: %s", logPrefix, generalError.Error()), auditParams.AllowPartialResults())
+				// We assign nil to 'generalError' after handling it to prevent it to propagate further, so it will not be captured twice - once here, and once in the error handling function of createJasScansTasks
+				generalError = nil
 			}
 		}
 		return
@@ -295,20 +300,20 @@ func initAuditCmdResults(params *AuditParams) (cmdResults *results.SecurityComma
 	// Initialize general information
 	serverDetails, err := params.ServerDetails()
 	if err != nil {
-		return cmdResults.AddGeneralError(err)
+		return cmdResults.AddGeneralError(err, false)
 	}
 	var xrayManager *xray.XrayServicesManager
 	if xrayManager, params.xrayVersion, err = xrayutils.CreateXrayServiceManagerAndGetVersion(serverDetails); err != nil {
-		return cmdResults.AddGeneralError(err)
+		return cmdResults.AddGeneralError(err, false)
 	} else {
 		cmdResults.SetXrayVersion(params.xrayVersion)
 	}
 	if err = clientutils.ValidateMinimumVersion(clientutils.Xray, params.xrayVersion, scangraph.GraphScanMinXrayVersion); err != nil {
-		return cmdResults.AddGeneralError(err)
+		return cmdResults.AddGeneralError(err, false)
 	}
 	entitledForJas, err := isEntitledForJas(xrayManager, params)
 	if err != nil {
-		return cmdResults.AddGeneralError(err)
+		return cmdResults.AddGeneralError(err, false)
 	} else {
 		cmdResults.SetEntitledForJas(entitledForJas)
 	}

--- a/commands/audit/audit.go
+++ b/commands/audit/audit.go
@@ -242,7 +242,6 @@ func RunJasScans(auditParallelRunner *utils.SecurityParallelRunner, auditParams 
 	}
 	auditParallelRunner.JasWg.Add(1)
 	if _, jasErr := auditParallelRunner.Runner.AddTaskWithError(createJasScansTasks(auditParallelRunner, scanResults, serverDetails, auditParams, jasScanner, jfrogAppsConfig), func(taskErr error) {
-		// TODO this change was for capturing a missed error that is coming from the threads
 		scanResults.AddGeneralError(fmt.Errorf("failed while adding JAS scan tasks: %s", taskErr.Error()), auditParams.AllowPartialResults())
 	}); jasErr != nil {
 		generalError = fmt.Errorf("failed to create JAS task: %s", jasErr.Error())
@@ -285,7 +284,6 @@ func createJasScansTasks(auditParallelRunner *utils.SecurityParallelRunner, scan
 				AllowPartialResults:         auditParams.AllowPartialResults(),
 			}
 			if generalError = runner.AddJasScannersTasks(params); generalError != nil {
-				// TODO this fix was in order to avoid capturing the error twice when using partial-results. if this is disables the error is collected twice - once from the target error and once from general error
 				_ = targetResult.AddTargetError(fmt.Errorf("%s failed to add JAS scan tasks: %s", logPrefix, generalError.Error()), auditParams.AllowPartialResults())
 				// We assign nil to 'generalError' after handling it to prevent it to propagate further, so it will not be captured twice - once here, and once in the error handling function of createJasScansTasks
 				generalError = nil

--- a/jas/runner/jasrunner.go
+++ b/jas/runner/jasrunner.go
@@ -27,8 +27,9 @@ type JasRunnerParams struct {
 	ServerDetails *config.ServerDetails
 	Scanner       *jas.JasScanner
 
-	Module        jfrogappsconfig.Module
-	ConfigProfile *services.ConfigProfile
+	Module              jfrogappsconfig.Module
+	ConfigProfile       *services.ConfigProfile
+	AllowPartialResults bool
 
 	ScansToPreform []utils.SubScanType
 
@@ -81,6 +82,7 @@ func addJasScanTaskForModuleIfNeeded(params JasRunnerParams, subScan utils.SubSc
 	}
 	if len(params.ScansToPreform) > 0 && !slices.Contains(params.ScansToPreform, subScan) {
 		log.Debug(fmt.Sprintf("Skipping %s scan as requested by input...", subScan))
+		// TODO fix bug where scan is not needed but we forgot to return
 		return
 	}
 	if params.ConfigProfile != nil {
@@ -101,7 +103,7 @@ func addJasScanTaskForModuleIfNeeded(params JasRunnerParams, subScan utils.SubSc
 			return
 		}
 		if enabled {
-			generalError = addModuleJasScanTask(jasType, params.Runner, task, params.ScanResults)
+			generalError = addModuleJasScanTask(jasType, params.Runner, task, params.ScanResults, params.AllowPartialResults)
 		} else {
 			log.Debug(fmt.Sprintf("Skipping %s scan as requested by '%s' config profile...", jasType, params.ConfigProfile.ProfileName))
 		}
@@ -111,15 +113,15 @@ func addJasScanTaskForModuleIfNeeded(params JasRunnerParams, subScan utils.SubSc
 		log.Debug(fmt.Sprintf("Skipping %s scan as requested by local module config...", subScan))
 		return
 	}
-	return addModuleJasScanTask(jasType, params.Runner, task, params.ScanResults)
+	return addModuleJasScanTask(jasType, params.Runner, task, params.ScanResults, params.AllowPartialResults)
 }
 
-func addModuleJasScanTask(scanType jasutils.JasScanType, securityParallelRunner *utils.SecurityParallelRunner, task parallel.TaskFunc, scanResults *results.TargetResults) (generalError error) {
+func addModuleJasScanTask(scanType jasutils.JasScanType, securityParallelRunner *utils.SecurityParallelRunner, task parallel.TaskFunc, scanResults *results.TargetResults, allowSkippingErrors bool) (generalError error) {
 	securityParallelRunner.JasScannersWg.Add(1)
 	if _, addTaskErr := securityParallelRunner.Runner.AddTaskWithError(task, func(err error) {
-		_ = scanResults.AddTargetError(fmt.Errorf("failed to run %s scan: %s", scanType, err.Error()), false)
+		_ = scanResults.AddTargetError(fmt.Errorf("failed to run %s scan: %s", scanType, err.Error()), allowSkippingErrors)
 	}); addTaskErr != nil {
-		generalError = fmt.Errorf("failed to create %s scan task: %s", scanType, addTaskErr.Error())
+		generalError = scanResults.AddTargetError(fmt.Errorf("error occurred while adding '%s' scan to parallel runner: %s", scanType, generalError.Error()), allowSkippingErrors)
 	}
 	return
 }

--- a/jas/runner/jasrunner.go
+++ b/jas/runner/jasrunner.go
@@ -82,7 +82,6 @@ func addJasScanTaskForModuleIfNeeded(params JasRunnerParams, subScan utils.SubSc
 	}
 	if len(params.ScansToPreform) > 0 && !slices.Contains(params.ScansToPreform, subScan) {
 		log.Debug(fmt.Sprintf("Skipping %s scan as requested by input...", subScan))
-		// TODO fix bug where scan is not needed but we forgot to return
 		return
 	}
 	if params.ConfigProfile != nil {

--- a/utils/results/results.go
+++ b/utils/results/results.go
@@ -110,8 +110,13 @@ func (r *SecurityCommandResults) SetMultiScanId(multiScanId string) *SecurityCom
 }
 
 // --- Aggregated results for all targets ---
-
-func (r *SecurityCommandResults) AddGeneralError(err error) *SecurityCommandResults {
+// Adds a general error to the command results in different phases of its execution.
+// Notice that in some usages we pass constant 'false' to the 'allowSkippingError' parameter in some places, where we wish to force propagation of the error when it occurrs.
+func (r *SecurityCommandResults) AddGeneralError(err error, allowSkippingError bool) *SecurityCommandResults {
+	if allowSkippingError && err != nil {
+		log.Warn(fmt.Sprintf("Partial results are allowed, the error is skipped: %s", err.Error()))
+		return r
+	}
 	r.GeneralError = errors.Join(r.GeneralError, err)
 	return r
 }
@@ -292,8 +297,8 @@ func (sr *TargetResults) HasFindings() bool {
 	return false
 }
 
-func (sr *TargetResults) AddTargetError(err error, allowPartialResults bool) error {
-	if allowPartialResults {
+func (sr *TargetResults) AddTargetError(err error, allowSkippingError bool) error {
+	if allowSkippingError && err != nil {
 		log.Warn(fmt.Sprintf("Partial results are allowed, the error is skipped in target '%s': %s", sr.String(), err.Error()))
 		return nil
 	}

--- a/utils/results/results.go
+++ b/utils/results/results.go
@@ -111,7 +111,7 @@ func (r *SecurityCommandResults) SetMultiScanId(multiScanId string) *SecurityCom
 
 // --- Aggregated results for all targets ---
 // Adds a general error to the command results in different phases of its execution.
-// Notice that in some usages we pass constant 'false' to the 'allowSkippingError' parameter in some places, where we wish to force propagation of the error when it occurrs.
+// Notice that in some usages we pass constant 'false' to the 'allowSkippingError' parameter in some places, where we wish to force propagation of the error when it occurs.
 func (r *SecurityCommandResults) AddGeneralError(err error, allowSkippingError bool) *SecurityCommandResults {
 	if allowSkippingError && err != nil {
 		log.Warn(fmt.Sprintf("Partial results are allowed, the error is skipped: %s", err.Error()))


### PR DESCRIPTION

- [x] The pull request is targeting the `dev` branch.
- [x] The code has been validated to compile successfully by running `go vet ./...`.
- [x] The code has been formatted properly using `go fmt ./...`.
- [x] All [static analysis checks](https://github.com/jfrog/jfrog-cli-security/actions/workflows/analysis.yml) passed.
- [x] All [tests](https://github.com/jfrog/jfrog-cli-security/actions/workflows/test.yml) have passed. If this feature is not already covered by the tests, new tests have been added.
- [x] Updated the [Contributing page](https://github.com/jfrog/jfrog-cli-security/blob/main/CONTRIBUTING.md) / [ReadMe page](https://github.com/jfrog/jfrog-cli-security/blob/main/README.md) / [CI Workflow files](https://github.com/jfrog/jfrog-cli-security/tree/main/.github/workflows) if needed.
- [x] All changes are detailed at the description. if not already covered at [JFrog Documentation](https://github.com/jfrog/documentation), new documentation have been added.

-----

This PR introduces improvement for the Allow-Partial-Results ability that was previously applied only on SCA scan and now is applied of JAS scans throughout its process.
This enables the code to capture failures and continue running even if some of the JAS scans have failed. Errors that we cannot continue after them remained as is and will fail the flow.
This is a continuance for this PR: https://github.com/jfrog/jfrog-cli-security/pull/200