### PR TITLE
Exclude patterns expansion

### DIFF
--- a/jas/common.go
+++ b/jas/common.go
@@ -352,11 +352,14 @@ func GetExcludePatterns(module jfrogappsconfig.Module, scanner *jfrogappsconfig.
 	// Adding exclusions from jfrog-apps-config IF no exclusions provided from other source (flags, env vars, config profile)
 	excludePatterns := module.ExcludePatterns
 	if scanner != nil {
+		log.Debug("Using scanner exclude patterns:", strings.Join(scanner.ExcludePatterns, ","))
 		excludePatterns = append(excludePatterns, scanner.ExcludePatterns...)
 	}
 	if len(excludePatterns) == 0 {
+		log.Debug("No exclude patterns provided, using default exclude patterns", strings.Join(utils.DefaultJasExcludePatterns, ","))
 		return utils.DefaultJasExcludePatterns
 	}
+	log.Debug("Using exclude patterns:", strings.Join(excludePatterns, ","))
 	return excludePatterns
 }
 
@@ -366,6 +369,11 @@ func GetExcludePatterns(module jfrogappsconfig.Module, scanner *jfrogappsconfig.
 func filterUniqueAndConvertToFilesExcludePatterns(excludePatterns []string) []string {
 	uniqueExcludePatterns := datastructures.MakeSet[string]()
 	for _, excludePattern := range excludePatterns {
+
+		// Add ignore for the pattern as-is, not only the pattern as a directory
+		uniqueExcludePatterns.Add(excludePattern)
+
+		// Avoid adding the pattern as a directory twice
 		if !strings.HasPrefix(excludePattern, "**/") {
 			excludePattern = "**/" + excludePattern
 		}

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -39,7 +39,7 @@ const (
 
 var (
 	// Exclude pattern for files.
-	DefaultJasExcludePatterns = []string{"**/.git/**", "**/*test*/**", "**/*venv*/**", NodeModulesPattern, "**/target/**", "**/dist/**"}
+	DefaultJasExcludePatterns = []string{"**/.git/**", "**/*test*/**", "**/*venv*/**", NodeModulesPattern, "**/target/**", "**/dist/**", "**test.go"}
 	// Exclude pattern for directories.
 	DefaultScaExcludePatterns = []string{"*.git*", "*node_modules*", "*target*", "*venv*", "*test*", "dist"}
 )


### PR DESCRIPTION
- [ ] The pull request is targeting the `dev` branch.
- [ ] The code has been validated to compile successfully by running `go vet ./...`.
- [ ] The code has been formatted properly using `go fmt ./...`.
- [ ] All [static analysis checks](https://github.com/jfrog/jfrog-cli-security/actions/workflows/analysis.yml) passed.
- [ ] All [tests](https://github.com/jfrog/jfrog-cli-security/actions/workflows/test.yml) have passed. If this feature is not already covered by the tests, new tests have been added.
- [ ] Updated the [Contributing page](https://github.com/jfrog/jfrog-cli-security/blob/main/CONTRIBUTING.md) / [ReadMe page](https://github.com/jfrog/jfrog-cli-security/blob/main/README.md) / [CI Workflow files](https://github.com/jfrog/jfrog-cli-security/tree/main/.github/workflows) if needed.
- [ ] All changes are detailed at the description. if not already covered at [JFrog Documentation](https://github.com/jfrog/documentation), new documentation have been added.

-----
As part of improving false positive results, we wish to ignore findings who shouldn't be scanned, as such:
1. We wish to add a possibility to ignore partial patterns, not only folder
2. Also - add `test.` to ignore the common cases in GO and JS/TS 