### PR TITLE
Add tests for fail_build in case of violation

### DIFF
--- a/audit_test.go
+++ b/audit_test.go
@@ -37,12 +37,29 @@ import (
 	"github.com/jfrog/jfrog-client-go/xray/services"
 )
 
-func TestXrayAuditNpmJson(t *testing.T) {
+func TestXrayViolationsAuditNpmJson(t *testing.T) {
 	integration.InitAuditJavaScriptTest(t, scangraph.GraphScanMinXrayVersion)
 	output := testAuditNpm(t, string(format.Json), false)
 	validations.VerifyJsonResults(t, output, validations.ValidationParams{
-		SecurityViolations: 1,
-		Licenses:           1,
+		SecurityViolations:   1,
+		Licenses:             1,
+		FailBuild:            true,
+		FailBuildCVESeverity: string(xrayUtils.High),
+	})
+}
+
+func TestXscViolationsAuditNpmJson(t *testing.T) {
+	integration.InitAuditJavaScriptTest(t, scangraph.GraphScanMinXrayVersion)
+	err := os.Setenv("JFROG_CLI_REPORT_USAGE", "True")
+	if err != nil {
+		assert.NoError(t, err)
+	}
+	output := testAuditNpm(t, string(format.Json), false)
+	validations.VerifyJsonResults(t, output, validations.ValidationParams{
+		SecurityViolations:   1,
+		Licenses:             1,
+		FailBuild:            true,
+		FailBuildCVESeverity: string(xrayUtils.High),
 	})
 }
 

--- a/scans_test.go
+++ b/scans_test.go
@@ -118,7 +118,7 @@ func TestXrayBinaryScanWithBypassArchiveLimits(t *testing.T) {
 // Docker scan tests
 
 func TestValidatePathFunc(t *testing.T) {
-	// ValidatePathFunc should return true for a valid path
+	// ValidatePathFunc is made to test the validatePaths function
 	validations.TestValidatePathsFunc(t)
 }
 

--- a/scans_test.go
+++ b/scans_test.go
@@ -117,6 +117,11 @@ func TestXrayBinaryScanWithBypassArchiveLimits(t *testing.T) {
 
 // Docker scan tests
 
+func TestValidatePathFunc(t *testing.T) {
+	// ValidatePathFunc should return true for a valid path
+	validations.TestValidatePathsFunc(t)
+}
+
 func TestDockerScanWithProgressBar(t *testing.T) {
 	callback := commonTests.MockProgressInitialization()
 	defer callback()

--- a/scans_test.go
+++ b/scans_test.go
@@ -174,7 +174,12 @@ func runDockerScan(t *testing.T, testCli *coreTests.JfrogCli, imageName, watchNa
 			if validateSecrets {
 				validations.VerifySimpleJsonResults(t, output, validations.ValidationParams{Inactive: minInactives})
 			} else {
-				validations.VerifyJsonResults(t, output, validations.ValidationParams{Vulnerabilities: minVulnerabilities, Licenses: minLicenses})
+				validations.VerifyJsonResults(t, output, validations.ValidationParams{
+					Vulnerabilities: minVulnerabilities,
+					Licenses:        minLicenses,
+					//ExistingProperties: []string{"targets[].sca_scans.xray_scan[].vulnerabilities[].components[*].impact_paths[][].full_path"}})
+					//ExistingProperties: []string{"vulnerabilities[].components[*].impact_paths[][].full_path"}})
+					ExistingProperties: []string{"impact_paths", "full_path"}})
 			}
 		}
 		// Run docker scan on image with watch
@@ -184,7 +189,7 @@ func runDockerScan(t *testing.T, testCli *coreTests.JfrogCli, imageName, watchNa
 		cmdArgs = append(cmdArgs, "--watches="+watchName)
 		output = testCli.WithoutCredentials().RunCliCmdWithOutput(t, cmdArgs...)
 		if assert.NotEmpty(t, output) {
-			validations.VerifyJsonResults(t, output, validations.ValidationParams{SecurityViolations: minViolations})
+			validations.VerifyJsonResults(t, output, validations.ValidationParams{SecurityViolations: minViolations, Vulnerabilities: 0})
 		}
 	}
 }

--- a/utils/validations/test_validate_sca.go
+++ b/utils/validations/test_validate_sca.go
@@ -3,6 +3,8 @@ package validations
 import (
 	"encoding/json"
 	"fmt"
+	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/jfrog/jfrog-cli-security/utils"
@@ -36,6 +38,13 @@ func ValidateCommandJsonOutput(t *testing.T, params ValidationParams) {
 		}
 		if params.FailBuild == true {
 			ValidateScanResponseFailBuild(t, params.FailBuildCVESeverity, results)
+		}
+		if params.ExistingProperties != nil {
+			//TODO: TEMP Function - to use ValidatePaths
+			ValidateContainedStrings(t, fmt.Sprintf("%v", results), params.ExistingProperties)
+			//for _, res := range results {
+			//	ValidatePaths(t, res, params.ExistingProperties)
+			//}
 		}
 	}
 }
@@ -95,4 +104,10 @@ func getScanResponseByScanId(scanId string, content []services.ScanResponse) *se
 		}
 	}
 	return nil
