### PR TITLE
Added no cache flag to gradle dep tree

### DIFF
--- a/commands/audit/sca/java/gradle.go
+++ b/commands/audit/sca/java/gradle.go
@@ -27,6 +27,7 @@ const (
 	gradleDepTreeJarFile    = "gradle-dep-tree.jar"
 	gradleDepTreeInitFile   = "gradledeptree.init"
 	gradleDepTreeOutputFile = "gradledeptree.out"
+	gradleNoCacheFlag       = "--no-configuration-cache"
 	gradleDepTreeInitScript = `initscript {
 	repositories { %s
 		mavenCentral()
@@ -158,6 +159,7 @@ func (gdt *gradleDepTreeManager) execGradleDepTree(depTreeDir string) (outputFil
 		"clean",
 		"generateDepTrees", "-I", filepath.Join(depTreeDir, gradleDepTreeInitFile),
 		"-q",
+		gradleNoCacheFlag,
 		fmt.Sprintf("-Dcom.jfrog.depsTreeOutputFile=%s", outputFilePath),
 		"-Dcom.jfrog.includeAllBuildFiles=true"}
 	log.Info("Running gradle deps tree command:", gradleExecPath, strings.Join(tasks, " "))


### PR DESCRIPTION
- [ ] The pull request is targeting the `dev` branch.
- [ ] The code has been validated to compile successfully by running `go vet ./...`.
- [ ] The code has been formatted properly using `go fmt ./...`.
- [ ] All [static analysis checks](https://github.com/jfrog/jfrog-cli-security/actions/workflows/analysis.yml) passed.
- [ ] All [tests](https://github.com/jfrog/jfrog-cli-security/actions/workflows/test.yml) have passed. If this feature is not already covered by the tests, new tests have been added.
- [ ] Updated the [Contributing page](https://github.com/jfrog/jfrog-cli-security/blob/main/CONTRIBUTING.md) / [ReadMe page](https://github.com/jfrog/jfrog-cli-security/blob/main/README.md) / [CI Workflow files](https://github.com/jfrog/jfrog-cli-security/tree/main/.github/workflows) if needed.
- [ ] All changes are detailed at the description. if not already covered at [JFrog Documentation](https://github.com/jfrog/documentation), new documentation have been added.

-----

Added no cache flag to gradle dep tree
referenced in this 
https://github.com/jfrog/jfrog-cli/issues/2594