### PR TITLE
Add CVE attributes to simple json format

### DIFF
--- a/utils/formats/simplejsonapi.go
+++ b/utils/formats/simplejsonapi.go
@@ -138,11 +138,11 @@ type ComponentRow struct {
 
 type CveRow struct {
 	Id            string         `json:"id"`
-	CvssV2        string         `json:"cvssV2"`
-	CvssV2Vector  string         `json:"cvssV2Vector"`
-	CvssV3        string         `json:"cvssV3"`
-	CvssV3Vector  string         `json:"cvssV3Vector"`
-	Cwe		      []string       `json:"cwe,omitempty"`
+	CvssV2        string         `json:"cvssV2,omitempty"`
+	CvssV2Vector  string         `json:"cvssV2Vector,omitempty"`
+	CvssV3        string         `json:"cvssV3,omitempty"`
+	CvssV3Vector  string         `json:"cvssV3Vector,omitempty"`
+	Cwe           []string       `json:"cwe,omitempty"`
 	Applicability *Applicability `json:"applicability,omitempty"`
 }
 

--- a/utils/formats/simplejsonapi.go
+++ b/utils/formats/simplejsonapi.go
@@ -140,6 +140,7 @@ type CveRow struct {
 	Id            string         `json:"id"`
 	CvssV2        string         `json:"cvssV2"`
 	CvssV3        string         `json:"cvssV3"`
+	Cwe		      []string       `json:"cwe,omitempty"`
 	Applicability *Applicability `json:"applicability,omitempty"`
 }
 

--- a/utils/formats/simplejsonapi.go
+++ b/utils/formats/simplejsonapi.go
@@ -139,7 +139,9 @@ type ComponentRow struct {
 type CveRow struct {
 	Id            string         `json:"id"`
 	CvssV2        string         `json:"cvssV2"`
+	CvssV2Vector  string         `json:"cvssV2Vector"`
 	CvssV3        string         `json:"cvssV3"`
+	CvssV3Vector  string         `json:"cvssV3Vector"`
 	Cwe		      []string       `json:"cwe,omitempty"`
 	Applicability *Applicability `json:"applicability,omitempty"`
 }

--- a/utils/results/common.go
+++ b/utils/results/common.go
@@ -318,12 +318,12 @@ func convertCves(cves []services.Cve) []formats.CveRow {
 	var cveRows []formats.CveRow
 	for _, cveObj := range cves {
 		cveRows = append(cveRows, formats.CveRow{
-			Id: cveObj.Id,
-			CvssV2: cveObj.CvssV2Score,
+			Id:           cveObj.Id,
+			CvssV2:       cveObj.CvssV2Score,
 			CvssV2Vector: cveObj.CvssV2Vector,
-			CvssV3: cveObj.CvssV3Score,
+			CvssV3:       cveObj.CvssV3Score,
 			CvssV3Vector: cveObj.CvssV3Vector,
-			Cwe:    cveObj.Cwe,
+			Cwe:          cveObj.Cwe,
 		})
 	}
 	return cveRows

--- a/utils/results/common.go
+++ b/utils/results/common.go
@@ -320,7 +320,9 @@ func convertCves(cves []services.Cve) []formats.CveRow {
 		cveRows = append(cveRows, formats.CveRow{
 			Id: cveObj.Id,
 			CvssV2: cveObj.CvssV2Score,
+			CvssV2Vector: cveObj.CvssV2Vector,
 			CvssV3: cveObj.CvssV3Score,
+			CvssV3Vector: cveObj.CvssV3Vector,
 			Cwe:    cveObj.Cwe,
 		})
 	}

--- a/utils/results/common.go
+++ b/utils/results/common.go
@@ -317,7 +317,12 @@ func ConvertCvesWithApplicability(cves []services.Cve, entitledForJas bool, appl
 func convertCves(cves []services.Cve) []formats.CveRow {
 	var cveRows []formats.CveRow
 	for _, cveObj := range cves {
-		cveRows = append(cveRows, formats.CveRow{Id: cveObj.Id, CvssV2: cveObj.CvssV2Score, CvssV3: cveObj.CvssV3Score})
+		cveRows = append(cveRows, formats.CveRow{
+			Id: cveObj.Id,
+			CvssV2: cveObj.CvssV2Score,
+			CvssV3: cveObj.CvssV3Score,
+			Cwe:    cveObj.Cwe,
+		})
 	}
 	return cveRows
 }

--- a/utils/results/conversion/simplejsonparser/simplejsonparser_test.go
+++ b/utils/results/conversion/simplejsonparser/simplejsonparser_test.go
@@ -21,7 +21,7 @@ var (
 			IssueId:  "XRAY-1",
 			Summary:  "summary-1",
 			Severity: "High",
-			Cves:     []services.Cve{{Id: "CVE-1"}},
+			Cves:     []services.Cve{{Id: "CVE-1", CvssV3Score: "5.3", CvssV3Vector: "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:L"}},
 			Components: map[string]services.Component{
 				"component-A": {
 					ImpactPaths: [][]services.ImpactPathNode{{
@@ -41,7 +41,7 @@ var (
 			IssueId:  "XRAY-2",
 			Summary:  "summary-2",
 			Severity: "Low",
-			Cves:     []services.Cve{{Id: "CVE-2"}},
+			Cves:     []services.Cve{{Id: "CVE-2", CvssV2Score: "5.0", CvssV2Vector: "CVSS:2.0/AV:N/AC:L/Au:N/C:N/I:N/A:P"}},
 			Components: map[string]services.Component{
 				"component-B": {
 					ImpactPaths: [][]services.ImpactPathNode{{
@@ -59,7 +59,7 @@ var (
 			Severity:      "High",
 			WatchName:     "watch-name",
 			ViolationType: "security",
-			Cves:          []services.Cve{{Id: "CVE-1"}},
+			Cves:          []services.Cve{{Id: "CVE-1", CvssV3Score: "5.3", CvssV3Vector: "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:L"}},
 			Components: map[string]services.Component{
 				"component-A": {
 					ImpactPaths: [][]services.ImpactPathNode{{
@@ -81,7 +81,7 @@ var (
 			Severity:      "Low",
 			WatchName:     "watch-name",
 			ViolationType: "security",
-			Cves:          []services.Cve{{Id: "CVE-2"}},
+			Cves:          []services.Cve{{Id: "CVE-2", CvssV2Score: "5.0", CvssV2Vector: "CVSS:2.0/AV:N/AC:L/Au:N/C:N/I:N/A:P"}},
 			Components: map[string]services.Component{
 				"component-B": {
 					ImpactPaths: [][]services.ImpactPathNode{{
@@ -287,7 +287,7 @@ func TestPrepareSimpleJsonVulnerabilities(t *testing.T) {
 				{
 					Summary: "summary-1",
 					IssueId: "XRAY-1",
-					Cves:    []formats.CveRow{{Id: "CVE-1"}},
+					Cves:    []formats.CveRow{{Id: "CVE-1", CvssV3: "5.3", CvssV3Vector: "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:L"}},
 					ImpactedDependencyDetails: formats.ImpactedDependencyDetails{
 						SeverityDetails:        formats.SeverityDetails{Severity: "High", SeverityNumValue: 18},
 						ImpactedDependencyName: "component-A",
@@ -302,7 +302,7 @@ func TestPrepareSimpleJsonVulnerabilities(t *testing.T) {
 				{
 					Summary: "summary-1",
 					IssueId: "XRAY-1",
-					Cves:    []formats.CveRow{{Id: "CVE-1"}},
+					Cves:    []formats.CveRow{{Id: "CVE-1", CvssV3: "5.3", CvssV3Vector: "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:L"}},
 					ImpactedDependencyDetails: formats.ImpactedDependencyDetails{
 						SeverityDetails:        formats.SeverityDetails{Severity: "High", SeverityNumValue: 18},
 						ImpactedDependencyName: "component-B",
@@ -317,7 +317,7 @@ func TestPrepareSimpleJsonVulnerabilities(t *testing.T) {
 				{
 					Summary: "summary-2",
 					IssueId: "XRAY-2",
-					Cves:    []formats.CveRow{{Id: "CVE-2"}},
+					Cves:    []formats.CveRow{{Id: "CVE-2", CvssV2: "5.0", CvssV2Vector: "CVSS:2.0/AV:N/AC:L/Au:N/C:N/I:N/A:P"}},
 					ImpactedDependencyDetails: formats.ImpactedDependencyDetails{
 						SeverityDetails:        formats.SeverityDetails{Severity: "Low", SeverityNumValue: 10},
 						ImpactedDependencyName: "component-B",
@@ -351,7 +351,12 @@ func TestPrepareSimpleJsonVulnerabilities(t *testing.T) {
 					Summary:    "summary-1",
 					IssueId:    "XRAY-1",
 					Applicable: jasutils.NotApplicable.String(),
-					Cves:       []formats.CveRow{{Id: "CVE-1", Applicability: &formats.Applicability{ScannerDescription: "rule-msg", Status: jasutils.NotApplicable.String()}}},
+					Cves: []formats.CveRow{{
+						Id:            "CVE-1",
+						CvssV3:        "5.3",
+						CvssV3Vector:  "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:L",
+						Applicability: &formats.Applicability{ScannerDescription: "rule-msg", Status: jasutils.NotApplicable.String()}},
+					},
 					ImpactedDependencyDetails: formats.ImpactedDependencyDetails{
 						SeverityDetails:        formats.SeverityDetails{Severity: "High", SeverityNumValue: 4},
 						ImpactedDependencyName: "component-A",
@@ -367,7 +372,12 @@ func TestPrepareSimpleJsonVulnerabilities(t *testing.T) {
 					Summary:    "summary-1",
 					IssueId:    "XRAY-1",
 					Applicable: jasutils.NotApplicable.String(),
-					Cves:       []formats.CveRow{{Id: "CVE-1", Applicability: &formats.Applicability{ScannerDescription: "rule-msg", Status: jasutils.NotApplicable.String()}}},
+					Cves: []formats.CveRow{{
+						Id:            "CVE-1",
+						CvssV3:        "5.3",
+						CvssV3Vector:  "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:L",
+						Applicability: &formats.Applicability{ScannerDescription: "rule-msg", Status: jasutils.NotApplicable.String()}},
+					},
 					ImpactedDependencyDetails: formats.ImpactedDependencyDetails{
 						SeverityDetails:        formats.SeverityDetails{Severity: "High", SeverityNumValue: 4},
 						ImpactedDependencyName: "component-B",
@@ -384,7 +394,9 @@ func TestPrepareSimpleJsonVulnerabilities(t *testing.T) {
 					IssueId:    "XRAY-2",
 					Applicable: jasutils.Applicable.String(),
 					Cves: []formats.CveRow{{
-						Id: "CVE-2",
+						Id:           "CVE-2",
+						CvssV2:       "5.0",
+						CvssV2Vector: "CVSS:2.0/AV:N/AC:L/Au:N/C:N/I:N/A:P",
 						Applicability: &formats.Applicability{
 							ScannerDescription: "rule-msg",
 							Status:             jasutils.Applicable.String(),
@@ -441,7 +453,7 @@ func TestPrepareSimpleJsonViolations(t *testing.T) {
 				{
 					Summary: "summary-1",
 					IssueId: "XRAY-1",
-					Cves:    []formats.CveRow{{Id: "CVE-1"}},
+					Cves:    []formats.CveRow{{Id: "CVE-1", CvssV3: "5.3", CvssV3Vector: "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:L"}},
 					ImpactedDependencyDetails: formats.ImpactedDependencyDetails{
 						SeverityDetails:        formats.SeverityDetails{Severity: "High", SeverityNumValue: 18},
 						ImpactedDependencyName: "component-A",
@@ -459,7 +471,7 @@ func TestPrepareSimpleJsonViolations(t *testing.T) {
 				{
 					Summary: "summary-1",
 					IssueId: "XRAY-1",
-					Cves:    []formats.CveRow{{Id: "CVE-1"}},
+					Cves:    []formats.CveRow{{Id: "CVE-1", CvssV3: "5.3", CvssV3Vector: "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:L"}},
 					ImpactedDependencyDetails: formats.ImpactedDependencyDetails{
 						SeverityDetails:        formats.SeverityDetails{Severity: "High", SeverityNumValue: 18},
 						ImpactedDependencyName: "component-B",
@@ -477,7 +489,7 @@ func TestPrepareSimpleJsonViolations(t *testing.T) {
 				{
 					Summary: "summary-2",
 					IssueId: "XRAY-2",
-					Cves:    []formats.CveRow{{Id: "CVE-2"}},
+					Cves:    []formats.CveRow{{Id: "CVE-2", CvssV2: "5.0", CvssV2Vector: "CVSS:2.0/AV:N/AC:L/Au:N/C:N/I:N/A:P"}},
 					ImpactedDependencyDetails: formats.ImpactedDependencyDetails{
 						SeverityDetails:        formats.SeverityDetails{Severity: "Low", SeverityNumValue: 10},
 						ImpactedDependencyName: "component-B",
@@ -529,7 +541,12 @@ func TestPrepareSimpleJsonViolations(t *testing.T) {
 					Summary:    "summary-1",
 					IssueId:    "XRAY-1",
 					Applicable: jasutils.NotApplicable.String(),
-					Cves:       []formats.CveRow{{Id: "CVE-1", Applicability: &formats.Applicability{ScannerDescription: "rule-msg", Status: jasutils.NotApplicable.String()}}},
+					Cves: []formats.CveRow{{
+						Id:            "CVE-1",
+						CvssV3:        "5.3",
+						CvssV3Vector:  "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:L",
+						Applicability: &formats.Applicability{ScannerDescription: "rule-msg", Status: jasutils.NotApplicable.String()}},
+					},
 					ImpactedDependencyDetails: formats.ImpactedDependencyDetails{
 						SeverityDetails:        formats.SeverityDetails{Severity: "High", SeverityNumValue: 4},
 						ImpactedDependencyName: "component-A",
@@ -548,7 +565,12 @@ func TestPrepareSimpleJsonViolations(t *testing.T) {
 					Summary:    "summary-1",
 					IssueId:    "XRAY-1",
 					Applicable: jasutils.NotApplicable.String(),
-					Cves:       []formats.CveRow{{Id: "CVE-1", Applicability: &formats.Applicability{ScannerDescription: "rule-msg", Status: jasutils.NotApplicable.String()}}},
+					Cves: []formats.CveRow{{
+						Id:            "CVE-1",
+						CvssV3:        "5.3",
+						CvssV3Vector:  "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:L",
+						Applicability: &formats.Applicability{ScannerDescription: "rule-msg", Status: jasutils.NotApplicable.String()}},
+					},
 					ImpactedDependencyDetails: formats.ImpactedDependencyDetails{
 						SeverityDetails:        formats.SeverityDetails{Severity: "High", SeverityNumValue: 4},
 						ImpactedDependencyName: "component-B",
@@ -568,7 +590,9 @@ func TestPrepareSimpleJsonViolations(t *testing.T) {
 					IssueId:    "XRAY-2",
 					Applicable: jasutils.Applicable.String(),
 					Cves: []formats.CveRow{{
-						Id: "CVE-2",
+						Id:           "CVE-2",
+						CvssV2:       "5.0",
+						CvssV2Vector: "CVSS:2.0/AV:N/AC:L/Au:N/C:N/I:N/A:P",
 						Applicability: &formats.Applicability{
 							ScannerDescription: "rule-msg",
 							Status:             jasutils.Applicable.String(),

--- a/utils/results/conversion/simplejsonparser/simplejsonparser_test.go
+++ b/utils/results/conversion/simplejsonparser/simplejsonparser_test.go
@@ -21,7 +21,7 @@ var (
 			IssueId:  "XRAY-1",
 			Summary:  "summary-1",
 			Severity: "High",
-			Cves:     []services.Cve{{Id: "CVE-1", CvssV3Score: "5.3", CvssV3Vector: "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:L"}},
+			Cves:     []services.Cve{{Id: "CVE-1", CvssV3Score: "5.3", CvssV3Vector: "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:L", Cwe: []string{"cwe-1"}}},
 			Components: map[string]services.Component{
 				"component-A": {
 					ImpactPaths: [][]services.ImpactPathNode{{
@@ -41,7 +41,7 @@ var (
 			IssueId:  "XRAY-2",
 			Summary:  "summary-2",
 			Severity: "Low",
-			Cves:     []services.Cve{{Id: "CVE-2", CvssV2Score: "5.0", CvssV2Vector: "CVSS:2.0/AV:N/AC:L/Au:N/C:N/I:N/A:P"}},
+			Cves:     []services.Cve{{Id: "CVE-2", CvssV2Score: "5.0", CvssV2Vector: "CVSS:2.0/AV:N/AC:L/Au:N/C:N/I:N/A:P", Cwe: []string{"CWE-284", "NVD-CWE-noinfo"}}},
 			Components: map[string]services.Component{
 				"component-B": {
 					ImpactPaths: [][]services.ImpactPathNode{{
@@ -59,7 +59,7 @@ var (
 			Severity:      "High",
 			WatchName:     "watch-name",
 			ViolationType: "security",
-			Cves:          []services.Cve{{Id: "CVE-1", CvssV3Score: "5.3", CvssV3Vector: "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:L"}},
+			Cves:          []services.Cve{{Id: "CVE-1", CvssV3Score: "5.3", CvssV3Vector: "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:L", Cwe: []string{"cwe-1"}}},
 			Components: map[string]services.Component{
 				"component-A": {
 					ImpactPaths: [][]services.ImpactPathNode{{
@@ -81,7 +81,7 @@ var (
 			Severity:      "Low",
 			WatchName:     "watch-name",
 			ViolationType: "security",
-			Cves:          []services.Cve{{Id: "CVE-2", CvssV2Score: "5.0", CvssV2Vector: "CVSS:2.0/AV:N/AC:L/Au:N/C:N/I:N/A:P"}},
+			Cves:          []services.Cve{{Id: "CVE-2", CvssV2Score: "5.0", CvssV2Vector: "CVSS:2.0/AV:N/AC:L/Au:N/C:N/I:N/A:P", Cwe: []string{"CWE-284", "NVD-CWE-noinfo"}}},
 			Components: map[string]services.Component{
 				"component-B": {
 					ImpactPaths: [][]services.ImpactPathNode{{
@@ -287,7 +287,7 @@ func TestPrepareSimpleJsonVulnerabilities(t *testing.T) {
 				{
 					Summary: "summary-1",
 					IssueId: "XRAY-1",
-					Cves:    []formats.CveRow{{Id: "CVE-1", CvssV3: "5.3", CvssV3Vector: "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:L"}},
+					Cves:    []formats.CveRow{{Id: "CVE-1", CvssV3: "5.3", CvssV3Vector: "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:L", Cwe: []string{"cwe-1"}}},
 					ImpactedDependencyDetails: formats.ImpactedDependencyDetails{
 						SeverityDetails:        formats.SeverityDetails{Severity: "High", SeverityNumValue: 18},
 						ImpactedDependencyName: "component-A",
@@ -302,7 +302,7 @@ func TestPrepareSimpleJsonVulnerabilities(t *testing.T) {
 				{
 					Summary: "summary-1",
 					IssueId: "XRAY-1",
-					Cves:    []formats.CveRow{{Id: "CVE-1", CvssV3: "5.3", CvssV3Vector: "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:L"}},
+					Cves:    []formats.CveRow{{Id: "CVE-1", CvssV3: "5.3", CvssV3Vector: "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:L", Cwe: []string{"cwe-1"}}},
 					ImpactedDependencyDetails: formats.ImpactedDependencyDetails{
 						SeverityDetails:        formats.SeverityDetails{Severity: "High", SeverityNumValue: 18},
 						ImpactedDependencyName: "component-B",
@@ -317,7 +317,7 @@ func TestPrepareSimpleJsonVulnerabilities(t *testing.T) {
 				{
 					Summary: "summary-2",
 					IssueId: "XRAY-2",
-					Cves:    []formats.CveRow{{Id: "CVE-2", CvssV2: "5.0", CvssV2Vector: "CVSS:2.0/AV:N/AC:L/Au:N/C:N/I:N/A:P"}},
+					Cves:    []formats.CveRow{{Id: "CVE-2", CvssV2: "5.0", CvssV2Vector: "CVSS:2.0/AV:N/AC:L/Au:N/C:N/I:N/A:P", Cwe: []string{"CWE-284", "NVD-CWE-noinfo"}}},
 					ImpactedDependencyDetails: formats.ImpactedDependencyDetails{
 						SeverityDetails:        formats.SeverityDetails{Severity: "Low", SeverityNumValue: 10},
 						ImpactedDependencyName: "component-B",
@@ -355,6 +355,7 @@ func TestPrepareSimpleJsonVulnerabilities(t *testing.T) {
 						Id:            "CVE-1",
 						CvssV3:        "5.3",
 						CvssV3Vector:  "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:L",
+						Cwe:           []string{"cwe-1"},
 						Applicability: &formats.Applicability{ScannerDescription: "rule-msg", Status: jasutils.NotApplicable.String()}},
 					},
 					ImpactedDependencyDetails: formats.ImpactedDependencyDetails{
@@ -376,6 +377,7 @@ func TestPrepareSimpleJsonVulnerabilities(t *testing.T) {
 						Id:            "CVE-1",
 						CvssV3:        "5.3",
 						CvssV3Vector:  "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:L",
+						Cwe:           []string{"cwe-1"},
 						Applicability: &formats.Applicability{ScannerDescription: "rule-msg", Status: jasutils.NotApplicable.String()}},
 					},
 					ImpactedDependencyDetails: formats.ImpactedDependencyDetails{
@@ -397,6 +399,7 @@ func TestPrepareSimpleJsonVulnerabilities(t *testing.T) {
 						Id:           "CVE-2",
 						CvssV2:       "5.0",
 						CvssV2Vector: "CVSS:2.0/AV:N/AC:L/Au:N/C:N/I:N/A:P",
+						Cwe:          []string{"CWE-284", "NVD-CWE-noinfo"},
 						Applicability: &formats.Applicability{
 							ScannerDescription: "rule-msg",
 							Status:             jasutils.Applicable.String(),
@@ -453,7 +456,7 @@ func TestPrepareSimpleJsonViolations(t *testing.T) {
 				{
 					Summary: "summary-1",
 					IssueId: "XRAY-1",
-					Cves:    []formats.CveRow{{Id: "CVE-1", CvssV3: "5.3", CvssV3Vector: "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:L"}},
+					Cves:    []formats.CveRow{{Id: "CVE-1", CvssV3: "5.3", CvssV3Vector: "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:L", Cwe: []string{"cwe-1"}}},
 					ImpactedDependencyDetails: formats.ImpactedDependencyDetails{
 						SeverityDetails:        formats.SeverityDetails{Severity: "High", SeverityNumValue: 18},
 						ImpactedDependencyName: "component-A",
@@ -471,7 +474,7 @@ func TestPrepareSimpleJsonViolations(t *testing.T) {
 				{
 					Summary: "summary-1",
 					IssueId: "XRAY-1",
-					Cves:    []formats.CveRow{{Id: "CVE-1", CvssV3: "5.3", CvssV3Vector: "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:L"}},
+					Cves:    []formats.CveRow{{Id: "CVE-1", CvssV3: "5.3", CvssV3Vector: "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:L", Cwe: []string{"cwe-1"}}},
 					ImpactedDependencyDetails: formats.ImpactedDependencyDetails{
 						SeverityDetails:        formats.SeverityDetails{Severity: "High", SeverityNumValue: 18},
 						ImpactedDependencyName: "component-B",
@@ -489,7 +492,7 @@ func TestPrepareSimpleJsonViolations(t *testing.T) {
 				{
 					Summary: "summary-2",
 					IssueId: "XRAY-2",
-					Cves:    []formats.CveRow{{Id: "CVE-2", CvssV2: "5.0", CvssV2Vector: "CVSS:2.0/AV:N/AC:L/Au:N/C:N/I:N/A:P"}},
+					Cves:    []formats.CveRow{{Id: "CVE-2", CvssV2: "5.0", CvssV2Vector: "CVSS:2.0/AV:N/AC:L/Au:N/C:N/I:N/A:P", Cwe: []string{"CWE-284", "NVD-CWE-noinfo"}}},
 					ImpactedDependencyDetails: formats.ImpactedDependencyDetails{
 						SeverityDetails:        formats.SeverityDetails{Severity: "Low", SeverityNumValue: 10},
 						ImpactedDependencyName: "component-B",
@@ -545,6 +548,7 @@ func TestPrepareSimpleJsonViolations(t *testing.T) {
 						Id:            "CVE-1",
 						CvssV3:        "5.3",
 						CvssV3Vector:  "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:L",
+						Cwe:           []string{"cwe-1"},
 						Applicability: &formats.Applicability{ScannerDescription: "rule-msg", Status: jasutils.NotApplicable.String()}},
 					},
 					ImpactedDependencyDetails: formats.ImpactedDependencyDetails{
@@ -569,6 +573,7 @@ func TestPrepareSimpleJsonViolations(t *testing.T) {
 						Id:            "CVE-1",
 						CvssV3:        "5.3",
 						CvssV3Vector:  "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:L",
+						Cwe:           []string{"cwe-1"},
 						Applicability: &formats.Applicability{ScannerDescription: "rule-msg", Status: jasutils.NotApplicable.String()}},
 					},
 					ImpactedDependencyDetails: formats.ImpactedDependencyDetails{
@@ -593,6 +598,7 @@ func TestPrepareSimpleJsonViolations(t *testing.T) {
 						Id:           "CVE-2",
 						CvssV2:       "5.0",
 						CvssV2Vector: "CVSS:2.0/AV:N/AC:L/Au:N/C:N/I:N/A:P",
+						Cwe:          []string{"CWE-284", "NVD-CWE-noinfo"},
 						Applicability: &formats.Applicability{
 							ScannerDescription: "rule-msg",
 							Status:             jasutils.Applicable.String(),


### PR DESCRIPTION
- [ ] The pull request is targeting the `dev` branch.
- [ ] The code has been validated to compile successfully by running `go vet ./...`.
- [ ] The code has been formatted properly using `go fmt ./...`.
- [ ] All [static analysis checks](https://github.com/jfrog/jfrog-cli-security/actions/workflows/analysis.yml) passed.
- [ ] All [tests](https://github.com/jfrog/jfrog-cli-security/actions/workflows/test.yml) have passed. If this feature is not already covered by the tests, new tests have been added.
- [ ] Updated the [Contributing page](https://github.com/jfrog/jfrog-cli-security/blob/main/CONTRIBUTING.md) / [ReadMe page](https://github.com/jfrog/jfrog-cli-security/blob/main/README.md) / [CI Workflow files](https://github.com/jfrog/jfrog-cli-security/tree/main/.github/workflows) if needed.
- [ ] All changes are detailed at the description. if not already covered at [JFrog Documentation](https://github.com/jfrog/documentation), new documentation have been added.

-----

Enhanced `Simple-Json` format for the security commands, adding the following attributes to the Cve:
* `Cwe` value list
* `CvssV3Vector` and `CvssV3Vector` values