+}
+
+func ValidateContainedStrings(t *testing.T, output string, strings []string) {
+	for _, str := range strings {
+		assert.Contains(t, output, str, "string not found: %s", str)
+	}
 }

--- a/utils/validations/test_validate_sca.go
+++ b/utils/validations/test_validate_sca.go
@@ -97,6 +97,187 @@ func ValidateScanResponses(t *testing.T, exactMatch bool, expected, actual []ser
 	}
 }
 
+func TestValidatePathsFunc(t *testing.T) {
+	//sampleJson := `{
+	//	"targets": [
+	//{
+	//  "target": "/path/to/target",
+	//  "name": "some-target-name",
+	//  "technology": "some-technology",
+	//  "sca_scans": {
+	//    "xray_scan": [
+	//{
+	sampleJson := `{
+         "scan_id": "1a97d1a4-4d30-430c-46e9-d0c998065d08",
+         "vulnerabilities": [
+           {
+             "cves": [
+               {
+                 "cve": "CVE-2024-51744",
+                 "cvss_v3_score": "3.1",
+                 "cvss_v3_vector": "CVSS:3.1/AV:N/AC:H/PR:N/UI:R/S:U/C:L/I:N/A:N",
+                 "cwe": [
+                   "CWE-347",
+                   "CWE-755"
+                 ],
+                 "cwe_details": {
+                   "CWE-347": {
+                     "name": "Improper Verification of Cryptographic Signature",
+                     "description": "The product does not verify, or incorrectly verifies, the cryptographic signature for data."
+                   },
+                   "CWE-755": {
+                     "name": "Improper Handling of Exceptional Conditions",
+                     "description": "The product does not handle or incorrectly handles an exceptional condition."
+                   }
+                 }
+               }
+             ],
+             "summary": "golang-jwt is a Go implementation of JSON Web Tokens. Unclear documentation of the error behavior in \"ParseWithClaims\" can lead to situation where users are potentially not checking errors in the way they should be. Especially, if a token is both expired and invalid, the errors returned by \"ParseWithClaims\" return both error codes. If users only check for the \"jwt.ErrTokenExpired\" using \"error.Is\", they will ignore the embedded \"jwt.ErrTokenSignatureInvalid\" and thus potentially accept invalid tokens. A fix has been back-ported with the error handling logic from the \"v5\" branch to the \"v4\" branch. In this logic, the \"ParseWithClaims\" function will immediately return in \"dangerous\" situations (e.g., an invalid signature), limiting the combined errors only to situations where the signature is valid, but further validation failed (e.g., if the signature is valid, but is expired AND has the wrong audience). This fix is part of the 4.5.1 release. We are aware that this changes the behaviour of an established function and is not 100 % backwards compatible, so updating to 4.5.1 might break your code. In case you cannot update to 4.5.0, please make sure that you are properly checking for all errors (\"dangerous\" ones first), so that you are not running in the case detailed above.",
+             "severity": "Low",
+             "components": {
+               "go://github.com/golang-jwt/jwt/v4:4.4.2": {
+                 "fixed_versions": [
+                   "[4.5.1]"
+                 ],
+                 "impact_paths": [
+                   [
+                     {
+                       "component_id": "docker://localhost:8046/cli-docker-virtual-1734626392/bitnami/minio:2022"
+                     },
+                     {
+                       "component_id": "generic://sha256:2252918a526208e7f0b752c923f267b14f1c8beece250ee6bc72c9c2ef7bb1c6/sha256__2252918a526208e7f0b752c923f267b14f1c8beece250ee6bc72c9c2ef7bb1c6.tar",
+                       "full_path": "sha256__2252918a526208e7f0b752c923f267b14f1c8beece250ee6bc72c9c2ef7bb1c6.tar"
+                     }
+                   ]
+                 ]
+               }
+             }
+           }
+         ]
+       }`
+	//       ]
+	//     }
+	//   }
+	// ]
+	//}`
+	actualJson := services.ScanResponse{}
+	err := json.Unmarshal([]byte(sampleJson), &actualJson)
+	if err != nil {
+		assert.NoError(t, err)
+	}
+	stringsToCheck := []string{"vulnerabilities[].components[*].impact_paths[][].full_path"}
+	ValidatePaths(t, actualJson, stringsToCheck)
+	//ValidateContainedStrings(t, sampleJson, []string{"impact_paths", "full_path"})
+}
+
+func ValidatePaths(t *testing.T, output interface{}, paths []string) {
+	for _, path := range paths {
+		elements := strings.Split(path, ".")
+		assert.True(t, validatePath(output, elements), "path does not exist: %s", path)
+	}
+}
+
+func validatePath(data interface{}, path []string) bool {
+	if len(path) == 0 {
+		return true
+	}
+
+	key := path[0]
+	sliceKey := strings.Replace(key, "[]", "", -1)
+	mapKey := strings.Replace(key, "[*]", "", -1)
+
+	if key == "[]" {
+		// Top-level is an array
+		if reflect.TypeOf(data).Kind() == reflect.Slice {
+			slice := reflect.ValueOf(data)
+			for i := 0; i < slice.Len(); i++ {
+				if validatePath(slice.Index(i).Interface(), path[1:]) {
+					return true
+				}
+			}
+		}
+	} else if strings.Contains(key, "[]") {
+		// Handle array notation in the middle
+		if reflect.TypeOf(data).Kind() == reflect.Map {
+			dataMap := reflect.ValueOf(data)
+			if val := dataMap.MapIndex(reflect.ValueOf(sliceKey)); val.IsValid() {
+				if val.Kind() == reflect.Slice {
+					slice := val
+					for i := 0; i < slice.Len(); i++ {
+						if validatePath(slice.Index(i).Interface(), path[1:]) {
+							return true
+						}
+					}
+				}
+			}
+		} else if reflect.TypeOf(data).Kind() == reflect.Struct {
+			structField, valid := getFieldByTag(data, sliceKey)
+			if valid && structField.Kind() == reflect.Slice {
+				slice := structField
+				for i := 0; i < slice.Len(); i++ {
+					if validatePath(slice.Index(i).Interface(), path[1:]) {
+						return true
+					}
+				}
+			}
+		}
+	} else if strings.Contains(key, "[*]") {
+		// Handle any map key
+		if reflect.TypeOf(data).Kind() == reflect.Map {
+			dataMap := reflect.ValueOf(data)
+			if val := dataMap.MapIndex(reflect.ValueOf(mapKey)); val.IsValid() {
+				if val.Kind() == reflect.Map {
+					for _, item := range val.Interface().(map[string]interface{}) {
+						if validatePath(item, path[1:]) {
+							return true
+						}
+					}
+				}
+			}
+		} else if reflect.TypeOf(data).Kind() == reflect.Struct {
+			structField, valid := getFieldByTag(data, mapKey)
+			if valid && structField.Kind() == reflect.Map {
+				for _, item := range reflect.ValueOf(structField.Interface()).MapKeys() {
+					if validatePath(item, path[1:]) {
+						return true
+					}
+				}
+			}
+		}
+	} else {
+		// Handle standard keys
+		if reflect.TypeOf(data).Kind() == reflect.Map {
+			dataMap := reflect.ValueOf(data)
+			if val := dataMap.MapIndex(reflect.ValueOf(key)); val.IsValid() {
+				return validatePath(val.Interface(), path[1:])
+			}
+		} else if reflect.TypeOf(data).Kind() == reflect.Struct {
+			structField, valid := getFieldByTag(data, key)
+			if valid {
+				return validatePath(structField.Interface(), path[1:])
+			}
+		}
+	}
+	return false
+}
+
+func getFieldByTag(data interface{}, key string) (reflect.Value, bool) {
+	structValue := reflect.ValueOf(data)
+	structType := structValue.Type()
+
+	for i := 0; i < structValue.NumField(); i++ {
+		field := structType.Field(i)
+		tag := field.Tag.Get("json")
+
+		tagParts := strings.Split(tag, ",")
+		if tagParts[0] == key {
+			return structValue.Field(i), true
+		}
+	}
+
+	return reflect.Value{}, false
+}
+
 func getScanResponseByScanId(scanId string, content []services.ScanResponse) *services.ScanResponse {
 	for _, result := range content {
 		if result.ScanId == scanId {

--- a/utils/validations/test_validate_sca.go
+++ b/utils/validations/test_validate_sca.go
@@ -34,6 +34,9 @@ func ValidateCommandJsonOutput(t *testing.T, params ValidationParams) {
 				ValidateScanResponses(t, params.ExactResultsMatch, expectedResults, results)
 			}
 		}
+		if params.FailBuild == true {
+			ValidateScanResponseFailBuild(t, params.FailBuildCVESeverity, results)
+		}
 	}
 }
 
