### PR TITLE
Apply fail-build when violation context exists even with --vuln flag

### DIFF
--- a/commands/audit/audit.go
+++ b/commands/audit/audit.go
@@ -222,7 +222,6 @@ func ProcessResultsAndOutput(auditResults *results.SecurityCommandResults, outpu
 		return
 	}
 	// Only in case Xray's context was given (!auditCmd.IncludeVulnerabilities), and the user asked to fail the build accordingly, do so.
-	// TODO eran fix the failBuild condition here as well and fix all relevant tests accordingly (run in CI) - fixed
 	if failBuild && auditResults.HasViolationContext() && results.CheckIfFailBuild(auditResults.GetScaScansXrayResults()) {
 		err = results.NewFailBuildError()
 	}

--- a/commands/audit/audit.go
+++ b/commands/audit/audit.go
@@ -222,6 +222,7 @@ func ProcessResultsAndOutput(auditResults *results.SecurityCommandResults, outpu
 		return
 	}
 	// Only in case Xray's context was given (!auditCmd.IncludeVulnerabilities), and the user asked to fail the build accordingly, do so.
+	// TODO eran fix the failBuild condition here as well and fix all relevant tests accordingly (run in CI)
 	if failBuild && !auditResults.ResultContext.IncludeVulnerabilities && results.CheckIfFailBuild(auditResults.GetScaScansXrayResults()) {
 		err = results.NewFailBuildError()
 	}

--- a/commands/audit/audit.go
+++ b/commands/audit/audit.go
@@ -222,8 +222,8 @@ func ProcessResultsAndOutput(auditResults *results.SecurityCommandResults, outpu
 		return
 	}
 	// Only in case Xray's context was given (!auditCmd.IncludeVulnerabilities), and the user asked to fail the build accordingly, do so.
