### PR TITLE
Use local AnalyzerManager

### DIFF
--- a/jas/analyzermanager.go
+++ b/jas/analyzermanager.go
@@ -43,6 +43,7 @@ const (
 	unsupportedOsExitCode                     = 55
 	ErrFailedScannerRun                       = "failed to run %s scan. Exit code received: %s"
 	jfrogCliAnalyzerManagerVersionEnvVariable = "JFROG_CLI_ANALYZER_MANAGER_VERSION"
+	jfrogCliAnalyzerManagerLocalEnvVariable   = "JFROG_CLI_ANALYZER_MANAGER_PATH"
 	JfPackageManagerEnvVariable               = "AM_PACKAGE_MANAGER"
 	JfLanguageEnvVariable                     = "AM_LANGUAGE"
 	// #nosec G101 -- Not credentials.
@@ -117,6 +118,9 @@ func GetAnalyzerManagerDirAbsolutePath() (string, error) {
 }
 
 func GetAnalyzerManagerExecutable() (analyzerManagerPath string, err error) {
+	if localPath := os.Getenv(jfrogCliAnalyzerManagerLocalEnvVariable); localPath != "" && fileutils.IsPathExists(localPath, false) {
+		return localPath, nil
+	}
 	analyzerManagerDir, err := GetAnalyzerManagerDirAbsolutePath()
 	if err != nil {
 		return "", err
@@ -184,6 +188,10 @@ func GetAnalyzerManagerExitCode(err error) int {
 // Download the latest AnalyzerManager executable if not cached locally.
 // By default, the zip is downloaded directly from jfrog releases.
 func DownloadAnalyzerManagerIfNeeded(threadId int) error {
+	if localPath := os.Getenv(jfrogCliAnalyzerManagerLocalEnvVariable); localPath != "" && fileutils.IsPathExists(localPath, false) {
+		log.Debug(fmt.Sprintf("Using local analyzer manager path: %s", localPath))
+		return nil
+	}
 	downloadPath, err := GetAnalyzerManagerDownloadPath()
 	if err != nil {
 		return err

--- a/jas/analyzermanager.go
+++ b/jas/analyzermanager.go
@@ -43,7 +43,7 @@ const (
 	unsupportedOsExitCode                     = 55
 	ErrFailedScannerRun                       = "failed to run %s scan. Exit code received: %s"
 	jfrogCliAnalyzerManagerVersionEnvVariable = "JFROG_CLI_ANALYZER_MANAGER_VERSION"
-	jfrogCliAnalyzerManagerLocalEnvVariable   = "JFROG_CLI_ANALYZER_MANAGER_PATH"
+	JfrogCliAnalyzerManagerLocalEnvVariable   = "JFROG_CLI_ANALYZER_MANAGER_PATH"
 	JfPackageManagerEnvVariable               = "AM_PACKAGE_MANAGER"
 	JfLanguageEnvVariable                     = "AM_LANGUAGE"
 	// #nosec G101 -- Not credentials.
@@ -118,7 +118,7 @@ func GetAnalyzerManagerDirAbsolutePath() (string, error) {
 }
 
 func GetAnalyzerManagerExecutable() (analyzerManagerPath string, err error) {
-	if localPath := os.Getenv(jfrogCliAnalyzerManagerLocalEnvVariable); localPath != "" && fileutils.IsPathExists(localPath, false) {
+	if localPath := os.Getenv(JfrogCliAnalyzerManagerLocalEnvVariable); localPath != "" && fileutils.IsPathExists(localPath, false) {
 		return localPath, nil
 	}
 	analyzerManagerDir, err := GetAnalyzerManagerDirAbsolutePath()
@@ -188,7 +188,7 @@ func GetAnalyzerManagerExitCode(err error) int {
 // Download the latest AnalyzerManager executable if not cached locally.
 // By default, the zip is downloaded directly from jfrog releases.
 func DownloadAnalyzerManagerIfNeeded(threadId int) error {
-	if localPath := os.Getenv(jfrogCliAnalyzerManagerLocalEnvVariable); localPath != "" && fileutils.IsPathExists(localPath, false) {
+	if localPath := os.Getenv(JfrogCliAnalyzerManagerLocalEnvVariable); localPath != "" && fileutils.IsPathExists(localPath, false) {
 		log.Debug(fmt.Sprintf("Using local analyzer manager path: %s", localPath))
 		return nil
 	}

--- a/jas/runner/jasrunner_test.go
+++ b/jas/runner/jasrunner_test.go
@@ -48,18 +48,18 @@ func TestJasRunner_AnalyzerManagerLocalPath(t *testing.T) {
 	defer func() {
 		assert.NoError(t, os.Unsetenv(coreutils.HomeDir))
 	}()
-	localPath := "local/path/to/analyzer/manager"
-	assert.NoError(t, os.Setenv(jas.JfrogCliAnalyzerManagerLocalEnvVariable, localPath))
+	// Create a temp file to simulate the local path
+	localPath, err := os.CreateTemp(tmpDir, "analyzer_manager")
+	assert.NoError(t, err)
+	assert.NoError(t, os.Setenv(jas.JfrogCliAnalyzerManagerLocalEnvVariable, localPath.Name()))
 	defer func() {
 		assert.NoError(t, os.Unsetenv(jas.JfrogCliAnalyzerManagerLocalEnvVariable))
 	}()
 	scanner, err := jas.CreateJasScanner(&jas.FakeServerDetails, false, "", jas.GetAnalyzerManagerXscEnvVars("", "", "", []string{}))
 	assert.NoError(t, err)
-	if scanner.AnalyzerManager.AnalyzerManagerFullPath, err = jas.GetAnalyzerManagerExecutable(); err != nil {
-		return
-	}
+	scanner.AnalyzerManager.AnalyzerManagerFullPath, err = jas.GetAnalyzerManagerExecutable()
 	assert.NoError(t, err)
-	assert.Equal(t, localPath, scanner.AnalyzerManager.AnalyzerManagerFullPath)
+	assert.Equal(t, localPath.Name(), scanner.AnalyzerManager.AnalyzerManagerFullPath)
 }
 
 func TestJasRunner(t *testing.T) {


### PR DESCRIPTION
- [ ] The pull request is targeting the `dev` branch.
- [ ] The code has been validated to compile successfully by running `go vet ./...`.
- [ ] The code has been formatted properly using `go fmt ./...`.
- [ ] All [static analysis checks](https://github.com/jfrog/jfrog-cli-security/actions/workflows/analysis.yml) passed.
- [ ] All [tests](https://github.com/jfrog/jfrog-cli-security/actions/workflows/test.yml) have passed. If this feature is not already covered by the tests, new tests have been added.
- [ ] Updated the [Contributing page](https://github.com/jfrog/jfrog-cli-security/blob/main/CONTRIBUTING.md) / [ReadMe page](https://github.com/jfrog/jfrog-cli-security/blob/main/README.md) / [CI Workflow files](https://github.com/jfrog/jfrog-cli-security/tree/main/.github/workflows) if needed.
- [ ] All changes are detailed at the description. if not already covered at [JFrog Documentation](https://github.com/jfrog/documentation), new documentation have been added.

-----

Add a new Environment variable `JFROG_CLI_ANALYZER_MANAGER_PATH` that can point to an `analyzerManager` local binary, which will avoid downloading the analyzerManager (also ignoring `JFROG_CLI_ANALYZER_MANAGER_VERSION` env var) and will use the provided binary in the variable path 