### PR TITLE
BuildScan - Fix parse violations if requested to show

### DIFF
--- a/utils/results/output/resultwriter.go
+++ b/utils/results/output/resultwriter.go
@@ -136,7 +136,7 @@ func (rw *ResultsWriter) createResultsConvertor(pretty bool) *conversion.Command
 		IncludeLicenses:        rw.commandResults.IncludesLicenses(),
 		IncludeSbom:            rw.commandResults.IncludeSbom(),
 		IncludeVulnerabilities: rw.commandResults.IncludesVulnerabilities(),
-		HasViolationContext:    rw.commandResults.HasViolationContext(),
+		HasViolationContext:    rw.showViolations || rw.commandResults.HasViolationContext(),
 		RequestedScans:         rw.subScansPerformed,
 		Pretty:                 pretty,
 	})


### PR DESCRIPTION
- [ ] The pull request is targeting the `dev` branch.
- [ ] The code has been validated to compile successfully by running `go vet ./...`.
- [ ] The code has been formatted properly using `go fmt ./...`.
- [ ] All [static analysis checks](https://github.com/jfrog/jfrog-cli-security/actions/workflows/analysis.yml) passed.
- [ ] All [tests](https://github.com/jfrog/jfrog-cli-security/actions/workflows/test.yml) have passed. If this feature is not already covered by the tests, new tests have been added.
- [ ] Updated the [Contributing page](https://github.com/jfrog/jfrog-cli-security/blob/main/CONTRIBUTING.md) / [ReadMe page](https://github.com/jfrog/jfrog-cli-security/blob/main/README.md) / [CI Workflow files](https://github.com/jfrog/jfrog-cli-security/tree/main/.github/workflows) if needed.
- [ ] All changes are detailed at the description. if not already covered at [JFrog Documentation](https://github.com/jfrog/documentation), new documentation have been added.

-----

if violation context flag is not requested in `jf build-scan` it did not parse the issues and displayed `empty` results.
only in `--format json` (raw response) was displayed since no conversion occur on this format.