-	// TODO eran fix the failBuild condition here as well and fix all relevant tests accordingly (run in CI)
-	if failBuild && !auditResults.ResultContext.IncludeVulnerabilities && results.CheckIfFailBuild(auditResults.GetScaScansXrayResults()) {
+	// TODO eran fix the failBuild condition here as well and fix all relevant tests accordingly (run in CI) - fixed
+	if failBuild && auditResults.HasViolationContext() && results.CheckIfFailBuild(auditResults.GetScaScansXrayResults()) {
 		err = results.NewFailBuildError()
 	}
 	return

--- a/commands/scan/scan.go
+++ b/commands/scan/scan.go
@@ -269,8 +269,8 @@ func (scanCmd *ScanCommand) RunAndRecordResults(cmdType utils.CommandType, recor
 	if err = cmdResults.GetErrors(); err != nil {
 		return
 	}
-	// If violation context was proivded it means that context was provided, so we need to check for build violations.
-	// If user provided --fail=false, don't fail the build.
+	// We consider failing the build only when --fail=true. If user provided --fail=false, don't fail the build even when fail-build rules are applied.
+	// If violation context was provided, we need to all existing violations for fail-build rules.
 	if scanCmd.fail && scanCmd.resultsContext.HasViolationContext() {
 		if results.CheckIfFailBuild(cmdResults.GetScaScansXrayResults()) {
 			return results.NewFailBuildError()

--- a/commands/scan/scan.go
+++ b/commands/scan/scan.go
@@ -269,8 +269,8 @@ func (scanCmd *ScanCommand) RunAndRecordResults(cmdType utils.CommandType, recor
 	if err = cmdResults.GetErrors(); err != nil {
 		return
 	}
-	// We consider failing the build only when --fail=true. If user provided --fail=false, don't fail the build even when fail-build rules are applied.
-	// If violation context was provided, we need to all existing violations for fail-build rules.
+	// We consider failing the build only when --fail=true. If a user had provided --fail=false, we don't fail the build even when fail-build rules are applied.
+	// If violation context was provided, we need to check all existing violations for fail-build rules.
 	if scanCmd.fail && scanCmd.resultsContext.HasViolationContext() {
 		if results.CheckIfFailBuild(cmdResults.GetScaScansXrayResults()) {
 			return results.NewFailBuildError()

--- a/commands/scan/scan.go
+++ b/commands/scan/scan.go
@@ -269,8 +269,9 @@ func (scanCmd *ScanCommand) RunAndRecordResults(cmdType utils.CommandType, recor
 	if err = cmdResults.GetErrors(); err != nil {
 		return
 	}
+	// If violation context was proivded it means that context was provided, so we need to check for build violations.
 	// If user provided --fail=false, don't fail the build.
-	if scanCmd.fail {
+	if scanCmd.fail && scanCmd.resultsContext.HasViolationContext() {
 		if results.CheckIfFailBuild(cmdResults.GetScaScansXrayResults()) {
 			return results.NewFailBuildError()
 		}

--- a/commands/scan/scan.go
+++ b/commands/scan/scan.go
@@ -269,9 +269,8 @@ func (scanCmd *ScanCommand) RunAndRecordResults(cmdType utils.CommandType, recor
 	if err = cmdResults.GetErrors(); err != nil {
 		return
 	}
-	// If includeVulnerabilities is false it means that context was provided, so we need to check for build violations.
 	// If user provided --fail=false, don't fail the build.
-	if scanCmd.fail && !scanCmd.resultsContext.IncludeVulnerabilities {
+	if scanCmd.fail {
 		if results.CheckIfFailBuild(cmdResults.GetScaScansXrayResults()) {
 			return results.NewFailBuildError()
 		}

--- a/git_test.go
+++ b/git_test.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"github.com/jfrog/jfrog-cli-core/v2/utils/coreutils"
 	"path/filepath"
 	"testing"
 
@@ -89,9 +88,12 @@ func TestGitAuditSimpleJson(t *testing.T) {
 
 // TODO eran fix this flaky test - remove Ubuntu restriction in local
 func TestGitAuditViolationsWithIgnoreRule(t *testing.T) {
-	if !coreutils.IsLinux() {
-		t.Skip("Skipping test. This test only runs on Linux to avoid flaky tests when running in parallel tests.")
-	}
+	/*
+		if !coreutils.IsLinux() {
+			t.Skip("Skipping test. This test only runs on Linux to avoid flaky tests when running in parallel tests.")
+		}
+
+	*/
 	xrayVersion, xscVersion, testCleanUp := integration.InitGitTest(t, services.MinXrayVersionGitRepoKey)
 	defer testCleanUp()
 
@@ -106,7 +108,7 @@ func TestGitAuditViolationsWithIgnoreRule(t *testing.T) {
 	// Run the audit command with git repo and verify violations are reported to the platform.
 	createTestProjectRunGitAuditAndValidate(t, projectPath,
 		auditCommandTestParams{Format: string(format.SimpleJson), WithLicense: true, WithVuln: true},
-		xrayVersion, xscVersion, "",
+		xrayVersion, xscVersion, "One or more of the detected violations are configured to fail the build that including them",
 		validations.ValidationParams{
 			Total: &validations.TotalCount{Licenses: 3, Violations: 12, Vulnerabilities: 12},
 			// Check that we have at least one violation for each scan type. (IAC is not supported yet)

--- a/git_test.go
+++ b/git_test.go
@@ -1,13 +1,13 @@
 package main
 
 import (
+	"github.com/jfrog/jfrog-cli-core/v2/utils/coreutils"
 	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 
 	"github.com/jfrog/jfrog-cli-core/v2/common/format"
-	"github.com/jfrog/jfrog-cli-core/v2/utils/coreutils"
 	"github.com/jfrog/jfrog-cli-security/commands/git/contributors"
 	securityTests "github.com/jfrog/jfrog-cli-security/tests"
 	securityTestUtils "github.com/jfrog/jfrog-cli-security/tests/utils"
@@ -87,6 +87,7 @@ func TestGitAuditSimpleJson(t *testing.T) {
 	)
 }
 
+// TODO eran fix this flaky test - remove Ubuntu restriction in local
 func TestGitAuditViolationsWithIgnoreRule(t *testing.T) {
 	if !coreutils.IsLinux() {
 		t.Skip("Skipping test. This test only runs on Linux to avoid flaky tests when running in parallel tests.")

--- a/git_test.go
+++ b/git_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"github.com/jfrog/jfrog-cli-core/v2/utils/coreutils"
 	"path/filepath"
 	"testing"
 
@@ -86,14 +87,10 @@ func TestGitAuditSimpleJson(t *testing.T) {
 	)
 }
 
-// TODO eran fix this flaky test - remove Ubuntu restriction in local
 func TestGitAuditViolationsWithIgnoreRule(t *testing.T) {
-	/*
-		if !coreutils.IsLinux() {
-			t.Skip("Skipping test. This test only runs on Linux to avoid flaky tests when running in parallel tests.")
-		}
-
-	*/
+	if !coreutils.IsLinux() {
+		t.Skip("Skipping test. This test only runs on Linux to avoid flaky tests when running in parallel tests.")
+	}
 	xrayVersion, xscVersion, testCleanUp := integration.InitGitTest(t, services.MinXrayVersionGitRepoKey)
 	defer testCleanUp()
 


### PR DESCRIPTION
- [ ] The pull request is targeting the `dev` branch.
- [ ] The code has been validated to compile successfully by running `go vet ./...`.
- [ ] The code has been formatted properly using `go fmt ./...`.
- [ ] All [static analysis checks](https://github.com/jfrog/jfrog-cli-security/actions/workflows/analysis.yml) passed.
- [ ] All [tests](https://github.com/jfrog/jfrog-cli-security/actions/workflows/test.yml) have passed. If this feature is not already covered by the tests, new tests have been added.
- [ ] Updated the [Contributing page](https://github.com/jfrog/jfrog-cli-security/blob/main/CONTRIBUTING.md) / [ReadMe page](https://github.com/jfrog/jfrog-cli-security/blob/main/README.md) / [CI Workflow files](https://github.com/jfrog/jfrog-cli-security/tree/main/.github/workflows) if needed.
- [ ] All changes are detailed at the description. if not already covered at [JFrog Documentation](https://github.com/jfrog/documentation), new documentation have been added.

-----

This PR includes a bug fix for the following issue:
So far, when a user added --vuln flag we used to move to "vulnerabilities context", therefore ignoring fail build rules in discovered violations.
According to the documentation this flag means: "Set to true if you'd like to receive all vulnerabilities, regardless of the policy configured in Xray."
Therefore, this flag is expected to affect display ONLY and present vulnerabilities along with the violations when the flag is provided, but should not change any existing violations logic, meaning - if we have a FailBuild rule it should be applied even when the flag is provided with 'true' value

Known failing tests:
![Screenshot 2025-04-09 at 17 37 20](https://github.com/user-attachments/assets/0a7796a8-652a-41ea-bf8e-569866d8db99)
