### PR TITLE
Fix bugs when converting results to SARIF

### DIFF
--- a/tests/testdata/output/audit/audit_sarif.json
+++ b/tests/testdata/output/audit/audit_sarif.json
@@ -1106,7 +1106,7 @@
           "ruleIndex": 6,
           "level": "warning",
           "message": {
-            "text": "[CVE-2020-28500] lodash 4.17.0"
+            "text": "Security violation [CVE-2020-28500] lodash 4.17.0"
           },
           "locations": [
             {

--- a/tests/testdata/output/dockerscan/docker_results.json
+++ b/tests/testdata/output/dockerscan/docker_results.json
@@ -616,7 +616,7 @@
                 ],
                 "executionSuccessful": true,
                 "workingDirectory": {
-                  "uri": "/var/folders/xv/th4cksxn7jv9wjrdnn1h4tj00000gq/T/jfrog.cli.temp.-1726210535-1985298017/image.tar"
+                  "uri": "/var/folders/xv/th4cksxn7jv9wjrdnn1h4tj00000gq/T/jfrog.cli.temp.-1726210535-1985298017"
                 }
               }
             ],
@@ -815,7 +815,7 @@
                 ],
                 "executionSuccessful": true,
                 "workingDirectory": {
-                  "uri": "/var/folders/xv/th4cksxn7jv9wjrdnn1h4tj00000gq/T/jfrog.cli.temp.-1726210535-1985298017/image.tar"
+                  "uri": "/var/folders/xv/th4cksxn7jv9wjrdnn1h4tj00000gq/T/jfrog.cli.temp.-1726210535-1985298017"
                 }
               }
             ],

--- a/tests/testdata/output/dockerscan/docker_sarif.json
+++ b/tests/testdata/output/dockerscan/docker_sarif.json
@@ -119,7 +119,7 @@
           ],
           "executionSuccessful": true,
           "workingDirectory": {
-            "uri": "/var/folders/xv/th4cksxn7jv9wjrdnn1h4tj00000gq/T/jfrog.cli.temp.-1726210535-1985298017/image.tar"
+            "uri": "/var/folders/xv/th4cksxn7jv9wjrdnn1h4tj00000gq/T/jfrog.cli.temp.-1726210535-1985298017"
           }
         }
       ],
@@ -393,7 +393,7 @@
         {
           "executionSuccessful": true,
           "workingDirectory": {
-            "uri": "/var/folders/xv/th4cksxn7jv9wjrdnn1h4tj00000gq/T/jfrog.cli.temp.-1726210535-1985298017/image.tar"
+            "uri": "/var/folders/xv/th4cksxn7jv9wjrdnn1h4tj00000gq/T/jfrog.cli.temp.-1726210535-1985298017"
           }
         }
       ],

