### PR TITLE
Fix empty tree sent to SCA scan

### DIFF
--- a/commands/audit/scarunner.go
+++ b/commands/audit/scarunner.go
@@ -39,8 +39,8 @@ func AddScaScansToRunner(auditParallelRunner *utils.SecurityParallelRunner, audi
 	// Perform SCA scans
 	for _, targetResult := range cmdResults.Targets {
 		treeResult := getTargetCompTree(targetResult, auditParams, cmdResults)
-		if treeResult == nil {
-			// No tree, no scan
+		if treeResult == nil || treeResult.FlatTree == nil || len(treeResult.FlatTree.Nodes) == 0 {
+			// If there is no tree, or a tree without any non-root dependencies - we don't need to scan it
 			continue
 		}
 		// Create sca scan task


### PR DESCRIPTION
- [ ] The pull request is targeting the `dev` branch.
- [ ] The code has been validated to compile successfully by running `go vet ./...`.
- [ ] The code has been formatted properly using `go fmt ./...`.
- [ ] All [static analysis checks](https://github.com/jfrog/jfrog-cli-security/actions/workflows/analysis.yml) passed.
- [ ] All [tests](https://github.com/jfrog/jfrog-cli-security/actions/workflows/test.yml) have passed. If this feature is not already covered by the tests, new tests have been added.
- [ ] Updated the [Contributing page](https://github.com/jfrog/jfrog-cli-security/blob/main/CONTRIBUTING.md) / [ReadMe page](https://github.com/jfrog/jfrog-cli-security/blob/main/README.md) / [CI Workflow files](https://github.com/jfrog/jfrog-cli-security/tree/main/.github/workflows) if needed.
- [ ] All changes are detailed at the description. if not already covered at [JFrog Documentation](https://github.com/jfrog/documentation), new documentation have been added.

-----
This change resolves a bug that made an empty dep-tree (tree without at least non-root dependency) to be sent to SCA scan