### PR TITLE
Add NoTech Technology for directories with no tech

### DIFF
--- a/audit_test.go
+++ b/audit_test.go
@@ -461,7 +461,6 @@ func testXrayAuditPip(t *testing.T, format, requirementsFile string) string {
 	args := []string{"audit", "--pip", "--licenses", "--format=" + format}
 	if requirementsFile != "" {
 		args = append(args, "--requirements-file="+requirementsFile)
-
 	}
 	return securityTests.PlatformCli.RunCliCmdWithOutput(t, args...)
 }

--- a/commands/audit/audit.go
+++ b/commands/audit/audit.go
@@ -352,13 +352,17 @@ func detectScanTargets(cmdResults *results.SecurityCommandResults, params *Audit
 				// We don't need to scan for both and get duplicate results.
 				continue
 			}
+			// No technology was detected, add scan without descriptors. (so no sca scan will be preformed and set at target level)
 			if len(workingDirs) == 0 {
 				// Requested technology (from params) descriptors/indicators were not found or recursive scan with NoTech value, add scan without descriptors.
 				cmdResults.NewScanResults(results.ScanTarget{Target: requestedDirectory, Technology: tech})
 			}
 			for workingDir, descriptors := range workingDirs {
 				// Add scan for each detected working directory.
-				cmdResults.NewScanResults(results.ScanTarget{Target: workingDir, Technology: tech}).SetDescriptors(descriptors...)
+				targetResults := cmdResults.NewScanResults(results.ScanTarget{Target: workingDir, Technology: tech})
+				if tech != techutils.NoTech {
+					targetResults.SetDescriptors(descriptors...)
+				}
 			}
 		}
 	}

