### PR TITLE
:bug: Fix bug to use Maven wrapper when DepTreeParams.UseWrapper is true

### DIFF
--- a/commands/audit/sca/java/mvn.go
+++ b/commands/audit/sca/java/mvn.go
@@ -174,7 +174,12 @@ func (mdt *MavenDepTreeManager) RunMvnCmd(goals []string) (cmdOutput []byte, err
 	}
 
 	//#nosec G204
-	cmdOutput, err = exec.Command("mvn", goals...).CombinedOutput()
+	// Fix bug #418 if DepTreeParams.UseWrapper is true, we need to run the maven wrapper script instead of 'mvn'
+	if mdt.useWrapper {
+		cmdOutput, err = exec.Command("./mvnw", goals...).CombinedOutput()
+	} else {
+		cmdOutput, err = exec.Command("mvn", goals...).CombinedOutput()
+	}
 	if err != nil {
 		stringOutput := string(cmdOutput)
 		if len(cmdOutput) > 0 {


### PR DESCRIPTION
## Description
As #418 explains, there's a hard-coded reference to run `mvn` tool even when we've passed the `--use-wrapper=true` option. This PR aims to fix the issue.

Resolves:
- #418   
- #323 
 
I can't find instructions for starting the test dependencies as outlined in https://github.com/ranma2913/jfrog-cli-security/blob/main/CONTRIBUTING.md#-running-tests. Is there a docker-compose or something I can start on http://localhost:8083 so tests can easily be ran on local?

## Tasks
- [x] The pull request is targeting the `dev` branch.
- [x] The code has been validated to compile successfully by running `go vet ./...`.
- [x] The code has been formatted properly using `go fmt ./...`.
- [ ] All [static analysis checks](https://github.com/jfrog/jfrog-cli-security/actions/workflows/analysis.yml) passed.
- [ ] All [tests](https://github.com/jfrog/jfrog-cli-security/actions/workflows/test.yml) have passed. If this feature is not already covered by the tests, new tests have been added.
- [x] Updated the [Contributing page](https://github.com/jfrog/jfrog-cli-security/blob/main/CONTRIBUTING.md) / [ReadMe page](https://github.com/jfrog/jfrog-cli-security/blob/main/README.md) / [CI Workflow files](https://github.com/jfrog/jfrog-cli-security/tree/main/.github/workflows) if needed.
- [ ] All changes are detailed at the description. if not already covered at [JFrog Documentation](https://github.com/jfrog/documentation), new documentation have been added.

-----