### PR TITLE
feat: Improve jf scan summary for unsupported file types

### DIFF
--- a/commands/scan/scan.go
+++ b/commands/scan/scan.go
@@ -205,6 +205,10 @@ func (scanCmd *ScanCommand) indexFile(filePath string) (*xrayUtils.BinaryGraphNo
 		var e *exec.ExitError
 		if errors.As(err, &e) {
 			if e.ExitCode() == fileNotSupportedExitCode {
+
+				// --- ADDED LINE ---
+				log.Warn(fmt.Sprintf("Skipping scan for file '%s': File type not supported by JFrog Xray.", filePath))
+				// --- END ADDED LINE ---
 				log.Debug(fmt.Sprintf("File %s is not supported by Xray indexer app.", filePath))
 				return &indexerResults, nil
 			}
@@ -317,6 +321,21 @@ func (scanCmd *ScanCommand) RunScan(cmdType utils.CommandType) (cmdResults *resu
 	// while the consumer uses the indexer to index those files.
 	scanCmd.prepareScanTasks(fileProducerConsumer, indexedFileProducerConsumer, &JasScanProducerConsumer, cmdResults)
 	scanCmd.performScanTasks(fileProducerConsumer, indexedFileProducerConsumer, &JasScanProducerConsumer)
+
+	// Initialize the flag to false by default
+	cmdResults.HasScannableComponents = false
+	// Iterate through the collected target results
+	for _, target := range cmdResults.Targets {
+		// Check if a technology was identified for the target. This implies
+		// successful indexing and that an SCA scan was likely performed or attempted.
+		// Check if Technology was identified (meaning indexing likely succeeded and scan was attempted)
+		if target.Technology != "" {
+
+			cmdResults.HasScannableComponents = true
+			// Found at least one scannable component, no need to check further
+			break
+		}
+	}
 	return
 }
 

--- a/utils/results/results.go
+++ b/utils/results/results.go
@@ -30,6 +30,8 @@ type SecurityCommandResults struct {
 	// MultiScanId is a unique identifier that is used to group multiple scans together.
 	MultiScanId string `json:"multi_scan_id,omitempty"`
 	// Results for each target in the command
+	HasScannableComponents bool `json:"has_scannable_components,omitempty"`
+
 	Targets      []*TargetResults `json:"targets"`
 	targetsMutex sync.Mutex       `json:"-"`
 	// GeneralError that occurred during the command execution


### PR DESCRIPTION
Currently, when jf scan is run on a file whose type is not supported by the Xray indexer (e.g., a plain .txt or .exe file), the command completes successfully but prints the summary message: ✨ No vulnerable components were found ✨. This is misleading for users, as it implies the file was scanned and found clean, rather than indicating it wasn't scanned at all due to incompatibility.

Solution:

This PR implements the following changes to provide clearer feedback in this scenario:

Added Warning: A log.Warn message is now printed immediately when the indexer skips a file due to an unsupported type (exit code 3), explicitly informing the user about that specific file. (Change in commands/scan/scan.go)
Track Scannable State: A new boolean field HasScannableComponents was added to the results.SecurityCommandResults struct to track whether at least one file in the scan input was successfully indexed and processed (i.e., was of a supported type). (Change in utils/results/results.go)
Set Tracking Flag: Logic was added at the end of the RunScan function to set the HasScannableComponents flag based on whether any TargetResults had their Technology identified. (Change in commands/scan/scan.go)
Conditional Summary: The output logic (in utils/results/output/resultwriter.go) was modified. Before printing the final summary, it now checks:
If zero vulnerabilities were found AND the HasScannableComponents flag is false AND files were actually attempted, it prints a new, more accurate summary: ✨ Scan completed: No files of a supported type were found or scanned. ✨
Otherwise, it prints the original summary ("No vulnerable components found" or the vulnerability table).
Benefit:

This change significantly improves the user experience by:

Providing immediate feedback when a file is skipped due to its type.
Displaying a clear and accurate summary message when only unsupported files are scanned, preventing confusion.
Testing:

Verified locally by running the modified jf scan command against:

An unsupported file type (e.g., .txt, .exe): Confirmed the warning and the new summary message appear.
A supported file type with no vulnerabilities: Confirmed the standard "No vulnerable components" message appears.
A supported file type with vulnerabilities: Confirmed the vulnerability table appears correctly.