### PR TITLE
License Violation - Show IssueId If LicenseKey is Empty

### DIFF
--- a/utils/results/conversion/simplejsonparser/simplejsonparser.go
+++ b/utils/results/conversion/simplejsonparser/simplejsonparser.go
@@ -232,7 +232,7 @@ func addSimpleJsonLicenseViolation(licenseViolationsRows *[]formats.LicenseRow, 
 	return func(violation services.Violation, cves []formats.CveRow, applicabilityStatus jasutils.ApplicabilityStatus, severity severityutils.Severity, impactedPackagesName, impactedPackagesVersion, impactedPackagesType string, fixedVersion []string, directComponents []formats.ComponentRow, impactPaths [][]formats.ComponentRow) error {
 		*licenseViolationsRows = append(*licenseViolationsRows,
 			formats.LicenseRow{
-				LicenseKey: violation.LicenseKey,
+				LicenseKey: getLicenseKey(violation.LicenseKey, violation.IssueId),
 				ImpactedDependencyDetails: formats.ImpactedDependencyDetails{
 					SeverityDetails:           severityutils.GetAsDetails(severity, applicabilityStatus, pretty),
 					ImpactedDependencyName:    impactedPackagesName,
@@ -244,6 +244,13 @@ func addSimpleJsonLicenseViolation(licenseViolationsRows *[]formats.LicenseRow, 
 		)
 		return nil
 	}
+}
+
+func getLicenseKey(licenseKey, issueId string) string {
+	if licenseKey == "" {
+		return issueId
+	}
+	return licenseKey
 }
 
 func addSimpleJsonOperationalRiskViolation(operationalRiskViolationsRows *[]formats.OperationalRiskViolationRow, pretty bool) results.ParseScaViolationFunc {


### PR DESCRIPTION
- [x] The pull request is targeting the `dev` branch.
- [x] The code has been validated to compile successfully by running `go vet ./...`.
- [x] The code has been formatted properly using `go fmt ./...`.
- [x] All [static analysis checks](https://github.com/jfrog/jfrog-cli-security/actions/workflows/analysis.yml) passed.
- [x] All [tests](https://github.com/jfrog/jfrog-cli-security/actions/workflows/test.yml) have passed. If this feature is not already covered by the tests, new tests have been added.
- [x] Updated the [Contributing page](https://github.com/jfrog/jfrog-cli-security/blob/main/CONTRIBUTING.md) / [ReadMe page](https://github.com/jfrog/jfrog-cli-security/blob/main/README.md) / [CI Workflow files](https://github.com/jfrog/jfrog-cli-security/tree/main/.github/workflows) if needed.
- [x] All changes are detailed at the description. if not already covered at [JFrog Documentation](https://github.com/jfrog/documentation), new documentation have been added.

-----

Some License Violations `licenseKey` attribute has empty value resulting in empty values displayed:
![image](https://github.com/user-attachments/assets/ddc9f766-15a9-4d8a-a99d-6f2743bf0fda)

* Fix this by using `IssueId` if empty
![image](https://github.com/user-attachments/assets/35677161-7843-45e9-9ea8-8b0546d40010)

