### PR TITLE
Pass Technology of SCA scan

### DIFF
--- a/commands/audit/sca/common.go
+++ b/commands/audit/sca/common.go
@@ -50,10 +50,14 @@ func RunXrayDependenciesTreeScanGraph(scanGraphParams *scangraph.ScanGraphParams
 		return
 	}
 	for i := range scanResults.Vulnerabilities {
-		scanResults.Vulnerabilities[i].Technology = technology.String()
+		if scanResults.Vulnerabilities[i].Technology == "" {
+			scanResults.Vulnerabilities[i].Technology = technology.String()
+		}
 	}
 	for i := range scanResults.Violations {
-		scanResults.Violations[i].Technology = technology.String()
+		if scanResults.Violations[i].Technology == "" {
+			scanResults.Violations[i].Technology = technology.String()
+		}
 	}
 	results = append(results, *scanResults)
 	return

--- a/commands/audit/scarunner.go
+++ b/commands/audit/scarunner.go
@@ -161,6 +161,7 @@ func runScaWithTech(tech techutils.Technology, params *AuditParams, serverDetail
 	scanGraphParams := scangraph.NewScanGraphParams().
 		SetServerDetails(serverDetails).
 		SetXrayGraphScanParams(xrayScanGraphParams).
+		SetTechnology(tech).
 		SetFixableOnly(params.fixableOnly).
 		SetSeverityLevel(params.minSeverityFilter.String())
 


### PR DESCRIPTION
- [ ] The pull request is targeting the `dev` branch.
- [ ] The code has been validated to compile successfully by running `go vet ./...`.
- [ ] The code has been formatted properly using `go fmt ./...`.
- [ ] All [static analysis checks](https://github.com/jfrog/jfrog-cli-security/actions/workflows/analysis.yml) passed.
- [ ] All [tests](https://github.com/jfrog/jfrog-cli-security/actions/workflows/test.yml) have passed. If this feature is not already covered by the tests, new tests have been added.
- [ ] Updated the [Contributing page](https://github.com/jfrog/jfrog-cli-security/blob/main/CONTRIBUTING.md) / [ReadMe page](https://github.com/jfrog/jfrog-cli-security/blob/main/README.md) / [CI Workflow files](https://github.com/jfrog/jfrog-cli-security/tree/main/.github/workflows) if needed.
- [ ] All changes are detailed at the description. if not already covered at [JFrog Documentation](https://github.com/jfrog/documentation), new documentation have been added.

-----

We were overriding the technology to empty value, not showing in display since the actual technology was not passed.
