### PR TITLE
Remove 'Root' from license violation when Unknown enabled

### DIFF
--- a/utils/results/common.go
+++ b/utils/results/common.go
@@ -161,6 +161,10 @@ func PrepareScaViolations(target ScanTarget, violations []services.Violation, en
 				continue
 			}
 			for compIndex := 0; compIndex < len(impactedPackagesNames); compIndex++ {
+				if impactedPackagesNames[compIndex] == "root" {
+					// No Need to output 'root' as impacted package for license since we add this as the root node for the scan
+					continue
+				}
 				if e := licenseHandler(
 					violation, cves, applicabilityStatus, severity,
 					impactedPackagesNames[compIndex], impactedPackagesVersions[compIndex], impactedPackagesTypes[compIndex],


### PR DESCRIPTION
- [ ] The pull request is targeting the `dev` branch.
- [ ] The code has been validated to compile successfully by running `go vet ./...`.
- [ ] The code has been formatted properly using `go fmt ./...`.
- [ ] All [static analysis checks](https://github.com/jfrog/jfrog-cli-security/actions/workflows/analysis.yml) passed.
- [ ] All [tests](https://github.com/jfrog/jfrog-cli-security/actions/workflows/test.yml) have passed. If this feature is not already covered by the tests, new tests have been added.
- [ ] Updated the [Contributing page](https://github.com/jfrog/jfrog-cli-security/blob/main/CONTRIBUTING.md) / [ReadMe page](https://github.com/jfrog/jfrog-cli-security/blob/main/README.md) / [CI Workflow files](https://github.com/jfrog/jfrog-cli-security/tree/main/.github/workflows) if needed.
- [ ] All changes are detailed at the description. if not already covered at [JFrog Documentation](https://github.com/jfrog/documentation), new documentation have been added.

-----

When `Unknown` license violation was enabled we output `root` as `Unknown` license violation.
This PR fixes this issue

Before:
![image](https://github.com/user-attachments/assets/a74da994-402d-40cf-b3f2-2ae557910d1d)

After:
![image](https://github.com/user-attachments/assets/705274cb-65d0-4161-8de0-f733392d654d)
