### PR TITLE
Send filename to xray on sbom-enrich api

### DIFF
--- a/commands/enrich/enrich.go
+++ b/commands/enrich/enrich.go
@@ -84,7 +84,7 @@ func AppendVulnsToJson(cmdResults *results.SecurityCommandResults) error {
 	}
 	var vulnerabilities []map[string]string
 	xrayResults := cmdResults.GetScaScansXrayResults()
-	if xrayResults == nil || len(xrayResults) == 0 {
+	if len(xrayResults) == 0 {
 		return fmt.Errorf("xray scan results are empty")
 	} else if len(xrayResults) > 1 {
 		log.Warn("Received %d results, parsing only first result", len(xrayResults))
@@ -109,7 +109,7 @@ func AppendVulnsToXML(cmdResults *results.SecurityCommandResults) error {
 	destination := result.FindElements("//bom")[0]
 	xrayResults := cmdResults.GetScaScansXrayResults()
 	if len(xrayResults) == 0 {
-		return fmt.Errorf("failed while getting sca scan from xray: %s", err.Error())
+		return fmt.Errorf("xray scan results are empty")
 	} else if len(xrayResults) > 1 {
 		log.Warn("Received %d results, parsing only first result", len(xrayResults))
 	}

--- a/commands/enrich/enrich.go
+++ b/commands/enrich/enrich.go
@@ -8,7 +8,6 @@ import (
 	"github.com/jfrog/jfrog-client-go/utils/errorutils"
 	"os"
 	"os/exec"
-	"path"
 	"path/filepath"
 
 	"github.com/beevik/etree"
@@ -205,9 +204,6 @@ func (enrichCmd *EnrichCommand) Run() (err error) {
 			return
 		}
 	}
-	if err != nil {
-		return err
-	}
 	log.Info("Enrich process completed successfully.")
 	return nil
 }
@@ -263,8 +259,7 @@ func (enrichCmd *EnrichCommand) createIndexerHandlerFunc(indexedFileProducer par
 				if err != nil {
 					return targetResults.AddTargetError(fmt.Errorf("%s failed to create Xray service manager: %s", logPrefix, err.Error()), false)
 				}
-				rootPath := path.Join("cli", filePath)
-				scanResults, err := enrichgraph.RunImportGraphAndGetResults(importGraphParams, xrayManager, rootPath)
+				scanResults, err := enrichgraph.RunImportGraphAndGetResults(importGraphParams, xrayManager, filepath.Base(filePath))
 				if err != nil {
 					return targetResults.AddTargetError(fmt.Errorf("%s failed to import graph: %s", logPrefix, err.Error()), false)
 				}

--- a/commands/enrich/enrich.go
+++ b/commands/enrich/enrich.go
@@ -5,8 +5,10 @@ import (
 	"errors"
 	"fmt"
 	"github.com/jfrog/jfrog-cli-security/utils/results/output"
+	"github.com/jfrog/jfrog-client-go/utils/errorutils"
 	"os"
 	"os/exec"
+	"path"
 	"path/filepath"
 
 	"github.com/beevik/etree"
@@ -22,7 +24,6 @@ import (
 	"github.com/jfrog/jfrog-cli-security/utils/xray"
 	"github.com/jfrog/jfrog-client-go/artifactory/services/fspatterns"
 	clientutils "github.com/jfrog/jfrog-client-go/utils"
-	"github.com/jfrog/jfrog-client-go/utils/errorutils"
 	ioUtils "github.com/jfrog/jfrog-client-go/utils/io"
 	"github.com/jfrog/jfrog-client-go/utils/io/fileutils"
 	"github.com/jfrog/jfrog-client-go/utils/log"
@@ -83,8 +84,8 @@ func AppendVulnsToJson(cmdResults *results.SecurityCommandResults) error {
 	}
 	var vulnerabilities []map[string]string
 	xrayResults := cmdResults.GetScaScansXrayResults()
-	if len(xrayResults) == 0 {
-		return fmt.Errorf("failed while getting sca scan from xray: %s", err.Error())
+	if xrayResults == nil || len(xrayResults) == 0 {
+		return fmt.Errorf("xray scan results are empty")
 	} else if len(xrayResults) > 1 {
 		log.Warn("Received %d results, parsing only first result", len(xrayResults))
 	}
@@ -187,6 +188,10 @@ func (enrichCmd *EnrichCommand) Run() (err error) {
 		scanResults.GeneralError = errors.Join(scanResults.GeneralError, fileCollectingErr)
 	}
 
+	if scanResults.GetErrors() != nil {
+		return errorutils.CheckError(scanResults.GetErrors())
+	}
+
 	isXml, err := isXML(scanResults.Targets)
 	if err != nil {
 		return
@@ -200,12 +205,8 @@ func (enrichCmd *EnrichCommand) Run() (err error) {
 			return
 		}
 	}
-
 	if err != nil {
 		return err
-	}
-	if scanResults.GetErrors() != nil {
-		return errorutils.CheckError(scanResults.GetErrors())
 	}
 	log.Info("Enrich process completed successfully.")
 	return nil
@@ -262,7 +263,8 @@ func (enrichCmd *EnrichCommand) createIndexerHandlerFunc(indexedFileProducer par
 				if err != nil {
 					return targetResults.AddTargetError(fmt.Errorf("%s failed to create Xray service manager: %s", logPrefix, err.Error()), false)
 				}
-				scanResults, err := enrichgraph.RunImportGraphAndGetResults(importGraphParams, xrayManager)
+				rootPath := path.Join("cli", filePath)
+				scanResults, err := enrichgraph.RunImportGraphAndGetResults(importGraphParams, xrayManager, rootPath)
 				if err != nil {
 					return targetResults.AddTargetError(fmt.Errorf("%s failed to import graph: %s", logPrefix, err.Error()), false)
 				}

--- a/commands/enrich/enrichgraph/enrichgraph.go
+++ b/commands/enrich/enrichgraph/enrichgraph.go
@@ -9,8 +9,8 @@ const (
 	EnrichMinimumVersionXray = "3.101.3"
 )
 
-func RunImportGraphAndGetResults(params *EnrichGraphParams, xrayManager *xray.XrayServicesManager) (*services.ScanResponse, error) {
-	scanId, err := xrayManager.ImportGraph(*params.xrayGraphImportParams)
+func RunImportGraphAndGetResults(params *EnrichGraphParams, xrayManager *xray.XrayServicesManager, rootPath string) (*services.ScanResponse, error) {
+	scanId, err := xrayManager.ImportGraph(*params.xrayGraphImportParams, rootPath)
 	if err != nil {
 		return nil, err
 	}

--- a/go.mod
+++ b/go.mod
@@ -112,7 +112,7 @@ require (
 	gopkg.in/warnings.v0 v0.1.2 // indirect
 )
 
-replace github.com/jfrog/jfrog-client-go => github.com/barv-jfrog/jfrog-client-go v0.0.0-20250121144329-59d97db9ffdf
+replace github.com/jfrog/jfrog-client-go => github.com/jfrog/jfrog-client-go v1.28.1-0.20250126110945-81abbdde452f
 
 // replace github.com/jfrog/jfrog-cli-core/v2 => github.com/jfrog/jfrog-cli-core/v2 dev
 

--- a/go.mod
+++ b/go.mod
@@ -112,7 +112,7 @@ require (
 	gopkg.in/warnings.v0 v0.1.2 // indirect
 )
 
-// replace github.com/jfrog/jfrog-client-go => github.com/jfrog/jfrog-client-go dev
+replace github.com/jfrog/jfrog-client-go => github.com/barv-jfrog/jfrog-client-go v0.0.0-20250121144329-59d97db9ffdf
 
 // replace github.com/jfrog/jfrog-cli-core/v2 => github.com/jfrog/jfrog-cli-core/v2 dev
 

--- a/go.sum
+++ b/go.sum
@@ -22,6 +22,8 @@ github.com/anmitsu/go-shlex v0.0.0-20200514113438-38f4b401e2be/go.mod h1:ySMOLuW
 github.com/apparentlymart/go-textseg/v13 v13.0.0/go.mod h1:ZK2fH7c4NqDTLtiYLvIkEghdlcqw7yxLeM89kiTRPUo=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPdPJAN/hZIm0C4OItdklCFmMRWYpio=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
+github.com/barv-jfrog/jfrog-client-go v0.0.0-20250121144329-59d97db9ffdf h1:MwTzvBeX5xHmyXYMFx5qSbhdC3Uu7BJyjLEDxL634gQ=
+github.com/barv-jfrog/jfrog-client-go v0.0.0-20250121144329-59d97db9ffdf/go.mod h1:ohIfKpMBCQsE9kunrKQ1wvoExpqsPLaluRFO186B5EM=
 github.com/beevik/etree v1.4.0 h1:oz1UedHRepuY3p4N5OjE0nK1WLCqtzHf25bxplKOHLs=
 github.com/beevik/etree v1.4.0/go.mod h1:cyWiXwGoasx60gHvtnEh5x8+uIjUVnjWqBvEnhnqKDA=
 github.com/bradleyjkemp/cupaloy/v2 v2.8.0 h1:any4BmKE+jGIaMpnU8YgH/I2LPiLBufr6oMMlVBbn9M=
@@ -129,8 +131,6 @@ github.com/jfrog/jfrog-apps-config v1.0.1 h1:mtv6k7g8A8BVhlHGlSveapqf4mJfonwvXYL
 github.com/jfrog/jfrog-apps-config v1.0.1/go.mod h1:8AIIr1oY9JuH5dylz2S6f8Ym2MaadPLR6noCBO4C22w=
 github.com/jfrog/jfrog-cli-core/v2 v2.57.7 h1:2cZS9C5jBYpyCF4PoUzvGCnwFA7CsvG6jszCj1I3tsg=
 github.com/jfrog/jfrog-cli-core/v2 v2.57.7/go.mod h1:ueB6LtU+gW7/hTyfKyka/BHi52oo5lEH46RodTly1PU=
-github.com/jfrog/jfrog-client-go v1.49.1 h1:AdJ+x+BSka3pCVDu6MCEvojwOmXvy1Q5S0dILvpfoDw=
-github.com/jfrog/jfrog-client-go v1.49.1/go.mod h1:ohIfKpMBCQsE9kunrKQ1wvoExpqsPLaluRFO186B5EM=
 github.com/k0kubun/colorstring v0.0.0-20150214042306-9440f1994b88/go.mod h1:3w7q1U84EfirKl04SVQ/s7nPm1ZPhiXd34z40TNz36k=
 github.com/k0kubun/pp v3.0.1+incompatible/go.mod h1:GWse8YhT0p8pT4ir3ZgBbfZild3tgzSScAn6HmfYukg=
 github.com/kevinburke/ssh_config v1.2.0 h1:x584FjTGwHzMwvHx18PXxbBVzfnxogHaAReU4gf13a4=

--- a/go.sum
+++ b/go.sum
@@ -22,8 +22,6 @@ github.com/anmitsu/go-shlex v0.0.0-20200514113438-38f4b401e2be/go.mod h1:ySMOLuW
 github.com/apparentlymart/go-textseg/v13 v13.0.0/go.mod h1:ZK2fH7c4NqDTLtiYLvIkEghdlcqw7yxLeM89kiTRPUo=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPdPJAN/hZIm0C4OItdklCFmMRWYpio=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
-github.com/barv-jfrog/jfrog-client-go v0.0.0-20250121144329-59d97db9ffdf h1:MwTzvBeX5xHmyXYMFx5qSbhdC3Uu7BJyjLEDxL634gQ=
-github.com/barv-jfrog/jfrog-client-go v0.0.0-20250121144329-59d97db9ffdf/go.mod h1:ohIfKpMBCQsE9kunrKQ1wvoExpqsPLaluRFO186B5EM=
 github.com/beevik/etree v1.4.0 h1:oz1UedHRepuY3p4N5OjE0nK1WLCqtzHf25bxplKOHLs=
 github.com/beevik/etree v1.4.0/go.mod h1:cyWiXwGoasx60gHvtnEh5x8+uIjUVnjWqBvEnhnqKDA=
 github.com/bradleyjkemp/cupaloy/v2 v2.8.0 h1:any4BmKE+jGIaMpnU8YgH/I2LPiLBufr6oMMlVBbn9M=
@@ -131,6 +129,8 @@ github.com/jfrog/jfrog-apps-config v1.0.1 h1:mtv6k7g8A8BVhlHGlSveapqf4mJfonwvXYL
 github.com/jfrog/jfrog-apps-config v1.0.1/go.mod h1:8AIIr1oY9JuH5dylz2S6f8Ym2MaadPLR6noCBO4C22w=
 github.com/jfrog/jfrog-cli-core/v2 v2.57.7 h1:2cZS9C5jBYpyCF4PoUzvGCnwFA7CsvG6jszCj1I3tsg=
 github.com/jfrog/jfrog-cli-core/v2 v2.57.7/go.mod h1:ueB6LtU+gW7/hTyfKyka/BHi52oo5lEH46RodTly1PU=
+github.com/jfrog/jfrog-client-go v1.28.1-0.20250126110945-81abbdde452f h1:2IIy3XfvmEp5zJgakKZiyKGGeVyDsouwYmtD+4QiVd4=
+github.com/jfrog/jfrog-client-go v1.28.1-0.20250126110945-81abbdde452f/go.mod h1:ohIfKpMBCQsE9kunrKQ1wvoExpqsPLaluRFO186B5EM=
 github.com/k0kubun/colorstring v0.0.0-20150214042306-9440f1994b88/go.mod h1:3w7q1U84EfirKl04SVQ/s7nPm1ZPhiXd34z40TNz36k=
 github.com/k0kubun/pp v3.0.1+incompatible/go.mod h1:GWse8YhT0p8pT4ir3ZgBbfZild3tgzSScAn6HmfYukg=
 github.com/kevinburke/ssh_config v1.2.0 h1:x584FjTGwHzMwvHx18PXxbBVzfnxogHaAReU4gf13a4=


### PR DESCRIPTION
- [ ] The pull request is targeting the `dev` branch.
- [ ] The code has been validated to compile successfully by running `go vet ./...`.
- [ ] The code has been formatted properly using `go fmt ./...`.
- [ ] All [static analysis checks](https://github.com/jfrog/jfrog-cli-security/actions/workflows/analysis.yml) passed.
- [ ] All [tests](https://github.com/jfrog/jfrog-cli-security/actions/workflows/test.yml) have passed. If this feature is not already covered by the tests, new tests have been added.
- [ ] Updated the [Contributing page](https://github.com/jfrog/jfrog-cli-security/blob/main/CONTRIBUTING.md) / [ReadMe page](https://github.com/jfrog/jfrog-cli-security/blob/main/README.md) / [CI Workflow files](https://github.com/jfrog/jfrog-cli-security/tree/main/.github/workflows) if needed.
- [ ] All changes are detailed at the description. if not already covered at [JFrog Documentation](https://github.com/jfrog/documentation), new documentation have been added.

-----

Depends on:
* https://github.com/jfrog/jfrog-client-go/pull/1078

----- 
Description:
sbom-enrich command should also send the file_name being enriched to xray in order to support a recent feature of GraphScan which requires Paths.