### PR TITLE
Add Breaking Changes Validator Action

### DIFF
--- a/.github/workflows/break-validator.yml
+++ b/.github/workflows/break-validator.yml
@@ -1,0 +1,44 @@
+name: Validate breaking depended libraries
+on:
+  pull_request:
+    types: [labeled, unlabeled, opened, edited]  # Run when labels change or PR events occur
+  workflow_dispatch:
+
+# Ensures that only the latest commit is running for each PR at a time.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  # required for the action to create comments on the PR
+  pull-requests: write
+
+jobs:
+  validate-depended-libraries:
+    name: "Validate if ${{ matrix.library.name }} is broken"
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        library:
+          - name: 'JFrog CLI'
+            branch: 'dev'
+            url: 'https://github.com/jfrog/jfrog-cli.git'
+          - name: 'Frogbot'
+            url: 'https://github.com/jfrog/frogbot.git'
+            branch: 'dev'
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - uses: attiasas/breaking-change-validator@main
+        env:
+          # Optional, needed for some action operations (generating PR comments)
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          repository: ${{ matrix.library.url }}
+          branch: ${{ matrix.library.branch }}
+          output_strategy: 'terminal, summary, comment'
+          test_command: ${{ github.event_name != 'pull_request' && matrix.library.test_command || (contains(github.event.pull_request.labels.*.name, 'test dependencies') && matrix.library.test_command) || '' }}
+          remediation_label: ${{ github.event_name == 'pull_request' && 'breaking change' || '' }}


### PR DESCRIPTION
- [ ] The pull request is targeting the `dev` branch.
- [ ] The code has been validated to compile successfully by running `go vet ./...`.
- [ ] The code has been formatted properly using `go fmt ./...`.
- [ ] All [static analysis checks](https://github.com/jfrog/jfrog-cli-security/actions/workflows/analysis.yml) passed.
- [ ] All [tests](https://github.com/jfrog/jfrog-cli-security/actions/workflows/test.yml) have passed. If this feature is not already covered by the tests, new tests have been added.
- [ ] Updated the [Contributing page](https://github.com/jfrog/jfrog-cli-security/blob/main/CONTRIBUTING.md) / [ReadMe page](https://github.com/jfrog/jfrog-cli-security/blob/main/README.md) / [CI Workflow files](https://github.com/jfrog/jfrog-cli-security/tree/main/.github/workflows) if needed.
- [ ] All changes are detailed at the description. if not already covered at [JFrog Documentation](https://github.com/jfrog/documentation), new documentation have been added.

-----

Adding a new action to validate if changes are breaking our internal depenendcies that uses `security-cli`