--- a/utils/results/conversion/sarifparser/sarifparser_test.go
+++ b/utils/results/conversion/sarifparser/sarifparser_test.go
@@ -65,8 +65,13 @@ func TestGetComponentSarifLocation(t *testing.T) {
 }
 
 func TestGetVulnerabilityOrViolationSarifHeadline(t *testing.T) {
-	assert.Equal(t, "[CVE-2022-1234] loadsh 1.4.1", getScaIssueSarifHeadline("loadsh", "1.4.1", "CVE-2022-1234"))
-	assert.NotEqual(t, "[CVE-2022-1234] comp 1.4.1", getScaIssueSarifHeadline("comp", "1.2.1", "CVE-2022-1234"))
+	assert.Equal(t, "[CVE-2022-1234] loadsh 1.4.1", getScaVulnerabilitySarifHeadline("loadsh", "1.4.1", "CVE-2022-1234"))
+	assert.NotEqual(t, "[CVE-2022-1234] comp 1.4.1", getScaVulnerabilitySarifHeadline("comp", "1.2.1", "CVE-2022-1234"))
+}
+
+func TestGetScaSecurityViolationSarifHeadline(t *testing.T) {
+	assert.Equal(t, "Security violation [CVE-2022-1234] loadsh 1.4.1", getScaSecurityViolationSarifHeadline("loadsh", "1.4.1", "CVE-2022-1234"))
+	assert.NotEqual(t, "Security violation [CVE-2022-1234] comp 1.2.1", getScaSecurityViolationSarifHeadline("comp", "1.2.1", "CVE-2022-1234"))
 }
 
 func TestGetXrayLicenseSarifHeadline(t *testing.T) {

--- a/utils/results/conversion/sarifparser/sarifparser_test.go
+++ b/utils/results/conversion/sarifparser/sarifparser_test.go
@@ -71,7 +71,7 @@ func TestGetVulnerabilityOrViolationSarifHeadline(t *testing.T) {
 
 func TestGetScaSecurityViolationSarifHeadline(t *testing.T) {
 	assert.Equal(t, "Security violation [CVE-2022-1234] loadsh 1.4.1", getScaSecurityViolationSarifHeadline("loadsh", "1.4.1", "CVE-2022-1234"))
-	assert.NotEqual(t, "Security violation [CVE-2022-1234] comp 1.2.1", getScaSecurityViolationSarifHeadline("comp", "1.2.1", "CVE-2022-1234"))
+	assert.NotEqual(t, "[CVE-2022-1234] comp 1.2.1", getScaSecurityViolationSarifHeadline("comp", "1.2.1", "CVE-2022-1234"))
 }
 
 func TestGetXrayLicenseSarifHeadline(t *testing.T) {
@@ -416,7 +416,7 @@ func TestPatchRunsToPassIngestionRules(t *testing.T) {
 					},
 					Invocations: []*sarif.Invocation{sarif.NewInvocation().WithWorkingDirectory(sarif.NewSimpleArtifactLocation(wd))},
 					Results: []*sarif.Result{
-						sarifutils.CreateDummyResultWithFingerprint(fmt.Sprintf("🔒 Found Secrets in Binary docker scanning:\nImage: dockerImage:imageVersion\nLayer (sha1): 9e88ea9de1b44baba5e96a79e33e4af64334b2bf129e838e12f6dae71b5c86f0\nFilepath: %s\nEvidence: snippet", filepath.Join("usr", "src", "app", "server", "index.js")), "", jfrogFingerprintAlgorithmName, "93d660ebfd39b1220c42c0beb6e4e863",
+						sarifutils.CreateDummyResultWithFingerprint(fmt.Sprintf("🔒 Found Secrets in Binary docker scanning:\nImage: dockerImage:imageVersion\nLayer (sha1): 9e88ea9de1b44baba5e96a79e33e4af64334b2bf129e838e12f6dae71b5c86f0\nFilepath: %s\nEvidence: snippet", filepath.Join("usr", "src", "app", "server", "index.js")), "", jfrogFingerprintAlgorithmName, "dee156c9fd75a4237102dc8fb29277a2",
 							sarifutils.CreateDummyLocationWithPathAndLogicalLocation(filepath.Join("usr", "src", "app", "server", "index.js"), "9e88ea9de1b44baba5e96a79e33e4af64334b2bf129e838e12f6dae71b5c86f0", "layer", "algorithm", "sha1"),
 						),
 					},

--- a/utils/validations/test_validate_sarif.go
+++ b/utils/validations/test_validate_sarif.go
@@ -191,7 +191,6 @@ func getResultByResultId(expected *sarif.Result, actual []*sarif.Result) *sarif.
 	log.Output("====================================")
 	log.Output(fmt.Sprintf(":: Actual results with expected results: %s", getResultId(expected)))
 	for _, result := range actual {
-
 		log.Output(fmt.Sprintf("Compare actual result (isPotential=%t, hasSameLocations=%t) with expected result: %s", isPotentialSimilarResults(expected, result), hasSameLocations(expected, result), getResultId(result)))
 		if isPotentialSimilarResults(expected, result) && hasSameLocations(expected, result) {
 			return result
@@ -202,7 +201,7 @@ func getResultByResultId(expected *sarif.Result, actual []*sarif.Result) *sarif.
 }
 
 func isPotentialSimilarResults(expected, actual *sarif.Result) bool {
-	return sarifutils.GetResultRuleId(actual) == sarifutils.GetResultRuleId(expected) && sarifutils.GetResultMsgText(actual) == sarifutils.GetResultMsgText(expected) && sarifutils.GetResultProperty(sarifparser.WatchSarifPropertyKey, actual) == sarifutils.GetResultProperty(sarifparser.WatchSarifPropertyKey, expected)
+	return sarifutils.GetResultRuleId(actual) == sarifutils.GetResultRuleId(expected) && sarifutils.GetResultProperty(sarifparser.WatchSarifPropertyKey, actual) == sarifutils.GetResultProperty(sarifparser.WatchSarifPropertyKey, expected)
 }
 
 func getResultId(result *sarif.Result) string {


### PR DESCRIPTION
- [x] The pull request is targeting the `dev` branch.
- [x] The code has been validated to compile successfully by running `go vet ./...`.
- [x] The code has been formatted properly using `go fmt ./...`.
- [x] All [static analysis checks](https://github.com/jfrog/jfrog-cli-security/actions/workflows/analysis.yml) passed.
- [x] All [tests](https://github.com/jfrog/jfrog-cli-security/actions/workflows/test.yml) have passed. If this feature is not already covered by the tests, new tests have been added.
- [x] Updated the [Contributing page](https://github.com/jfrog/jfrog-cli-security/blob/main/CONTRIBUTING.md) / [ReadMe page](https://github.com/jfrog/jfrog-cli-security/blob/main/README.md) / [CI Workflow files](https://github.com/jfrog/jfrog-cli-security/tree/main/.github/workflows) if needed.
- [x] All changes are detailed at the description. if not already covered at [JFrog Documentation](https://github.com/jfrog/documentation), new documentation have been added.

-----

### Fixing the following bugs when parsing the results to SARIF format

#### Duplicate [Secret in Binary found]
![image](https://github.com/user-attachments/assets/845f9ac5-19f6-463c-a43e-1a723a58b768)

* Some attributes were not copied when parsing to format, when parsing for the second time it already was "padded" with the prefix which resulted in duplicate "padding"

#### Uri attribute is empty on binary scan
```json
  "locations": [
           {
             "physicalLocation": {
               "artifactLocation": {
                 "uri": ""
               }
             },
             "logicalLocations": [
               {
                 "name": "38610c0cfc18becc30c87e0af68f1c43c5cdc0ef10d920dde284df0d58fb00e1",
                 "kind": "layer",
                 "properties": {
                   "algorithm": "sha256"
                 }
               }
             ]
           }
         ],
```

* For `Docker` targets (and some binaries), the `target.Target ` is a file and not a directory and we set it as the `wd` of the SCA Sarig run, when we are translating the results location to relative paths it had `uri=wd` which resulted in leaving empty value