### PR TITLE
Don't download AM if JAS not requested

### DIFF
--- a/commands/audit/audit.go
+++ b/commands/audit/audit.go
@@ -270,6 +270,10 @@ func RunJasScans(auditParallelRunner *utils.SecurityParallelRunner, auditParams 
 		log.Info("Not entitled for JAS, skipping advance security scans...")
 		return
 	}
+	if !utils.IsJASRequested(scanResults.CmdType, auditParams.ScansToPerform()...) {
+		log.Debug("JAS scans were not requested, skipping advance security scans...")
+		return
+	}
 	serverDetails, err := auditParams.ServerDetails()
 	if err != nil {
 		generalError = fmt.Errorf("failed to get server details: %s", err.Error())

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -93,6 +93,13 @@ func IsScanRequested(cmdType CommandType, subScan SubScanType, requestedScans ..
 	return len(requestedScans) == 0 || slices.Contains(requestedScans, subScan)
 }
 
+func IsJASRequested(cmdType CommandType, requestedScans ...SubScanType) bool {
+	return IsScanRequested(cmdType, ContextualAnalysisScan, requestedScans...) ||
+		IsScanRequested(cmdType, SecretsScan, requestedScans...) ||
+		IsScanRequested(cmdType, IacScan, requestedScans...) ||
+		IsScanRequested(cmdType, SastScan, requestedScans...)
+}
+
 func GetScanFindingsLog(scanType SubScanType, vulnerabilitiesCount, violationsCount, threadId int) string {
 	threadPrefix := ""
 	if threadId >= 0 {


### PR DESCRIPTION
- [ ] The pull request is targeting the `dev` branch.
- [ ] The code has been validated to compile successfully by running `go vet ./...`.
- [ ] The code has been formatted properly using `go fmt ./...`.
- [ ] All [static analysis checks](https://github.com/jfrog/jfrog-cli-security/actions/workflows/analysis.yml) passed.
- [ ] All [tests](https://github.com/jfrog/jfrog-cli-security/actions/workflows/test.yml) have passed. If this feature is not already covered by the tests, new tests have been added.
- [ ] Updated the [Contributing page](https://github.com/jfrog/jfrog-cli-security/blob/main/CONTRIBUTING.md) / [ReadMe page](https://github.com/jfrog/jfrog-cli-security/blob/main/README.md) / [CI Workflow files](https://github.com/jfrog/jfrog-cli-security/tree/main/.github/workflows) if needed.
- [ ] All changes are detailed at the description. if not already covered at [JFrog Documentation](https://github.com/jfrog/documentation), new documentation have been added.

-----

Don't download AM if only `SCA` scan is requested.

Before:
![image](https://github.com/user-attachments/assets/e5d41087-3a4e-4eb3-8f6f-66dd553527b2)


After:
![image](https://github.com/user-attachments/assets/58a00528-e3ee-48d4-9a61-875f086ce078)
![image](https://github.com/user-attachments/assets/0c53bf3a-2ec7-4ff2-ab22-dad9fd0856f7)


