### PR TITLE
Add an option to provide descriptor name in Conan graph info command

### DIFF
--- a/commands/audit/sca/conan/conan.go
+++ b/commands/audit/sca/conan/conan.go
@@ -109,6 +109,11 @@ func calculateUniqueDependencies(nodes map[string]conanRef) []string {
 
 func calculateDependencies(executablePath, workingDir string, params utils.AuditParams) (dependencyTrees []*xrayUtils.GraphNode, uniqueDeps []string, err error) {
 	graphInfo := append([]string{"info", ".", "--format=json"}, params.Args()...)
+	if params.PipRequirementsFile() != "" {
+		// We allow passing a name for the descriptor file to be used in the 'graph info' command.
+		// Since this ability already exists for python we leverage this ability
+		graphInfo = append(graphInfo, "-f", params.PipRequirementsFile())
+	}
 	conanGraphInfoContent, err := getConanCmd(executablePath, workingDir, "graph", graphInfo...).RunWithOutput()
 	if err != nil {
 		return

--- a/commands/audit/sca/conan/conan.go
+++ b/commands/audit/sca/conan/conan.go
@@ -111,7 +111,7 @@ func calculateUniqueDependencies(nodes map[string]conanRef) []string {
 func calculateDependencies(executablePath, workingDir string, params utils.AuditParams) (dependencyTrees []*xrayUtils.GraphNode, uniqueDeps []string, err error) {
 	graphInfo := []string{"info"}
 	if params.PipRequirementsFile() != "" {
-		// We allow passing a name for the descriptor file to be used in the 'graph info' command. If non has provided we execute the command on the current dir.
+		// We allow passing a custom name for the descriptor file to be used in the 'graph info' command. If non has provided we execute the command on the current dir.
 		// Since this ability already exists for python we leverage this ability
 		graphInfo = append(graphInfo, filepath.Join(workingDir, params.PipRequirementsFile()))
 	} else {

--- a/commands/audit/sca/conan/conan_test.go
+++ b/commands/audit/sca/conan/conan_test.go
@@ -43,7 +43,6 @@ func TestParseConanDependencyTree(t *testing.T) {
 	}
 }
 
-// TODO eran add a testcase with a provided descriptor name
 func TestBuildDependencyTree(t *testing.T) {
 	testcases := []struct {
 		name           string
@@ -64,8 +63,7 @@ func TestBuildDependencyTree(t *testing.T) {
 			params := &utils.AuditBasicParams{}
 			if testcase.descriptorName != "" {
 				// changing the name of the descriptor to verify the work with a non-default descriptor name
-				changeNameCmd := exec.Command("mv", "conanfile.txt", testcase.descriptorName)
-				changeNameCmd.Dir = dir
+				changeNameCmd := exec.Command("mv", filepath.Join(dir, "conanfile.txt"), filepath.Join(dir, testcase.descriptorName))
 				_, err := changeNameCmd.CombinedOutput()
 				require.NoError(t, err)
 				require.FileExists(t, filepath.Join(dir, testcase.descriptorName))

--- a/commands/audit/sca/conan/conan_test.go
+++ b/commands/audit/sca/conan/conan_test.go
@@ -78,20 +78,6 @@ func TestBuildDependencyTree(t *testing.T) {
 			assert.ElementsMatch(t, uniqueDeps, expectedUniqueDeps, "First is actual, Second is Expected")
 		})
 	}
-
-	/*
-		dir, cleanUp := sca.CreateTestWorkspace(t, filepath.Join("projects", "package-managers", "conan"))
-		defer cleanUp()
-		params := &utils.AuditBasicParams{}
-		params.SetConanProfile(filepath.Join(dir, "profile"))
-		graph, uniqueDeps, err := BuildDependencyTree(params)
-		assert.NoError(t, err)
-		if !tests.CompareTree(expectedResult, graph[0]) {
-			t.Errorf("expected %+v, got: %+v", expectedResult.Nodes, graph)
-		}
-		assert.ElementsMatch(t, uniqueDeps, expectedUniqueDeps, "First is actual, Second is Expected")
-
-	*/
 }
 
 func TestCalculateUniqueDeps(t *testing.T) {

--- a/commands/audit/sca/conan/conan_test.go
+++ b/commands/audit/sca/conan/conan_test.go
@@ -2,7 +2,9 @@ package conan
 
 import (
 	"encoding/json"
+	"github.com/stretchr/testify/require"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"testing"
 
@@ -41,17 +43,57 @@ func TestParseConanDependencyTree(t *testing.T) {
 	}
 }
 
+// TODO eran add a testcase with a provided descriptor name
 func TestBuildDependencyTree(t *testing.T) {
-	dir, cleanUp := sca.CreateTestWorkspace(t, filepath.Join("projects", "package-managers", "conan"))
-	defer cleanUp()
-	params := &utils.AuditBasicParams{}
-	params.SetConanProfile(filepath.Join(dir, "profile"))
-	graph, uniqueDeps, err := BuildDependencyTree(params)
-	assert.NoError(t, err)
-	if !tests.CompareTree(expectedResult, graph[0]) {
-		t.Errorf("expected %+v, got: %+v", expectedResult.Nodes, graph)
+	testcases := []struct {
+		name           string
+		descriptorName string
+	}{
+		{
+			name: "default descriptor file",
+		},
+		{
+			name:           "custom descriptor file",
+			descriptorName: "conanfile-system.txt",
+		},
 	}
-	assert.ElementsMatch(t, uniqueDeps, expectedUniqueDeps, "First is actual, Second is Expected")
+	for _, testcase := range testcases {
+		t.Run(testcase.name, func(t *testing.T) {
+			dir, cleanUp := sca.CreateTestWorkspace(t, filepath.Join("projects", "package-managers", "conan"))
+			defer cleanUp()
+			params := &utils.AuditBasicParams{}
+			if testcase.descriptorName != "" {
+				// changing the name of the descriptor to verify the work with a non-default descriptor name
+				changeNameCmd := exec.Command("mv", "conanfile.txt", testcase.descriptorName)
+				changeNameCmd.Dir = dir
+				_, err := changeNameCmd.CombinedOutput()
+				require.NoError(t, err)
+				require.FileExists(t, filepath.Join(dir, testcase.descriptorName))
+				params.SetPipRequirementsFile(testcase.descriptorName)
+			}
+			params.SetConanProfile(filepath.Join(dir, "profile"))
+			graph, uniqueDeps, err := BuildDependencyTree(params)
+			assert.NoError(t, err)
+			if !tests.CompareTree(expectedResult, graph[0]) {
+				t.Errorf("expected %+v, got: %+v", expectedResult.Nodes, graph)
+			}
+			assert.ElementsMatch(t, uniqueDeps, expectedUniqueDeps, "First is actual, Second is Expected")
+		})
+	}
+
+	/*
+		dir, cleanUp := sca.CreateTestWorkspace(t, filepath.Join("projects", "package-managers", "conan"))
+		defer cleanUp()
+		params := &utils.AuditBasicParams{}
+		params.SetConanProfile(filepath.Join(dir, "profile"))
+		graph, uniqueDeps, err := BuildDependencyTree(params)
+		assert.NoError(t, err)
+		if !tests.CompareTree(expectedResult, graph[0]) {
+			t.Errorf("expected %+v, got: %+v", expectedResult.Nodes, graph)
+		}
+		assert.ElementsMatch(t, uniqueDeps, expectedUniqueDeps, "First is actual, Second is Expected")
+
+	*/
 }
 
 func TestCalculateUniqueDeps(t *testing.T) {

--- a/commands/audit/scarunner.go
+++ b/commands/audit/scarunner.go
@@ -117,6 +117,8 @@ func getRequestedDescriptors(params *AuditParams) map[techutils.Technology][]str
 	requestedDescriptors := map[techutils.Technology][]string{}
 	if params.PipRequirementsFile() != "" {
 		requestedDescriptors[techutils.Pip] = []string{params.PipRequirementsFile()}
+		// We leverage the ability to pass a custom descriptor name for Conan through PipRequirementsFile as well, therefore we set also Conan with the provided descriptor name.
+		requestedDescriptors[techutils.Conan] = []string{params.PipRequirementsFile()}
 	}
 	return requestedDescriptors
 }


### PR DESCRIPTION
- [ ] The pull request is targeting the `dev` branch.
- [ ] The code has been validated to compile successfully by running `go vet ./...`.
- [ ] The code has been formatted properly using `go fmt ./...`.
- [ ] All [static analysis checks](https://github.com/jfrog/jfrog-cli-security/actions/workflows/analysis.yml) passed.
- [ ] All [tests](https://github.com/jfrog/jfrog-cli-security/actions/workflows/test.yml) have passed. If this feature is not already covered by the tests, new tests have been added.
- [ ] Updated the [Contributing page](https://github.com/jfrog/jfrog-cli-security/blob/main/CONTRIBUTING.md) / [ReadMe page](https://github.com/jfrog/jfrog-cli-security/blob/main/README.md) / [CI Workflow files](https://github.com/jfrog/jfrog-cli-security/tree/main/.github/workflows) if needed.
- [ ] All changes are detailed at the description. if not already covered at [JFrog Documentation](https://github.com/jfrog/documentation), new documentation have been added.

-----
This PR adds the ability to specify a custom conanfile (Conan descriptor) name to be used with the 'graph info' command. This enhancement addresses use cases where the descriptor does not have the default name "conanfile.txt".

Since Conan does not require installation before calculating dependencies, we cannot rely on an install command to provide this information. Hence, we leverage the existing functionality of Python package managers to specify a custom descriptor name through options like --requirements-file (or JF_REQUIREMENTS_FILE / pipRequirementsFile in the context of a Frogbot scan) to achieve this same flexibility in Conan.