@@ -62,6 +65,18 @@ func ValidateScanResponseIssuesCount(t *testing.T, params ValidationParams, cont
 		CountValidation[int]{Expected: params.LicenseViolations, Actual: licenseViolations, Msg: GetValidationCountErrMsg("license violations", "scan responses", params.ExactResultsMatch, params.LicenseViolations, licenseViolations)},
 		CountValidation[int]{Expected: params.OperationalViolations, Actual: operationalViolations, Msg: GetValidationCountErrMsg("operational risk violations", "scan responses", params.ExactResultsMatch, params.OperationalViolations, operationalViolations)},
 	)
+}
+
+func ValidateScanResponseFailBuild(t *testing.T, severity string, content []services.ScanResponse) {
+	for _, result := range content {
+		for _, violation := range result.Violations {
+			if violation.Severity == severity {
+				assert.True(t, violation.FailBuild, "FailBuild field is true")
+				return
+			}
+		}
+	}
+	assert.Fail(t, "fail_build field not found in the scan responses")
 }
 
 func ValidateScanResponses(t *testing.T, exactMatch bool, expected, actual []services.ScanResponse) {

--- a/utils/validations/test_validation.go
+++ b/utils/validations/test_validation.go
@@ -26,6 +26,8 @@ type ValidationParams struct {
 	Actual interface{}
 	// If provided, the test will check if the content matches the expected results.
 	Expected interface{}
+	// If provided, will go through this list of point attribute - and validate they exists in the actual content.
+	ExistingProperties []string
 	// If provided, the test will check exact values and not only the minimum values / existence.
 	ExactResultsMatch bool
 	// Expected issues for each type to check if the content has the correct amount of issues.

--- a/utils/validations/test_validation.go
+++ b/utils/validations/test_validation.go
@@ -43,6 +43,10 @@ type ValidationParams struct {
 	Sast                  int
 	Iac                   int
 	Secrets               int
+	//If provided, the test will check if the fail_build field exists
+	FailBuild bool
+	//If FailBuild provided, the test will that check CVEs with this severity will fail the build
+	FailBuildCVESeverity string
 }
 
 // Validation allows to validate/assert a content with expected values.


### PR DESCRIPTION
- [ ] The pull request is targeting the `dev` branch.
- [ ] The code has been validated to compile successfully by running `go vet ./...`.
- [ ] The code has been formatted properly using `go fmt ./...`.
- [ ] All [static analysis checks](https://github.com/jfrog/jfrog-cli-security/actions/workflows/analysis.yml) passed.
- [ ] All [tests](https://github.com/jfrog/jfrog-cli-security/actions/workflows/test.yml) have passed. If this feature is not already covered by the tests, new tests have been added.
- [ ] Updated the [Contributing page](https://github.com/jfrog/jfrog-cli-security/blob/main/CONTRIBUTING.md) / [ReadMe page](https://github.com/jfrog/jfrog-cli-security/blob/main/README.md) / [CI Workflow files](https://github.com/jfrog/jfrog-cli-security/tree/main/.github/workflows) if needed.
- [ ] All changes are detailed at the description. if not already covered at [JFrog Documentation](https://github.com/jfrog/documentation), new documentation have been added.

-----

As part of internal services migration of XSC into Xray - the field `fail_build` wasn't returning in the response from Xray - and didn't fail the run - even if it did create a violation according to the defined policies.

The fix itself happened on **Xray v3.111** - and we wanted to add a test for audit to run against it as well in JFrog-CLI