### PR TITLE
Fix generate URL after upload-cdx

### DIFF
--- a/commands/upload/uploadcdx.go
+++ b/commands/upload/uploadcdx.go
@@ -90,13 +90,13 @@ func validateInputFile(cdxFilePath string) (metadata *cyclonedx.Metadata, err er
 	}
 	// check if the file is a valid cdx file
 	bom, err := utils.ReadSbomFromFile(cdxFilePath)
-	if err != nil || bom == nil || bom.Metadata == nil {
+	if err != nil || bom == nil || bom.Metadata == nil || bom.Metadata.Component == nil {
 		return nil, fmt.Errorf("provided file %s is not a valid CycloneDX SBOM: %w", cdxFilePath, err)
 	}
 	metadata = bom.Metadata
-	metadataStr, err := utils.GetAsJsonString(bom.Metadata, true, true)
+	componentStr, err := utils.GetAsJsonString(bom.Metadata.Component, true, true)
 	if err == nil {
-		log.Debug(fmt.Sprintf("found valid CycloneDX SBOM file with Metadata:\n%s", metadataStr))
+		log.Debug(fmt.Sprintf("found valid CycloneDX SBOM file with Metadata component:\n%s", componentStr))
 	}
 	return
 }
@@ -129,6 +129,8 @@ func generateURLFromPath(baseUrl, repoPath, filePath, metadataComponent string) 
 		if sha256 != "" {
 			shaPart = fmt.Sprintf("sha256:%s/", sha256)
 		}
+		// If no metadata component is provided, use the artifact name as the package ID
+		metadataComponent = artifactName
 	}
 
 	packageID := fmt.Sprintf("generic://%s%s", shaPart, metadataComponent)

