### PR TITLE
Add skipAutoInstall for Pip and Poetry package managers

### DIFF
--- a/commands/audit/sca/python/python.go
+++ b/commands/audit/sca/python/python.go
@@ -34,8 +34,8 @@ const (
 	CurationPipMinimumVersion = "23.0.0"
 )
 
-func BuildDependencyTree(params utils.AuditParams) (dependencyTree []*clientutils.GraphNode, uniqueDeps []string, downloadUrls map[string]string, err error) {
-	dependenciesGraph, directDependenciesList, pipUrls, errGetTree := getDependencies(params)
+func BuildDependencyTree(params utils.AuditParams, technology techutils.Technology) (dependencyTree []*clientutils.GraphNode, uniqueDeps []string, downloadUrls map[string]string, err error) {
+	dependenciesGraph, directDependenciesList, pipUrls, errGetTree := getDependencies(params, technology)
 	if errGetTree != nil {
 		err = errGetTree
 		return
@@ -60,7 +60,7 @@ func BuildDependencyTree(params utils.AuditParams) (dependencyTree []*clientutil
 	return
 }
 
-func getDependencies(params utils.AuditParams) (dependenciesGraph map[string][]string, directDependencies []string, pipUrls map[string]string, err error) {
+func getDependencies(params utils.AuditParams, technology techutils.Technology) (dependenciesGraph map[string][]string, directDependencies []string, pipUrls map[string]string, err error) {
 	wd, err := os.Getwd()
 	if errorutils.CheckError(err) != nil {
 		return
@@ -91,8 +91,8 @@ func getDependencies(params utils.AuditParams) (dependenciesGraph map[string][]s
 		return
 	}
 
-	pythonTool := pythonutils.PythonTool(params.Technologies()[0])
-	if !params.SkipAutoInstall() {
+	pythonTool := pythonutils.PythonTool(technology)
+	if technology == techutils.Pipenv || !params.SkipAutoInstall() {
 		var restoreEnv func() error
 		restoreEnv, err = runPythonInstall(params, pythonTool)
 		defer func() {

--- a/commands/audit/scarunner.go
+++ b/commands/audit/scarunner.go
@@ -255,9 +255,8 @@ func GetTechDependencyTree(params xrayutils.AuditParams, artifactoryServerDetail
 	case techutils.Go:
 		depTreeResult.FullDepTrees, uniqueDeps, err = _go.BuildDependencyTree(params)
 	case techutils.Pipenv, techutils.Pip, techutils.Poetry:
-		params.AddTechnologyIfNotExist(tech.String())
 		depTreeResult.FullDepTrees, uniqueDeps,
-			depTreeResult.DownloadUrls, err = python.BuildDependencyTree(params)
+			depTreeResult.DownloadUrls, err = python.BuildDependencyTree(params, tech)
 	case techutils.Nuget:
 		depTreeResult.FullDepTrees, uniqueDeps, err = nuget.BuildDependencyTree(params)
 	case techutils.Cocoapods:

--- a/utils/auditbasicparams.go
+++ b/utils/auditbasicparams.go
@@ -21,7 +21,6 @@ type AuditParams interface {
 	SetInsecureTls(insecureTls bool) *AuditBasicParams
 	Technologies() []string
 	SetTechnologies(technologies []string) *AuditBasicParams
-	AddTechnologyIfNotExist(technology string) *AuditBasicParams
 	Progress() ioUtils.ProgressMgr
 	SetProgress(progress ioUtils.ProgressMgr)
 	Args() []string
@@ -174,16 +173,6 @@ func (abp *AuditBasicParams) Technologies() []string {
 
 func (abp *AuditBasicParams) SetTechnologies(technologies []string) *AuditBasicParams {
 	abp.technologies = technologies
-	return abp
-}
-
-func (abp *AuditBasicParams) AddTechnologyIfNotExist(technology string) *AuditBasicParams {
-	for _, tech := range abp.technologies {
-		if tech == technology {
-			return abp
-		}
-	}
-	abp.technologies = append(abp.technologies, technology)
 	return abp
 }
 


### PR DESCRIPTION
- [x] The pull request is targeting the `dev` branch.
- [x] The code has been validated to compile successfully by running `go vet ./...`.
- [x] The code has been formatted properly using `go fmt ./...`.
- [x] All [static analysis checks](https://github.com/jfrog/jfrog-cli-security/actions/workflows/analysis.yml) passed.
- [ ] All [tests](https://github.com/jfrog/jfrog-cli-security/actions/workflows/test.yml) have passed. If this feature is not already covered by the tests, new tests have been added.
- [x] Updated the [Contributing page](https://github.com/jfrog/jfrog-cli-security/blob/main/CONTRIBUTING.md) / [ReadMe page](https://github.com/jfrog/jfrog-cli-security/blob/main/README.md) / [CI Workflow files](https://github.com/jfrog/jfrog-cli-security/tree/main/.github/workflows) if needed.
- [x] All changes are detailed at the description. if not already covered at [JFrog Documentation](https://github.com/jfrog/documentation), new documentation have been added.

-----

This PR extends the SkipAutoInstall abilities into Pip and Poetry.
This allows to run audit scan (or any Frogbot flow) without running installation command during the process, and the resolved dependencies are the existing dependencies within the execution context (virtual env or global if possible).

**Note: In order to use this for the mentioned python package managers, an installation at the customer's end is required and also we must be in the context of the virtual env in which we installed the dependencies**