### PR TITLE
Add audit swift & cocoapods flags

### DIFF
--- a/cli/docs/flags.go
+++ b/cli/docs/flags.go
@@ -35,16 +35,18 @@ const (
 )
 
 const (
-	Mvn    = "mvn"
-	Gradle = "gradle"
-	Npm    = "npm"
-	Pnpm   = "pnpm"
-	Yarn   = "yarn"
-	Nuget  = "nuget"
-	Go     = "go"
-	Pip    = "pip"
-	Pipenv = "pipenv"
-	Poetry = "poetry"
+	Mvn       = "mvn"
+	Gradle    = "gradle"
+	Npm       = "npm"
+	Pnpm      = "pnpm"
+	Yarn      = "yarn"
+	Nuget     = "nuget"
+	Go        = "go"
+	Pip       = "pip"
+	Pipenv    = "pipenv"
+	Poetry    = "poetry"
+	Swift     = "swift"
+	Cocoapods = "cocoapods"
 )
 
 const (
@@ -159,7 +161,7 @@ var commandFlags = map[string][]string{
 	Audit: {
 		url, xrayUrl, user, password, accessToken, ServerId, InsecureTls, Project, Watches, RepoPath, Sbom, Licenses, OutputFormat, ExcludeTestDeps,
 		useWrapperAudit, DepType, RequirementsFile, Fail, ExtendedTable, WorkingDirs, ExclusionsAudit, Mvn, Gradle, Npm,
-		Pnpm, Yarn, Go, Nuget, Pip, Pipenv, Poetry, MinSeverity, FixableOnly, ThirdPartyContextualAnalysis, Threads,
+		Pnpm, Yarn, Go, Swift, Cocoapods, Nuget, Pip, Pipenv, Poetry, MinSeverity, FixableOnly, ThirdPartyContextualAnalysis, Threads,
 		Sca, Iac, Sast, Secrets, WithoutCA, ScanVuln, SecretValidation, OutputDir, SkipAutoInstall, AllowPartialResults, MaxTreeDepth,
 	},
 	GitAudit: {
@@ -267,6 +269,8 @@ var flagsMap = map[string]components.Flag{
 	Pipenv:       components.NewBoolFlag(Pipenv, "Set to true to request audit for a Pipenv project."),
 	Poetry:       components.NewBoolFlag(Poetry, "Set to true to request audit for a Poetry project."),
 	Go:           components.NewBoolFlag(Go, "Set to true to request audit for a Go project."),
+	Swift:        components.NewBoolFlag(Swift, "Set to true to request audit for a Swift project."),
+	Cocoapods:    components.NewBoolFlag(Cocoapods, "Set to true to request audit for a Cocoapods project."),
 	DepType:      components.NewStringFlag(DepType, "[npm] Defines npm dependencies type. Possible values are: all, devOnly and prodOnly."),
 	MaxTreeDepth: components.NewStringFlag(MaxTreeDepth, "[pnpm] Max depth of the generated dependencies tree for SCA scan.", components.WithStrDefaultValue("Infinity")),
 	ThirdPartyContextualAnalysis: components.NewBoolFlag(


### PR DESCRIPTION
- [ ] The pull request is targeting the `dev` branch.
- [ ] The code has been validated to compile successfully by running `go vet ./...`.
- [ ] The code has been formatted properly using `go fmt ./...`.
- [ ] All [static analysis checks](https://github.com/jfrog/jfrog-cli-security/actions/workflows/analysis.yml) passed.
- [ ] All [tests](https://github.com/jfrog/jfrog-cli-security/actions/workflows/test.yml) have passed. If this feature is not already covered by the tests, new tests have been added.
- [ ] Updated the [Contributing page](https://github.com/jfrog/jfrog-cli-security/blob/main/CONTRIBUTING.md) / [ReadMe page](https://github.com/jfrog/jfrog-cli-security/blob/main/README.md) / [CI Workflow files](https://github.com/jfrog/jfrog-cli-security/tree/main/.github/workflows) if needed.
- [ ] All changes are detailed at the description. if not already covered at [JFrog Documentation](https://github.com/jfrog/documentation), new documentation have been added.

-----

Adding new flags to force scan Swift or Cocoapods SCA:
* Swift: `--swift`
* Cocoapods: `--cocoapods`