--- a/commands/audit/audit.go
+++ b/commands/audit/audit.go
@@ -353,7 +353,7 @@ func detectScanTargets(cmdResults *results.SecurityCommandResults, params *Audit
 				continue
 			}
 			if len(workingDirs) == 0 {
-				// Requested technology (from params) descriptors/indicators were not found, scan only requested directory for this technology.
+				// Requested technology (from params) descriptors/indicators were not found or recursive scan with NoTech value, add scan without descriptors.
 				cmdResults.NewScanResults(results.ScanTarget{Target: requestedDirectory, Technology: tech})
 			}
 			for workingDir, descriptors := range workingDirs {

--- a/commands/audit/audit_test.go
+++ b/commands/audit/audit_test.go
@@ -196,9 +196,15 @@ func TestDetectScansToPreform(t *testing.T) {
 				sort.Slice(results.Targets, func(i, j int) bool {
 					return results.Targets[i].ScanTarget.Target < results.Targets[j].ScanTarget.Target
 				})
+				sort.Slice(test.expected, func(i, j int) bool {
+					return test.expected[i].ScanTarget.Target < test.expected[j].ScanTarget.Target
+				})
 				for i := range results.Targets {
 					if results.Targets[i].ScaResults != nil {
 						sort.Strings(results.Targets[i].ScaResults.Descriptors)
+					}
+					if test.expected[i].ScaResults != nil {
+						sort.Strings(test.expected[i].ScaResults.Descriptors)
 					}
 				}
 			}

--- a/commands/audit/scarunner.go
+++ b/commands/audit/scarunner.go
@@ -45,7 +45,7 @@ func hasAtLeastOneTech(cmdResults *results.SecurityCommandResults) bool {
 		return false
 	}
 	for _, scan := range cmdResults.Targets {
-		if scan.Technology != "" {
+		if scan.Technology != techutils.NoTech {
 			return true
 		}
 	}

--- a/utils/results/results.go
+++ b/utils/results/results.go
@@ -75,9 +75,11 @@ func (st ScanTarget) String() (str string) {
 	if st.Name != "" {
 		str = st.Name
 	}
-	if st.Technology != "" {
-		str += fmt.Sprintf(" [%s]", st.Technology)
+	tech := st.Technology.String()
+	if tech == techutils.NoTech.String() {
+		tech = "unknown"
 	}
+	str += fmt.Sprintf(" [%s]", tech)
 	return
 }
 

--- a/utils/techutils/techutils.go
+++ b/utils/techutils/techutils.go
@@ -394,7 +394,7 @@ func getDirectDirectories(path, excludePathPattern string) (directories []string
 	for _, potentialDir := range filesOrDirsInPath {
 		isDir, err := fileutils.IsDirExists(potentialDir, true)
 		if err != nil {
-			errors.Join(err, fmt.Errorf("failed to check if %s is a directory: %w", potentialDir, err))
+			err = errors.Join(err, fmt.Errorf("failed to check if %s is a directory: %w", potentialDir, err))
 			continue
 		}
 		if isDir {

--- a/utils/techutils/techutils.go
+++ b/utils/techutils/techutils.go
@@ -392,9 +392,9 @@ func getDirectDirectories(path, excludePathPattern string) (directories []string
 	}
 	// Filter to directories only
 	for _, potentialDir := range filesOrDirsInPath {
-		isDir, err := fileutils.IsDirExists(potentialDir, true)
-		if err != nil {
-			err = errors.Join(err, fmt.Errorf("failed to check if %s is a directory: %w", potentialDir, err))
+		isDir, e := fileutils.IsDirExists(potentialDir, true)
+		if e != nil {
+			err = errors.Join(err, fmt.Errorf("failed to check if %s is a directory: %w", potentialDir, e))
 			continue
 		}
 		if isDir {

--- a/utils/techutils/techutils.go
+++ b/utils/techutils/techutils.go
@@ -379,12 +379,9 @@ func listFilesAndDirs(rootPath string, isRecursive, excludeWithRelativePath, pre
 
 func addNoTechIfNeeded(technologiesDetected map[Technology]map[string][]string, rootPath string, dirsList []string) (_ map[Technology]map[string][]string, err error) {
 	noTechMap := map[string][]string{}
-	for _, dir := range getDirChildren(rootPath, dirsList) {
-		noTechDirs := getDirNoTechList(technologiesDetected, dir, dirsList)
+	for _, dir := range getDirNoTechList(technologiesDetected, rootPath, dirsList) {
 		// Convert the directories
-		for _, dir := range noTechDirs {
-			noTechMap[dir] = []string{}
-		}
+		noTechMap[dir] = []string{}
 	}
 	if len(technologiesDetected) == 0 || len(noTechMap) > 0 {
 		// no technologies detected at all (add NoTech without any directories) or some directories were added to NoTech

--- a/utils/techutils/techutils.go
+++ b/utils/techutils/techutils.go
@@ -347,7 +347,7 @@ func DetectTechnologiesDescriptors(path string, recursive bool, requestedTechs [
 	}
 	if recursive {
 		// If recursive search, we need to also make sure to include directories that do not have any technology indicators.
-		technologiesDetected, err = addNoTechIfNeeded(technologiesDetected, path, dirsList)
+		technologiesDetected = addNoTechIfNeeded(technologiesDetected, path, dirsList)
 	}
 	techCount := len(technologiesDetected)
 	if _, exist := technologiesDetected[NoTech]; exist {
@@ -377,7 +377,7 @@ func listFilesAndDirs(rootPath string, isRecursive, excludeWithRelativePath, pre
 	return
 }
 
-func addNoTechIfNeeded(technologiesDetected map[Technology]map[string][]string, rootPath string, dirsList []string) (_ map[Technology]map[string][]string, err error) {
+func addNoTechIfNeeded(technologiesDetected map[Technology]map[string][]string, rootPath string, dirsList []string) (_ map[Technology]map[string][]string) {
 	noTechMap := map[string][]string{}
 	for _, dir := range getDirNoTechList(technologiesDetected, rootPath, dirsList) {
 		// Convert the directories
@@ -387,7 +387,7 @@ func addNoTechIfNeeded(technologiesDetected map[Technology]map[string][]string, 
 		// no technologies detected at all (add NoTech without any directories) or some directories were added to NoTech
 		technologiesDetected[NoTech] = noTechMap
 	}
-	return technologiesDetected, err
+	return technologiesDetected
 }
 
 func getDirNoTechList(technologiesDetected map[Technology]map[string][]string, dir string, dirsList []string) (noTechList []string) {

--- a/utils/techutils/techutils.go
+++ b/utils/techutils/techutils.go
@@ -327,7 +327,7 @@ func detectedTechnologiesListInPath(path string, recursive bool) (technologies [
 // If requestedTechs is empty, all technologies will be checked.
 // If excludePathPattern is not empty, files/directories that match the wildcard pattern will be excluded from the search.
 func DetectTechnologiesDescriptors(path string, recursive bool, requestedTechs []string, requestedDescriptors map[Technology][]string, excludePathPattern string) (technologiesDetected map[Technology]map[string][]string, err error) {
-	filesList, err := fspatterns.ListFiles(path, recursive, false, true, true, excludePathPattern)
+	filesList, dirsList, err := listFilesAndDirs(path, recursive, true, true, excludePathPattern)
 	if err != nil {
 		return
 	}
@@ -347,62 +347,158 @@ func DetectTechnologiesDescriptors(path string, recursive bool, requestedTechs [
 	}
 	if recursive {
 		// If recursive search, we need to also make sure to include directories that do not have any technology indicators.
-		technologiesDetected, err = addNoTechIfNeeded(technologiesDetected, path, excludePathPattern)
+		technologiesDetected, err = addNoTechIfNeeded(technologiesDetected, path, dirsList)
 	}
-	// In case we have recursive search, and the
-	if len(technologiesDetected) > 0 {
-		log.Debug(fmt.Sprintf("Detected %d technologies at %s: %s.", len(technologiesDetected), path, maps.Keys(technologiesDetected)))
+	techCount := len(technologiesDetected)
+	if _, exist := technologiesDetected[NoTech]; exist {
+		techCount--
+	}
+	if techCount > 0 {
+		log.Debug(fmt.Sprintf("Detected %d technologies at %s: %s.", techCount, path, maps.Keys(technologiesDetected)))
 	}
 	return
 }
 
-func addNoTechIfNeeded(technologiesDetected map[Technology]map[string][]string, path, excludePathPattern string) (finalMap map[Technology]map[string][]string, err error) {
-	finalMap = technologiesDetected
-	noTechMap := map[string][]string{}
-	directories, err := getDirectDirectories(path, excludePathPattern)
+func listFilesAndDirs(rootPath string, isRecursive, excludeWithRelativePath, preserveSymlink bool, excludePathPattern string) (files, dirs []string, err error) {
+	filesOrDirsInPath, err := fspatterns.ListFiles(rootPath, isRecursive, true, excludeWithRelativePath, preserveSymlink, excludePathPattern)
 	if err != nil {
 		return
 	}
-	for _, dir := range directories {
-		// Check if the directory is already mapped to a technology
-		isMapped := false
-		for _, techDirs := range finalMap {
-			if _, exist := techDirs[dir]; exist {
-				isMapped = true
-				break
-			}
+	for _, path := range filesOrDirsInPath {
+		if isDir, e := fileutils.IsDirExists(path, preserveSymlink); e != nil {
+			err = errors.Join(err, fmt.Errorf("failed to check if %s is a directory: %w", path, e))
+			continue
+		} else if isDir {
+			dirs = append(dirs, path)
+		} else {
+			files = append(files, path)
 		}
-		if !isMapped {
-			// Add the directory to NoTech (no indicators/descriptors were found)
+	}
+	return
+}
+
+func addNoTechIfNeeded(technologiesDetected map[Technology]map[string][]string, rootPath string, dirsList []string) (_ map[Technology]map[string][]string, err error) {
+	noTechMap := map[string][]string{}
+	for _, dir := range getDirChildren(rootPath, dirsList) {
+		noTechDirs := getDirNoTechList(technologiesDetected, dir, dirsList)
+		// Convert the directories
+		for _, dir := range noTechDirs {
 			noTechMap[dir] = []string{}
 		}
 	}
 	if len(technologiesDetected) == 0 || len(noTechMap) > 0 {
 		// no technologies detected at all (add NoTech without any directories) or some directories were added to NoTech
-		finalMap[NoTech] = noTechMap
+		technologiesDetected[NoTech] = noTechMap
+	}
+	return technologiesDetected, err
+}
+
+func getDirNoTechList(technologiesDetected map[Technology]map[string][]string, dir string, dirsList []string) (noTechList []string) {
+	for _, techDirs := range technologiesDetected {
+		if _, exist := techDirs[dir]; exist {
+			// The directory is already mapped to a technology, no need to add the dir or its sub directories to NoTech
+			return
+		}
+	}
+	children := getDirChildren(dir, dirsList)
+	childNoTechCount := 0
+	for _, child := range children {
+		childNoTechList := getDirNoTechList(technologiesDetected, child, dirsList)
+		if len(childNoTechList) > 0 {
+			childNoTechCount++
+		}
+		noTechList = append(noTechList, childNoTechList...)
+	}
+	if childNoTechCount == len(children) {
+		// If all children exists in childNoTechList, add only the parent directory to NoTech
+		noTechList = []string{dir}
+	}
+
+	// for _, techDirs := range technologiesDetected {
+	// 	if _, exist := techDirs[dir]; exist {
+	// 		// The directory is already mapped to a technology, no need to add the dir or its sub directories to NoTech
+	// 		break
+	// 	}
+	// 	for _, child := range children {
+	// 		childNoTechList := getDirNoTechList(technologiesDetected, child, dirsList)
+	// 	}
+
+	// 	if len(children) == 0 {
+	// 		// No children directories, add the directory to NoTech
+	// 		childNoTechList = append(childNoTechList, dir)
+	// 		break
+	// 	}
+	// 	for _, child := range children {
+	// 		childNoTechList = append(childNoTechList, getDirNoTechList(technologiesDetected, child, dirsList)...)
+	// 	}
+	// 	// If all children exists in childNoTechList, add only the parent directory to NoTech
+	// 	if len(children) == len(childNoTechList) {
+	// 		childNoTechList = []string{dir}
+	// 	}
+	// }
+	return
+}
+
+func getDirChildren(dir string, dirsList []string) (children []string) {
+	for _, dirPath := range dirsList {
+		if filepath.Dir(dirPath) == dir {
+			children = append(children, dirPath)
+		}
 	}
 	return
 }
 
-func getDirectDirectories(path, excludePathPattern string) (directories []string, err error) {
-	// Get all files and directories in the path, not recursive
-	filesOrDirsInPath, err := fspatterns.ListFiles(path, false, true, true, true, excludePathPattern)
-	if err != nil {
-		return
-	}
-	// Filter to directories only
-	for _, potentialDir := range filesOrDirsInPath {
-		isDir, e := fileutils.IsDirExists(potentialDir, true)
-		if e != nil {
-			err = errors.Join(err, fmt.Errorf("failed to check if %s is a directory: %w", potentialDir, e))
-			continue
-		}
-		if isDir {
-			directories = append(directories, potentialDir)
-		}
-	}
-	return
-}
+// func addNoTechIfNeeded(technologiesDetected map[Technology]map[string][]string, path, excludePathPattern string) (finalMap map[Technology]map[string][]string, err error) {
+// 	finalMap = technologiesDetected
+// 	noTechMap := map[string][]string{}
+// 	// TODO: not only direct, need to see if multiple levels of directories are missing technology indicators
+// 	// if all directories in are found no need for anything else,
+// 	// if one missing need to add it to NoTech
+// 	// if not one detected add only parent directory no need for each directory
+// 	directories, err := getDirectDirectories(path, excludePathPattern)
+// 	if err != nil {
+// 		return
+// 	}
+// 	for _, dir := range directories {
+// 		// Check if the directory is already mapped to a technology
+// 		isMapped := false
+// 		for _, techDirs := range finalMap {
+// 			if _, exist := techDirs[dir]; exist {
+// 				isMapped = true
+// 				break
+// 			}
+// 		}
+// 		if !isMapped {
+// 			// Add the directory to NoTech (no indicators/descriptors were found)
+// 			noTechMap[dir] = []string{}
+// 		}
+// 	}
+// 	if len(technologiesDetected) == 0 || len(noTechMap) > 0 {
+// 		// no technologies detected at all (add NoTech without any directories) or some directories were added to NoTech
+// 		finalMap[NoTech] = noTechMap
+// 	}
+// 	return
+// }
+
+// func getDirectDirectories(path, excludePathPattern string) (directories []string, err error) {
+// 	// Get all files and directories in the path, not recursive
+// 	filesOrDirsInPath, err := fspatterns.ListFiles(path, false, true, true, true, excludePathPattern)
+// 	if err != nil {
+// 		return
+// 	}
+// 	// Filter to directories only
+// 	for _, potentialDir := range filesOrDirsInPath {
+// 		isDir, e := fileutils.IsDirExists(potentialDir, true)
+// 		if e != nil {
+// 			err = errors.Join(err, fmt.Errorf("failed to check if %s is a directory: %w", potentialDir, e))
+// 			continue
+// 		}
+// 		if isDir {
+// 			directories = append(directories, potentialDir)
+// 		}
+// 	}
+// 	return
+// }
 
 // Map files to relevant working directories according to the technologies' indicators/descriptors and requested descriptors.
 // files: The file paths to map.
@@ -603,6 +699,9 @@ func hasCompletePathPrefix(root, wd string) bool {
 func DetectedTechnologiesToSlice(detected map[Technology]map[string][]string) []string {
 	keys := make([]string, 0, len(detected))
 	for tech := range detected {
+		if tech == NoTech {
+			continue
+		}
 		keys = append(keys, string(tech))
 	}
 	return keys

--- a/utils/techutils/techutils_test.go
+++ b/utils/techutils/techutils_test.go
@@ -260,21 +260,21 @@ func TestAddNoTechIfNeeded(t *testing.T) {
 	tests := []struct {
 		name                 string
 		path                 string
-		excludePathPattern   string
+		dirList              []string
 		technologiesDetected map[Technology]map[string][]string
 		expected             map[Technology]map[string][]string
 	}{
 		{
-			name:                 "No tech detected with exclude pattern",
+			name:                 "No tech detected",
 			path:                 tmpDir,
-			excludePathPattern:   "(^.*folder.*$)",
+			dirList:              []string{},
 			technologiesDetected: map[Technology]map[string][]string{},
 			expected:             map[Technology]map[string][]string{NoTech: {}},
 		},
 		{
-			name:                 "No tech detected",
+			name:                 "No tech detected, sub dir",
 			path:                 tmpDir,
-			excludePathPattern:   "",
+			dirList:              []string{filepath.Join(tmpDir, "folder")},
 			technologiesDetected: map[Technology]map[string][]string{},
 			expected:             map[Technology]map[string][]string{NoTech: {filepath.Join(tmpDir, "folder"): {}}},
 		},
@@ -282,7 +282,7 @@ func TestAddNoTechIfNeeded(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			actual, err := addNoTechIfNeeded(test.technologiesDetected, test.path, test.excludePathPattern)
+			actual, err := addNoTechIfNeeded(test.technologiesDetected, test.path, test.dirList)
 			assert.NoError(t, err)
 			assert.Equal(t, test.expected, actual)
 		})

--- a/utils/techutils/techutils_test.go
+++ b/utils/techutils/techutils_test.go
@@ -245,22 +245,17 @@ func TestMapWorkingDirectoriesToTechnologies(t *testing.T) {
 	}
 }
 
-func createTempDirAndChangeWD(t *testing.T) (string, func()) {
+func TestAddNoTechIfNeeded(t *testing.T) {
 	tmpDir, err := fileutils.CreateTempDir()
 	assert.NoError(t, err, "Couldn't create temp dir")
-	fileutils.CreateDirIfNotExist(filepath.Join(tmpDir, "folder"))
+	assert.NoError(t, fileutils.CreateDirIfNotExist(filepath.Join(tmpDir, "folder")))
 
 	prevWd, err := os.Getwd()
 	assert.NoError(t, os.Chdir(tmpDir), "Couldn't change working directory")
-	return tmpDir, func() {
+	defer func() {
 		clientTests.ChangeDirAndAssert(t, prevWd)
 		assert.NoError(t, fileutils.RemoveTempDir(tmpDir), "Couldn't remove temp dir")
-	}
-}
-
-func TestAddNoTechIfNeeded(t *testing.T) {
-	tmpDir, cleanUp := createTempDirAndChangeWD(t)
-	defer cleanUp()
+	}()
 
 	tests := []struct {
 		name                 string

--- a/utils/techutils/techutils_test.go
+++ b/utils/techutils/techutils_test.go
@@ -249,6 +249,7 @@ func TestAddNoTechIfNeeded(t *testing.T) {
 	tmpDir, err := fileutils.CreateTempDir()
 	assert.NoError(t, err, "Couldn't create temp dir")
 	assert.NoError(t, fileutils.CreateDirIfNotExist(filepath.Join(tmpDir, "folder")))
+	assert.NoError(t, fileutils.CreateDirIfNotExist(filepath.Join(tmpDir, "tech-folder")))
 
 	prevWd, err := os.Getwd()
 	assert.NoError(t, os.Chdir(tmpDir), "Couldn't change working directory")
@@ -269,14 +270,14 @@ func TestAddNoTechIfNeeded(t *testing.T) {
 			path:                 tmpDir,
 			dirList:              []string{},
 			technologiesDetected: map[Technology]map[string][]string{},
-			expected:             map[Technology]map[string][]string{NoTech: {}},
+			expected:             map[Technology]map[string][]string{NoTech: {tmpDir: {}}},
 		},
 		{
 			name:                 "No tech detected, sub dir",
 			path:                 tmpDir,
-			dirList:              []string{filepath.Join(tmpDir, "folder")},
-			technologiesDetected: map[Technology]map[string][]string{},
-			expected:             map[Technology]map[string][]string{NoTech: {filepath.Join(tmpDir, "folder"): {}}},
+			dirList:              []string{filepath.Join(tmpDir, "folder"), filepath.Join(tmpDir, "tech-folder")},
+			technologiesDetected: map[Technology]map[string][]string{Npm: {filepath.Join(tmpDir, "tech-folder"): {}}},
+			expected:             map[Technology]map[string][]string{Npm: {filepath.Join(tmpDir, "tech-folder"): {}}, NoTech: {filepath.Join(tmpDir, "folder"): {}}},
 		},
 	}
 

--- a/utils/techutils/techutils_test.go
+++ b/utils/techutils/techutils_test.go
@@ -252,6 +252,7 @@ func TestAddNoTechIfNeeded(t *testing.T) {
 	assert.NoError(t, fileutils.CreateDirIfNotExist(filepath.Join(tmpDir, "tech-folder")))
 
 	prevWd, err := os.Getwd()
+	assert.NoError(t, err, "Couldn't get working directory")
 	assert.NoError(t, os.Chdir(tmpDir), "Couldn't change working directory")
 	defer func() {
 		clientTests.ChangeDirAndAssert(t, prevWd)

--- a/utils/techutils/techutils_test.go
+++ b/utils/techutils/techutils_test.go
@@ -284,8 +284,7 @@ func TestAddNoTechIfNeeded(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			actual, err := addNoTechIfNeeded(test.technologiesDetected, test.path, test.dirList)
-			assert.NoError(t, err)
+			actual := addNoTechIfNeeded(test.technologiesDetected, test.path, test.dirList)
 			assert.Equal(t, test.expected, actual)
 		})
 	}


### PR DESCRIPTION
- [x] The pull request is targeting the `dev` branch.
- [x] The code has been validated to compile successfully by running `go vet ./...`.
- [x] The code has been formatted properly using `go fmt ./...`.
- [x] All [static analysis checks](https://github.com/jfrog/jfrog-cli-security/actions/workflows/analysis.yml) passed.
- [x] All [tests](https://github.com/jfrog/jfrog-cli-security/actions/workflows/test.yml) have passed. If this feature is not already covered by the tests, new tests have been added.
- [x] Updated the [Contributing page](https://github.com/jfrog/jfrog-cli-security/blob/main/CONTRIBUTING.md) / [ReadMe page](https://github.com/jfrog/jfrog-cli-security/blob/main/README.md) / [CI Workflow files](https://github.com/jfrog/jfrog-cli-security/tree/main/.github/workflows) if needed.
- [x] All changes are detailed at the description. if not already covered at [JFrog Documentation](https://github.com/jfrog/documentation), new documentation have been added.

-----

On recursive scan (when `working-dir` flag and `jfrog-apps-config` file is not provided) if we detected sub directories with some tech, we would exclude all the other siblings' directories without one. in case the client is entitled for JAS, we would skip scanning does directories.

This PR adds a new technology `NoTech` for those cases