--- a/commands/upload/uploadcdx_test.go
+++ b/commands/upload/uploadcdx_test.go
@@ -1,0 +1,104 @@
+package upload
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/CycloneDX/cyclonedx-go"
+	coreTests "github.com/jfrog/jfrog-cli-core/v2/utils/tests"
+	"github.com/jfrog/jfrog-cli-security/utils"
+	"github.com/jfrog/jfrog-cli-security/utils/formats/cdxutils"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestValidateInputFile(t *testing.T) {
+	tempDirPath, createTempDirCallback := coreTests.CreateTempDirWithCallbackAndAssert(t)
+	defer createTempDirCallback()
+	// Create a valid CycloneDX file for testing
+	validCdxFilePath := filepath.Join(tempDirPath, "some_results.cdx.json")
+	fileComponent := cdxutils.CreateFileOrDirComponent(filepath.Join("a", "directory", "file.txt"))
+	cdx := cyclonedx.NewBOM()
+	cdx.Metadata = &cyclonedx.Metadata{
+		Component: &fileComponent,
+	}
+	assert.NoError(t, utils.SaveCdxContentToFile(validCdxFilePath, cdx))
+	// create a file with not valid extension
+	noCdxExtensionFile := filepath.Join(tempDirPath, "invalid_results.json")
+	assert.NoError(t, utils.DumpContentToFile([]byte("This is not a valid CycloneDX file."), tempDirPath, "invalid_results", -1))
+
+	tests := []struct {
+		name        string
+		filePath    string
+		expectError bool
+	}{
+		{
+			name:        "Valid CycloneDX file",
+			filePath:    validCdxFilePath,
+			expectError: false,
+		},
+		{
+			name:        "Not valid existent file",
+			filePath:    noCdxExtensionFile,
+			expectError: true,
+		},
+		{
+			name:        "Not existing file",
+			filePath:    "testdata/invalid_cdx.json",
+			expectError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := validateInputFile(tt.filePath)
+			if (err != nil) != tt.expectError {
+				t.Errorf("validateInputFile() error = %v, expectError %v", err, tt.expectError)
+			}
+		})
+	}
+}
+
+func TestGenerateURLFromPath(t *testing.T) {
+	baseUrl := "https://example.com/"
+	// Create a temp file with some content for testing
+	tempDirPath, createTempDirCallback := coreTests.CreateTempDirWithCallbackAndAssert(t)
+	defer createTempDirCallback()
+	// Create a valid CycloneDX file for testing
+	validCdxFilePath := filepath.Join(tempDirPath, "valid_cdx.json")
+	fileComponent := cdxutils.CreateFileOrDirComponent(filepath.Join("a", "directory", "file.txt"))
+	cdx := cyclonedx.NewBOM()
+	cdx.Metadata = &cyclonedx.Metadata{
+		Component: &fileComponent,
+	}
+	assert.NoError(t, utils.SaveCdxContentToFile(validCdxFilePath, cdx))
+
+	tests := []struct {
+		name              string
+		repoPath          string
+		filePath          string
+		metadataComponent string
+		expected          string
+	}{
+		{
+			name:     "No metadata component",
+			repoPath: "testdata/",
+			filePath: validCdxFilePath,
+			expected: "https://example.com/ui/scans-list/repositories/testdata%2F/scan-descendants/valid_cdx.json?package_id=generic%3A%2F%2Fsha256%3A0d4ec5a32b4e6f0dcda6d22ae7b802339a0e9931dbd62363365e8e2977b943f0%2Fvalid_cdx.json&page_type=overview&path=testdata%2F%2Fvalid_cdx.json",
+		},
+		{
+			name:              "With metadata component",
+			repoPath:          "testdata/",
+			filePath:          validCdxFilePath,
+			metadataComponent: fileComponent.Name,
+			expected:          "https://example.com/ui/scans-list/repositories/testdata%2F/scan-descendants/valid_cdx.json?package_id=generic%3A%2F%2Fa%2Fdirectory%2Ffile.txt&page_type=overview&path=testdata%2F%2Fvalid_cdx.json",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := generateURLFromPath(baseUrl, tt.repoPath, tt.filePath, tt.metadataComponent)
+			assert.NoError(t, err)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}

--- a/commands/upload/uploadcdx_test.go
+++ b/commands/upload/uploadcdx_test.go
@@ -73,30 +73,36 @@ func TestGenerateURLFromPath(t *testing.T) {
 	assert.NoError(t, utils.SaveCdxContentToFile(validCdxFilePath, cdx))
 
 	tests := []struct {
-		name              string
-		repoPath          string
-		filePath          string
-		metadataComponent string
-		expected          string
+		name     string
+		repoPath string
+		filePath string
+		metadata *cyclonedx.Metadata
+		expected string
 	}{
 		{
 			name:     "No metadata component",
 			repoPath: "testdata/",
 			filePath: validCdxFilePath,
-			expected: "https://example.com/ui/scans-list/repositories/testdata%2F/scan-descendants/valid_cdx.json?package_id=generic%3A%2F%2Fsha256%3A0d4ec5a32b4e6f0dcda6d22ae7b802339a0e9931dbd62363365e8e2977b943f0%2Fvalid_cdx.json&page_type=overview&path=testdata%2F%2Fvalid_cdx.json",
+			expected: "https://example.com/ui/scans-list/repositories/testdata/scan-descendants/valid_cdx.json?package_id=generic%3A%2F%2Fsha256%3A0d4ec5a32b4e6f0dcda6d22ae7b802339a0e9931dbd62363365e8e2977b943f0%2Fvalid_cdx.json&page_type=overview&path=testdata%2F%2Fvalid_cdx.json",
 		},
 		{
-			name:              "With metadata component",
-			repoPath:          "testdata/",
-			filePath:          validCdxFilePath,
-			metadataComponent: fileComponent.Name,
-			expected:          "https://example.com/ui/scans-list/repositories/testdata%2F/scan-descendants/valid_cdx.json?package_id=generic%3A%2F%2Fa%2Fdirectory%2Ffile.txt&page_type=overview&path=testdata%2F%2Fvalid_cdx.json",
+			name:     "With metadata component",
+			repoPath: "testdata/",
+			filePath: validCdxFilePath,
+			metadata: &cyclonedx.Metadata{Component: &cyclonedx.Component{Name: "metadata-comp:name", Version: "1.0", Type: cyclonedx.ComponentTypeFile}},
+			expected: "https://example.com/ui/scans-list/repositories/testdata/scan-descendants/valid_cdx.json?package_id=generic%3A%2F%2Fmetadata-comp%3Aname&page_type=overview&path=testdata%2F%2Fvalid_cdx.json",
+		},
+		{
+			name:     "With subdirectory in repoPath",
+			repoPath: "testdata/subdir/",
+			filePath: validCdxFilePath,
+			expected: "https://example.com/ui/scans-list/repositories/testdata/scan-descendants/valid_cdx.json?package_id=generic%3A%2F%2Fsha256%3A0d4ec5a32b4e6f0dcda6d22ae7b802339a0e9931dbd62363365e8e2977b943f0%2Fvalid_cdx.json&page_type=overview&path=testdata%2Fsubdir%2F%2Fvalid_cdx.json",
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result, err := generateURLFromPath(baseUrl, tt.repoPath, tt.filePath, tt.metadataComponent)
+			result, err := generateURLFromPath(baseUrl, tt.repoPath, tt.filePath, tt.metadata)
 			assert.NoError(t, err)
 			assert.Equal(t, tt.expected, result)
 		})

--- a/utils/artifactory/artifactoryutils.go
+++ b/utils/artifactory/artifactoryutils.go
@@ -3,6 +3,7 @@ package artifactory
 import (
 	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/jfrog/jfrog-cli-security/utils/techutils"
 	"github.com/jfrog/jfrog-client-go/artifactory/services"
@@ -85,6 +86,11 @@ func getArtifactoryRepositoryConfig(tech techutils.Technology) (repoConfig *proj
 }
 
 func UploadArtifactsByPattern(pattern string, serverDetails *config.ServerDetails, repo string) (err error) {
+	if strings.Contains(repo, "/") && !strings.HasSuffix(repo, "/") {
+		// target repo is <repository name>/<repository path>, If the target path ends with a slash, the path is assumed to be a folder.
+		// Else it is assumed to be a file. so we add a slash to the end of the repo to indicate that it is a folder.
+		repo = fmt.Sprintf("%s/", repo)
+	}
 	uploadCmd := generic.NewUploadCommand()
 	uploadCmd.SetUploadConfiguration(&artifactoryUtils.UploadConfiguration{Threads: 1}).SetServerDetails(serverDetails).SetSpec(spec.NewBuilder().Pattern(pattern).Target(repo).Flat(true).BuildSpec())
 	uploadCmd.SetDetailedSummary(true)

--- a/utils/path_test.go
+++ b/utils/path_test.go
@@ -85,7 +85,6 @@ func TestGetRepositoriesScansListUrlForArtifact(t *testing.T) {
 		name         string
 		baseUrl      string
 		repoPath     string
-		targetPath   string
 		artifactName string
 		packageId    string
 		expected     string
@@ -94,25 +93,23 @@ func TestGetRepositoriesScansListUrlForArtifact(t *testing.T) {
 			name:         "basic case",
 			baseUrl:      "http://localhost:8081/",
 			repoPath:     "my-repo",
-			targetPath:   "artifact.zip",
 			artifactName: "artifact.zip",
 			packageId:    "abc123",
 			expected:     "http://localhost:8081/ui/scans-list/repositories/my-repo/scan-descendants/artifact.zip?package_id=abc123&page_type=overview&path=my-repo%2Fartifact.zip",
 		},
 		{
-			name:         "with subdirectory",
+			name:         "with sub dir in repoPath",
 			baseUrl:      "http://localhost:8081/",
-			repoPath:     "my-repo",
-			targetPath:   "path/to/artifact.zip",
+			repoPath:     "my-repo/subdir",
 			artifactName: "artifact.zip",
 			packageId:    "abc123",
-			expected:     "http://localhost:8081/ui/scans-list/repositories/my-repo/scan-descendants/artifact.zip?package_id=abc123&page_type=overview&path=my-repo%2Fpath%2Fto%2Fartifact.zip",
+			expected:     "http://localhost:8081/ui/scans-list/repositories/my-repo/scan-descendants/artifact.zip?package_id=abc123&page_type=overview&path=my-repo%2Fsubdir%2Fartifact.zip",
 		},
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			result := GetRepositoriesScansListUrlForArtifact(test.baseUrl, test.repoPath, test.targetPath, test.artifactName, test.packageId)
+			result := GetRepositoriesScansListUrlForArtifact(test.baseUrl, test.repoPath, test.artifactName, test.packageId)
 			assert.Equal(t, test.expected, result, "expected '%s', got '%s'", test.expected, result)
 		})
 	}

--- a/utils/path_test.go
+++ b/utils/path_test.go
@@ -87,7 +87,7 @@ func TestGetRepositoriesScansListUrlForArtifact(t *testing.T) {
 		repoPath     string
 		targetPath   string
 		artifactName string
-		sha256       string
+		packageId    string
 		expected     string
 	}{
 		{
@@ -96,8 +96,8 @@ func TestGetRepositoriesScansListUrlForArtifact(t *testing.T) {
 			repoPath:     "my-repo",
 			targetPath:   "artifact.zip",
 			artifactName: "artifact.zip",
-			sha256:       "abc123",
-			expected:     "http://localhost:8081/ui/scans-list/repositories/my-repo/scan-descendants/artifact.zip?package_id=generic%3A%2F%2Fsha256%3Aabc123%2Fartifact.zip&page_type=overview&path=my-repo%2Fartifact.zip",
+			packageId:    "abc123",
+			expected:     "http://localhost:8081/ui/scans-list/repositories/my-repo/scan-descendants/artifact.zip?package_id=abc123&page_type=overview&path=my-repo%2Fartifact.zip",
 		},
 		{
 			name:         "with subdirectory",
@@ -105,15 +105,15 @@ func TestGetRepositoriesScansListUrlForArtifact(t *testing.T) {
 			repoPath:     "my-repo",
 			targetPath:   "path/to/artifact.zip",
 			artifactName: "artifact.zip",
-			sha256:       "abc123",
-			expected:     "http://localhost:8081/ui/scans-list/repositories/my-repo/scan-descendants/artifact.zip?package_id=generic%3A%2F%2Fsha256%3Aabc123%2Fartifact.zip&page_type=overview&path=my-repo%2Fpath%2Fto%2Fartifact.zip",
+			packageId:    "abc123",
+			expected:     "http://localhost:8081/ui/scans-list/repositories/my-repo/scan-descendants/artifact.zip?package_id=abc123&page_type=overview&path=my-repo%2Fpath%2Fto%2Fartifact.zip",
 		},
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			result := GetRepositoriesScansListUrlForArtifact(test.baseUrl, test.repoPath, test.targetPath, test.artifactName, test.sha256)
-			assert.Equal(t, result, test.expected, "expected '%s', got '%s'", test.expected, result)
+			result := GetRepositoriesScansListUrlForArtifact(test.baseUrl, test.repoPath, test.targetPath, test.artifactName, test.packageId)
+			assert.Equal(t, test.expected, result, "expected '%s', got '%s'", test.expected, result)
 		})
 	}
 }

--- a/utils/paths.go
+++ b/utils/paths.go
@@ -5,6 +5,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/jfrog/jfrog-cli-core/v2/utils/coreutils"
 	"github.com/jfrog/jfrog-client-go/utils/log"
@@ -149,14 +150,20 @@ func ToURI(path string) string {
 	return u.String()
 }
 
-func GetRepositoriesScansListUrlForArtifact(baseUrl, repoPath, targetPath, artifactName, packageID string) string {
+func GetRepositoriesScansListUrlForArtifact(baseUrl, repoPath, artifactName, packageID string) string {
+	repoName := repoPath
+	if strings.Contains(repoPath, "/") {
+		// If repoPath contains a slash, it may be a repository path with sub-paths.
+		// We need to extract the repository name from the path.
+		repoName = strings.Split(repoPath, "/")[0]
+	}
 	// Path
-	path := fmt.Sprintf("ui/scans-list/repositories/%s/scan-descendants/%s", url.PathEscape(repoPath), url.PathEscape(artifactName))
+	path := fmt.Sprintf("ui/scans-list/repositories/%s/scan-descendants/%s", url.PathEscape(repoName), url.PathEscape(artifactName))
 
 	// Query params
 	query := url.Values{}
 	query.Set("package_id", packageID)
-	query.Set("path", fmt.Sprintf("%s/%s", repoPath, targetPath))
+	query.Set("path", fmt.Sprintf("%s/%s", repoPath, artifactName))
 	query.Set("page_type", "overview")
 
 	// Final URL

--- a/utils/paths.go
+++ b/utils/paths.go
@@ -149,12 +149,11 @@ func ToURI(path string) string {
 	return u.String()
 }
 
-func GetRepositoriesScansListUrlForArtifact(baseUrl, repoPath, targetPath, artifactName, sha256 string) string {
+func GetRepositoriesScansListUrlForArtifact(baseUrl, repoPath, targetPath, artifactName, packageID string) string {
 	// Path
 	path := fmt.Sprintf("ui/scans-list/repositories/%s/scan-descendants/%s", url.PathEscape(repoPath), url.PathEscape(artifactName))
 
 	// Query params
-	packageID := fmt.Sprintf("generic://sha256:%s/%s", sha256, artifactName)
 	query := url.Values{}
 	query.Set("package_id", packageID)
 	query.Set("path", fmt.Sprintf("%s/%s", repoPath, targetPath))

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -289,6 +289,10 @@ func DumpCdxContentToFile(bom *cyclonedx.BOM, scanResultsOutputDir, filePrefix s
 	}
 	pathToSave := filepath.Join(scanResultsOutputDir, fmt.Sprintf("%s_%s.cdx.json", filePrefix, GetCurrentTimeUnix()))
 	log.Debug(fmt.Sprintf("%sScans output directory was provided, saving CycloneDX SBOM to file '%s'...", logPrefix, pathToSave))
+	return SaveCdxContentToFile(pathToSave, bom)
+}
+
+func SaveCdxContentToFile(pathToSave string, bom *cyclonedx.BOM) (err error) {
 	file, err := os.Create(pathToSave)
 	defer func() {
 		err = errors.Join(err, file.Close())


### PR DESCRIPTION
- [ ] The pull request is targeting the `dev` branch.
- [ ] The code has been validated to compile successfully by running `go vet ./...`.
- [ ] The code has been formatted properly using `go fmt ./...`.
- [ ] All [static analysis checks](https://github.com/jfrog/jfrog-cli-security/actions/workflows/analysis.yml) passed.
- [ ] All [tests](https://github.com/jfrog/jfrog-cli-security/actions/workflows/test.yml) have passed. If this feature is not already covered by the tests, new tests have been added.
- [ ] Updated the [Contributing page](https://github.com/jfrog/jfrog-cli-security/blob/main/CONTRIBUTING.md) / [ReadMe page](https://github.com/jfrog/jfrog-cli-security/blob/main/README.md) / [CI Workflow files](https://github.com/jfrog/jfrog-cli-security/tree/main/.github/workflows) if needed.
- [ ] All changes are detailed at the description. if not already covered at [JFrog Documentation](https://github.com/jfrog/documentation), new documentation have been added.

-----

if metadata component exists, use it instead of the artifact sha and name as the package ID for the generated URL.
This is how routes in Artifactory are generated and working with scan results