### PR TITLE
AppTrust: Forward ApplicationKey through audit params to AnalyzerManager

### DIFF
--- a/commands/audit/audit.go
+++ b/commands/audit/audit.go
@@ -103,11 +103,12 @@ func (auditCmd *AuditCommand) SetThreads(threads int) *AuditCommand {
 }
 
 // Create a results context based on the provided parameters. resolves conflicts between the parameters based on the retrieved platform watches.
-func CreateAuditResultsContext(serverDetails *config.ServerDetails, xrayVersion string, watches []string, artifactoryRepoPath, projectKey, gitRepoHttpsCloneUrl string, includeVulnerabilities, includeLicenses, includeSbom bool) (context results.ResultContext) {
+func CreateAuditResultsContext(serverDetails *config.ServerDetails, xrayVersion string, watches []string, artifactoryRepoPath, projectKey, gitRepoHttpsCloneUrl, applicationKey string, includeVulnerabilities, includeLicenses, includeSbom bool) (context results.ResultContext) {
 	context = results.ResultContext{
 		RepoPath:               artifactoryRepoPath,
 		Watches:                watches,
 		ProjectKey:             projectKey,
+		ApplicationKey:         applicationKey,
 		IncludeVulnerabilities: shouldIncludeVulnerabilities(includeVulnerabilities, watches, artifactoryRepoPath, projectKey, ""),
 		IncludeLicenses:        includeLicenses,
 		IncludeSbom:            includeSbom,
@@ -180,6 +181,8 @@ func (auditCmd *AuditCommand) Run() (err error) {
 			auditCmd.targetRepoPath,
 			auditCmd.projectKey,
 			auditCmd.gitRepoHttpsCloneUrl,
+			// AppTrust is currently not supported in Audit command, therefore we pass an empty applicationKey
+			"",
 			auditCmd.IncludeVulnerabilities,
 			auditCmd.IncludeLicenses,
 			auditCmd.IncludeSbom,
@@ -435,6 +438,7 @@ func AddJasScansToRunner(auditParallelRunner *utils.SecurityParallelRunner, audi
 				auditParams.GetMultiScanId(),
 				utils.GetGitRepoUrlKey(auditParams.resultsContext.GitRepoHttpsCloneUrl),
 				auditParams.resultsContext.ProjectKey,
+				auditParams.resultsContext.ApplicationKey,
 				auditParams.resultsContext.Watches,
 				scanResults.GetTechnologies()...,
 			),

--- a/commands/audit/audit_test.go
+++ b/commands/audit/audit_test.go
@@ -829,6 +829,7 @@ func TestCreateResultsContext(t *testing.T) {
 	mockWatches := []string{"watch-1", "watch-2"}
 	mockProjectKey := "project"
 	mockArtifactoryRepoPath := "repo/path"
+	mockApplicationKey := "app-key"
 
 	tests := []struct {
 		name                    string
@@ -862,6 +863,7 @@ func TestCreateResultsContext(t *testing.T) {
 			httpCloneUrl           string
 			watches                []string
 			jfrogProjectKey        string
+			jfrogApplicationKey    string
 			includeVulnerabilities bool
 			includeLicenses        bool
 			includeSbom            bool
@@ -870,6 +872,7 @@ func TestCreateResultsContext(t *testing.T) {
 			expectedHttpCloneUrl           string
 			expectedWatches                []string
 			expectedJfrogProjectKey        string
+			expectedJfrogApplicationKey    string
 			expectedIncludeVulnerabilities bool
 			expectedIncludeLicenses        bool
 			expectedIncludeSbom            bool
@@ -901,6 +904,12 @@ func TestCreateResultsContext(t *testing.T) {
 				expectedIncludeLicenses: true,
 			},
 			{
+				name:                           "Application Key",
+				jfrogApplicationKey:            mockApplicationKey,
+				expectedJfrogApplicationKey:    mockApplicationKey,
+				expectedIncludeVulnerabilities: true,
+			},
+			{
 				name:                           "Git Clone Url",
 				httpCloneUrl:                   validations.TestMockGitInfo.Source.GitRepoHttpsCloneUrl,
 				expectedHttpCloneUrl:           testCaseExpectedGitRepoHttpsCloneUrl,
@@ -911,6 +920,7 @@ func TestCreateResultsContext(t *testing.T) {
 				httpCloneUrl:           validations.TestMockGitInfo.Source.GitRepoHttpsCloneUrl,
 				watches:                mockWatches,
 				jfrogProjectKey:        mockProjectKey,
+				jfrogApplicationKey:    mockApplicationKey,
 				includeVulnerabilities: true,
 				includeLicenses:        true,
 				includeSbom:            true,
@@ -918,6 +928,7 @@ func TestCreateResultsContext(t *testing.T) {
 				expectedHttpCloneUrl:           testCaseExpectedGitRepoHttpsCloneUrl,
 				expectedWatches:                mockWatches,
 				expectedJfrogProjectKey:        mockProjectKey,
+				expectedJfrogApplicationKey:    mockApplicationKey,
 				expectedIncludeVulnerabilities: true,
 				expectedIncludeLicenses:        true,
 				expectedIncludeSbom:            true,
@@ -927,11 +938,12 @@ func TestCreateResultsContext(t *testing.T) {
 			t.Run(fmt.Sprintf("%s - %s", test.name, testCase.name), func(t *testing.T) {
 				mockServer, serverDetails, _ := validations.XrayServer(t, validations.MockServerParams{XrayVersion: test.xrayVersion, ReturnMockPlatformWatches: test.expectedPlatformWatches})
 				defer mockServer.Close()
-				context := CreateAuditResultsContext(serverDetails, test.xrayVersion, testCase.watches, testCase.artifactoryRepoPath, testCase.jfrogProjectKey, testCase.httpCloneUrl, testCase.includeVulnerabilities, testCase.includeLicenses, testCase.includeSbom)
+				context := CreateAuditResultsContext(serverDetails, test.xrayVersion, testCase.watches, testCase.artifactoryRepoPath, testCase.jfrogProjectKey, testCase.httpCloneUrl, testCase.jfrogApplicationKey, testCase.includeVulnerabilities, testCase.includeLicenses, testCase.includeSbom)
 				assert.Equal(t, testCase.expectedArtifactoryRepoPath, context.RepoPath)
 				assert.Equal(t, testCase.expectedHttpCloneUrl, context.GitRepoHttpsCloneUrl)
 				assert.Equal(t, testCase.expectedWatches, context.Watches)
 				assert.Equal(t, testCase.expectedJfrogProjectKey, context.ProjectKey)
+				assert.Equal(t, testCase.expectedJfrogApplicationKey, context.ApplicationKey)
 				assert.Equal(t, testCase.expectedIncludeVulnerabilities, context.IncludeVulnerabilities)
 				assert.Equal(t, testCase.expectedIncludeLicenses, context.IncludeLicenses)
 				assert.Equal(t, testCase.expectedIncludeSbom, context.IncludeSbom)

--- a/commands/git/audit/gitaudit.go
+++ b/commands/git/audit/gitaudit.go
@@ -84,6 +84,8 @@ func toAuditParams(params GitAuditParams) *sourceAudit.AuditParams {
 		params.resultsContext.RepoPath,
 		params.resultsContext.ProjectKey,
 		params.source.Source.GitRepoHttpsCloneUrl,
+		// AppTrust is currently not supported in Git Audit command, therefore we pass an empty applicationKey
+		"",
 		params.resultsContext.IncludeVulnerabilities,
 		params.resultsContext.IncludeLicenses,
 		false,

--- a/commands/scan/scan.go
+++ b/commands/scan/scan.go
@@ -497,9 +497,11 @@ func (scanCmd *ScanCommand) RunBinaryJasScans(cmdType utils.CommandType, msi str
 			jas.NotDiffScanEnvValue,
 			jas.GetAnalyzerManagerXscEnvVars(
 				msi,
-				// Passing but empty since not supported for binary scans
-				scanCmd.resultsContext.GitRepoHttpsCloneUrl,
+				// GitRepoHttpsCloneUrl is not relevant for binary scans, therefore we pass an empty value
+				"",
 				scanCmd.resultsContext.ProjectKey,
+				// AppTrust is not supported for binary scans, therefore we pass an empty applicationKey
+				"",
 				scanCmd.resultsContext.Watches,
 				targetResults.GetTechnologies()...,
 			),

--- a/jas/analyzermanager.go
+++ b/jas/analyzermanager.go
@@ -39,6 +39,7 @@ const (
 	watchesEnvVariable                        = "AM_WATCHES"
 	projectEnvVariable                        = "AM_PROJECT_KEY"
 	gitRepoEnvVariable                        = "AM_GIT_REPO_VIOLATIONS"
+	applicationKeyEnvVariable                 = "AM_APPLICATION_KEY"
 	notEntitledExitCode                       = 31
 	unsupportedCommandExitCode                = 13
 	unsupportedOsExitCode                     = 55

--- a/jas/common.go
+++ b/jas/common.go
@@ -450,13 +450,16 @@ func CheckForSecretValidation(xrayManager *xray.XrayServicesManager, xrayVersion
 	return err == nil && isEnabled
 }
 
-func GetAnalyzerManagerXscEnvVars(msi string, gitRepoUrl, projectKey string, watches []string, technologies ...techutils.Technology) map[string]string {
+func GetAnalyzerManagerXscEnvVars(msi string, gitRepoUrl, projectKey, applicationKey string, watches []string, technologies ...techutils.Technology) map[string]string {
 	envVars := map[string]string{utils.JfMsiEnvVariable: msi}
 	if gitRepoUrl != "" {
 		envVars[gitRepoEnvVariable] = gitRepoUrl
 	}
 	if projectKey != "" {
 		envVars[projectEnvVariable] = projectKey
+	}
+	if applicationKey != "" {
+		envVars[applicationKeyEnvVariable] = applicationKey
 	}
 	if len(watches) > 0 {
 		envVars[watchesEnvVariable] = strings.Join(watches, ",")

--- a/jas/common_test.go
+++ b/jas/common_test.go
@@ -416,6 +416,7 @@ func TestGetAnalyzerManagerXscEnvVars(t *testing.T) {
 		msi            string
 		gitRepoUrl     string
 		projectKey     string
+		applicationKey string
 		watches        []string
 		technologies   []techutils.Technology
 		expectedOutput map[string]string
@@ -482,10 +483,24 @@ func TestGetAnalyzerManagerXscEnvVars(t *testing.T) {
 				watchesEnvVariable:          "watch1,watch2",
 			},
 		},
+		{
+			name:           "With Application Key",
+			msi:            "msi",
+			gitRepoUrl:     "gitRepoUrl",
+			applicationKey: "appKey",
+			technologies:   []techutils.Technology{techutils.Npm},
+			expectedOutput: map[string]string{
+				JfPackageManagerEnvVariable: string(techutils.Npm),
+				JfLanguageEnvVariable:       string(techutils.JavaScript),
+				utils.JfMsiEnvVariable:      "msi",
+				gitRepoEnvVariable:          "gitRepoUrl",
+				applicationKeyEnvVariable:   "appKey",
+			},
+		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			assert.Equal(t, test.expectedOutput, GetAnalyzerManagerXscEnvVars(test.msi, test.gitRepoUrl, test.projectKey, test.watches, test.technologies...))
+			assert.Equal(t, test.expectedOutput, GetAnalyzerManagerXscEnvVars(test.msi, test.gitRepoUrl, test.projectKey, test.applicationKey, test.watches, test.technologies...))
 		})
 	}
 }

--- a/jas/runner/jasrunner_test.go
+++ b/jas/runner/jasrunner_test.go
@@ -43,7 +43,7 @@ func TestJasRunner(t *testing.T) {
 	securityParallelRunnerForTest := utils.CreateSecurityParallelRunner(cliutils.Threads)
 	targetResults := results.NewCommandResults(utils.SourceCode).SetEntitledForJas(true).SetSecretValidation(true).NewScanResults(results.ScanTarget{Target: "target", Technology: techutils.Pip})
 
-	jasScanner, err := jas.NewJasScanner(&jas.FakeServerDetails, jas.WithEnvVars(false, jas.NotDiffScanEnvValue, jas.GetAnalyzerManagerXscEnvVars("", "", "", []string{}, targetResults.GetTechnologies()...)))
+	jasScanner, err := jas.NewJasScanner(&jas.FakeServerDetails, jas.WithEnvVars(false, jas.NotDiffScanEnvValue, jas.GetAnalyzerManagerXscEnvVars("", "", "", "", []string{}, targetResults.GetTechnologies()...)))
 	assert.NoError(t, err)
 
 	targetResults.NewScaScanResults(0, jas.FakeBasicXrayResults[0])

--- a/utils/results/results.go
+++ b/utils/results/results.go
@@ -55,6 +55,8 @@ type ResultContext struct {
 	ProjectKey string `json:"project_key,omitempty"`
 	// (Resource) If gitRepository is provided we will fetch the watches defined on the git repository.
 	GitRepoHttpsCloneUrl string `json:"git_repo_key,omitempty"`
+	// (Resource) If applicationKey is provided we will fetch the watches defined on the application, and the scans will be performed and presented in the Application context only.
+	ApplicationKey string `json:"application_key,omitempty"`
 	// If non of the above is provided or requested, the results will include vulnerabilities
 	IncludeVulnerabilities bool `json:"include_vulnerabilities"`
 	// If requested, the results will include licenses


### PR DESCRIPTION
- [ ] The pull request is targeting the `dev` branch.
- [ ] The code has been validated to compile successfully by running `go vet ./...`.
- [ ] The code has been formatted properly using `go fmt ./...`.
- [ ] All [static analysis checks](https://github.com/jfrog/jfrog-cli-security/actions/workflows/analysis.yml) passed.
- [ ] All [tests](https://github.com/jfrog/jfrog-cli-security/actions/workflows/test.yml) have passed. If this feature is not already covered by the tests, new tests have been added.
- [ ] Updated the [Contributing page](https://github.com/jfrog/jfrog-cli-security/blob/main/CONTRIBUTING.md) / [ReadMe page](https://github.com/jfrog/jfrog-cli-security/blob/main/README.md) / [CI Workflow files](https://github.com/jfrog/jfrog-cli-security/tree/main/.github/workflows) if needed.
- [ ] All changes are detailed at the description. if not already covered at [JFrog Documentation](https://github.com/jfrog/documentation), new documentation have been added.

-----
This Pr is part of the new AppTrust initiative.
We pass the application key, if received, through audit params to the analyzer manager, but only if we enter from **Frogbot**
Currently AppTrust is not supported for on-demand audit/ on-demand git audit/ on-demand scan