### PR TITLE
Revert conan use of PipRequirementsFile

### DIFF
--- a/commands/audit/sca/conan/conan.go
+++ b/commands/audit/sca/conan/conan.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"os/exec"
-	"path/filepath"
 
 	"github.com/jfrog/gofrog/datastructures"
 	"github.com/jfrog/gofrog/io"
@@ -109,16 +108,7 @@ func calculateUniqueDependencies(nodes map[string]conanRef) []string {
 }
 
 func calculateDependencies(executablePath, workingDir string, params utils.AuditParams) (dependencyTrees []*xrayUtils.GraphNode, uniqueDeps []string, err error) {
-	graphInfo := []string{"info"}
-	if params.PipRequirementsFile() != "" {
-		// We allow passing a custom name for the descriptor file to be used in the 'graph info' command. If non has provided we execute the command on the current dir.
-		// Since this ability already exists for python we leverage this ability
-		graphInfo = append(graphInfo, filepath.Join(workingDir, params.PipRequirementsFile()))
-	} else {
-		graphInfo = append(graphInfo, ".")
-	}
-	graphInfo = append(graphInfo, "--format=json")
-	graphInfo = append(graphInfo, params.Args()...)
+	graphInfo := append([]string{"info", ".", "--format=json"}, params.Args()...)
 	conanGraphInfoContent, err := getConanCmd(executablePath, workingDir, "graph", graphInfo...).RunWithOutput()
 	if err != nil {
 		return

--- a/commands/audit/scarunner.go
+++ b/commands/audit/scarunner.go
@@ -117,8 +117,6 @@ func getRequestedDescriptors(params *AuditParams) map[techutils.Technology][]str
 	requestedDescriptors := map[techutils.Technology][]string{}
 	if params.PipRequirementsFile() != "" {
 		requestedDescriptors[techutils.Pip] = []string{params.PipRequirementsFile()}
-		// We leverage the ability to pass a custom descriptor name for Conan through PipRequirementsFile as well, therefore we set also Conan with the provided descriptor name.
-		requestedDescriptors[techutils.Conan] = []string{params.PipRequirementsFile()}
 	}
 	return requestedDescriptors
 }


### PR DESCRIPTION
- [ ] The pull request is targeting the `dev` branch.
- [ ] The code has been validated to compile successfully by running `go vet ./...`.
- [ ] The code has been formatted properly using `go fmt ./...`.
- [ ] All [static analysis checks](https://github.com/jfrog/jfrog-cli-security/actions/workflows/analysis.yml) passed.
- [ ] All [tests](https://github.com/jfrog/jfrog-cli-security/actions/workflows/test.yml) have passed. If this feature is not already covered by the tests, new tests have been added.
- [ ] Updated the [Contributing page](https://github.com/jfrog/jfrog-cli-security/blob/main/CONTRIBUTING.md) / [ReadMe page](https://github.com/jfrog/jfrog-cli-security/blob/main/README.md) / [CI Workflow files](https://github.com/jfrog/jfrog-cli-security/tree/main/.github/workflows) if needed.
- [ ] All changes are detailed at the description. if not already covered at [JFrog Documentation](https://github.com/jfrog/documentation), new documentation have been added.

-----

Fixing issue of running conan when PipRequirementsFile and intended for python (if requested, we will add additional flag for this) introduced at https://github.com/jfrog/jfrog-cli-security/pull/412

when provided `PipRequirementsFile` it always detects the dir as `conan` and `python`