### PR TITLE
Add min version check for gitRepoKey in analytics finalized event

### DIFF
--- a/git_test.go
+++ b/git_test.go
@@ -11,6 +11,7 @@ import (
 	securityTests "github.com/jfrog/jfrog-cli-security/tests"
 	securityTestUtils "github.com/jfrog/jfrog-cli-security/tests/utils"
 	"github.com/jfrog/jfrog-cli-security/tests/utils/integration"
+	securityUtils "github.com/jfrog/jfrog-cli-security/utils"
 	"github.com/jfrog/jfrog-cli-security/utils/results"
 	"github.com/jfrog/jfrog-cli-security/utils/validations"
 	"github.com/jfrog/jfrog-cli-security/utils/xray/scangraph"
@@ -161,7 +162,7 @@ func TestGitAuditJasViolationsProjectKeySimpleJson(t *testing.T) {
 }
 
 func TestXrayAuditJasSkipNotApplicableCvesViolations(t *testing.T) {
-	xrayVersion, xscVersion, testCleanUp := integration.InitGitTest(t, services.MinXrayVersionGitRepoKey)
+	xrayVersion, xscVersion, testCleanUp := integration.InitGitTest(t, securityUtils.GitRepoKeyAnalyticsMinVersion)
 	defer testCleanUp()
 
 	projectPath := filepath.Join(filepath.FromSlash(securityTests.GetTestResourcesPath()), "git", "projects", "issues")

--- a/git_test.go
+++ b/git_test.go
@@ -102,7 +102,7 @@ func TestGitAuditViolationsWithIgnoreRule(t *testing.T) {
 		auditCommandTestParams{Format: string(format.SimpleJson), WithLicense: true, WithVuln: true},
 		xrayVersion, xscVersion, "",
 		validations.ValidationParams{
-			Total: &validations.TotalCount{Licenses: 3, Violations: 16, Vulnerabilities: 16},
+			Total: &validations.TotalCount{Licenses: 3, Violations: 12, Vulnerabilities: 12},
 			// Check that we have at least one violation for each scan type. (IAC is not supported yet)
 			Violations: &validations.ViolationCount{ValidateScan: &validations.ScanCount{Sca: 1, Sast: 1, Secrets: 1}},
 		},
@@ -153,7 +153,7 @@ func TestGitAuditJasViolationsProjectKeySimpleJson(t *testing.T) {
 		auditCommandTestParams{Format: string(format.SimpleJson), ProjectKey: *securityTests.JfrogTestProjectKey},
 		xrayVersion, xscVersion, results.NewFailBuildError().Error(),
 		validations.ValidationParams{
-			Total: &validations.TotalCount{Violations: 16},
+			Total: &validations.TotalCount{Violations: 12},
 			// Check that we have at least one violation for each scan type. (IAC is not supported yet)
 			Violations: &validations.ViolationCount{ValidateScan: &validations.ScanCount{Sca: 1, Sast: 1, Secrets: 1}},
 		},

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -27,9 +27,10 @@ const (
 	NodeModulesPattern = "**/*node_modules*/**"
 	JfMsiEnvVariable   = "JF_MSI"
 
-	BaseDocumentationURL   = "https://docs.jfrog-applications.jfrog.io/jfrog-security-features/"
-	JasInfoURL             = "https://jfrog.com/xray/"
-	EntitlementsMinVersion = "3.66.5"
+	BaseDocumentationURL          = "https://docs.jfrog-applications.jfrog.io/jfrog-security-features/"
+	JasInfoURL                    = "https://jfrog.com/xray/"
+	EntitlementsMinVersion        = "3.66.5"
+	GitRepoKeyAnalyticsMinVersion = "3.114.0"
 
 	JfrogExternalRunIdEnv   = "JFROG_CLI_USAGE_RUN_ID"
 	JfrogExternalJobIdEnv   = "JFROG_CLI_USAGE_JOB_ID"

--- a/utils/xsc/analyticsmetrics.go
+++ b/utils/xsc/analyticsmetrics.go
@@ -2,9 +2,10 @@ package xsc
 
 import (
 	"fmt"
-	"github.com/jfrog/jfrog-cli-security/utils"
 	"strings"
 	"time"
+
+	"github.com/jfrog/jfrog-cli-security/utils"
 
 	"github.com/jfrog/jfrog-cli-core/v2/utils/config"
 	"github.com/jfrog/jfrog-cli-core/v2/utils/coreutils"
@@ -100,10 +101,8 @@ func CreateFinalizedEvent(xrayVersion, multiScanId string, startTime time.Time, 
 	}
 
 	var gitRepoUrlKey string
-	if resultsContext != nil && resultsContext.GitRepoHttpsCloneUrl != "" {
-		if e := clientutils.ValidateMinimumVersion(clientutils.Xray, xrayVersion, utils.GitRepoKeyAnalyticsMinVersion); e == nil {
-			gitRepoUrlKey = utils.GetGitRepoUrlKey(resultsContext.GitRepoHttpsCloneUrl)
-		}
+	if resultsContext != nil && resultsContext.GitRepoHttpsCloneUrl != "" && checkVersionForGitRepoKeyAnalytics(xrayVersion) {
+		gitRepoUrlKey = utils.GetGitRepoUrlKey(resultsContext.GitRepoHttpsCloneUrl)
 	}
 
 	return xscservices.XscAnalyticsGeneralEventFinalize{
@@ -115,6 +114,17 @@ func CreateFinalizedEvent(xrayVersion, multiScanId string, startTime time.Time, 
 			TotalScanDuration: totalDuration.String(),
 		},
 	}
+}
+
+func checkVersionForGitRepoKeyAnalytics(xrayVersion string) bool {
+	// TODO: Private patch, remove when not needed anymore
+	if xrayVersion == "3.111.13" {
+		return true
+	}
+	if e := clientutils.ValidateMinimumVersion(clientutils.Xray, xrayVersion, utils.GitRepoKeyAnalyticsMinVersion); e == nil {
+		return true
+	}
+	return false
 }
 
 func createFinalizedEvent(cmdResults *results.SecurityCommandResults) xscservices.XscAnalyticsGeneralEventFinalize {

--- a/utils/xsc/analyticsmetrics_test.go
+++ b/utils/xsc/analyticsmetrics_test.go
@@ -203,7 +203,7 @@ func TestCreateFinalizedEvent(t *testing.T) {
 func getDummyContentForGeneralEvent(withJas, withErr, withResultContext bool) *results.SecurityCommandResults {
 	vulnerabilities := []services.Vulnerability{{IssueId: "XRAY-ID", Severity: "medium", Cves: []services.Cve{{Id: "CVE-123"}}, Components: map[string]services.Component{"issueId_2_direct_dependency": {}}}}
 
-	cmdResults := results.NewCommandResults(utils.SourceCode).SetEntitledForJas(true).SetSecretValidation(true)
+	cmdResults := results.NewCommandResults(utils.SourceCode).SetEntitledForJas(true).SetSecretValidation(true).SetXrayVersion(utils.GitRepoKeyAnalyticsMinVersion)
 	cmdResults.StartTime = time.Now()
 	cmdResults.MultiScanId = "msi"
 	scanResults := cmdResults.NewScanResults(results.ScanTarget{Target: "target"})


### PR DESCRIPTION
- [ ] The pull request is targeting the `dev` branch.
- [ ] The code has been validated to compile successfully by running `go vet ./...`.
- [ ] The code has been formatted properly using `go fmt ./...`.
- [ ] All [static analysis checks](https://github.com/jfrog/jfrog-cli-security/actions/workflows/analysis.yml) passed.
- [ ] All [tests](https://github.com/jfrog/jfrog-cli-security/actions/workflows/test.yml) have passed. If this feature is not already covered by the tests, new tests have been added.
- [ ] Updated the [Contributing page](https://github.com/jfrog/jfrog-cli-security/blob/main/CONTRIBUTING.md) / [ReadMe page](https://github.com/jfrog/jfrog-cli-security/blob/main/README.md) / [CI Workflow files](https://github.com/jfrog/jfrog-cli-security/tree/main/.github/workflows) if needed.
- [ ] All changes are detailed at the description. if not already covered at [JFrog Documentation](https://github.com/jfrog/documentation), new documentation have been added.

-----

Check Xray version before passing the new attributes to analytics, only pass it if xray has `3.114.0` min version

Fixes:
![image](https://github.com/user-attachments/assets/35580cda-c9b4-4489-9e68-41d8a975048d)
