### PR TITLE
Fix buildinfo pip root component

### DIFF
--- a/sca/bom/buildinfo/technologies/python/python_test.go
+++ b/sca/bom/buildinfo/technologies/python/python_test.go
@@ -69,11 +69,10 @@ func TestBuildPipDependencyListSetuppyForCuration(t *testing.T) {
 	assert.Contains(t, uniqueDeps, PythonPackageTypeIdentifier+"ptyprocess:0.7.0")
 	assert.Contains(t, uniqueDeps, PythonPackageTypeIdentifier+"pip-example:1.2.3")
 	assert.Len(t, rootNode, 1)
+	tests.GetAndAssertNode(t, rootNode, "pip-example:1.2.3")
 	if assert.NotNil(t, rootNode[0].Nodes) && assert.NotEmpty(t, rootNode[0].Nodes) {
-		// Test direct dependency
-		directDepNode := tests.GetAndAssertNode(t, rootNode[0].Nodes, "pip-example:1.2.3")
 		// Test child module
-		childNode := tests.GetAndAssertNode(t, directDepNode.Nodes, "pexpect:4.8.0")
+		childNode := tests.GetAndAssertNode(t, rootNode[0].Nodes, "pexpect:4.8.0")
 		// Test sub child module
 		tests.GetAndAssertNode(t, childNode.Nodes, "ptyprocess:0.7.0")
 

--- a/sca/bom/buildinfo/technologies/python/python_test.go
+++ b/sca/bom/buildinfo/technologies/python/python_test.go
@@ -201,6 +201,7 @@ func TestBuildDependencyTreeWhenInstallForbidden(t *testing.T) {
 		testDir                          string
 		technology                       techutils.Technology
 		installBeforeFetchingInitialDeps bool
+		rootDetected                     bool
 	}{
 		// pip
 		{
@@ -208,24 +209,28 @@ func TestBuildDependencyTreeWhenInstallForbidden(t *testing.T) {
 			testDir:                          filepath.Join("projects", "package-managers", "python", "pip", "pip", "requirementsproject"),
 			technology:                       techutils.Pip,
 			installBeforeFetchingInitialDeps: false,
+			rootDetected:                     false,
 		},
 		{
 			name:                             "pip: project installed before dep tree construction| install forbidden",
 			testDir:                          filepath.Join("projects", "package-managers", "python", "pip", "pip", "requirementsproject"),
 			technology:                       techutils.Pip,
 			installBeforeFetchingInitialDeps: true,
+			rootDetected:                     false,
 		},
 		{
 			name:                             "poetry: project not installed | install forbidden",
 			testDir:                          filepath.Join("projects", "package-managers", "python", "poetry", "poetry"),
 			technology:                       techutils.Poetry,
 			installBeforeFetchingInitialDeps: false,
+			rootDetected:                     false,
 		},
 		{
 			name:                             "poetry: project installed before dep tree construction| install forbidden",
 			testDir:                          filepath.Join("projects", "package-managers", "python", "poetry", "poetry"),
 			technology:                       techutils.Poetry,
 			installBeforeFetchingInitialDeps: true,
+			rootDetected:                     false,
 		},
 	}
 
@@ -253,11 +258,12 @@ func TestBuildDependencyTreeWhenInstallForbidden(t *testing.T) {
 			}
 
 			if test.installBeforeFetchingInitialDeps {
-				restoreEnv, err := runPythonInstall(params, pythonutils.PythonTool(test.technology))
+				rootDetected, restoreEnv, err := runPythonInstall(params, pythonutils.PythonTool(test.technology))
 				defer func() {
 					assert.NoError(t, restoreEnv(), "restoring env after setting "+test.technology+" virtual env creation failed")
 				}()
 				require.NoError(t, err)
+				assert.Equal(t, test.rootDetected, rootDetected, "Root detection mismatch for "+test.technology+" technology")
 			}
 
 			// Checking dependencies before BuildDependencyTree

--- a/sca/bom/buildinfo/technologies/python/python_test.go
+++ b/sca/bom/buildinfo/technologies/python/python_test.go
@@ -32,13 +32,13 @@ func TestBuildPipDependencyListSetuppy(t *testing.T) {
 	assert.Contains(t, uniqueDeps, PythonPackageTypeIdentifier+"ptyprocess:0.7.0")
 	assert.Contains(t, uniqueDeps, PythonPackageTypeIdentifier+"pip-example:1.2.3")
 	assert.Len(t, rootNode, 1)
+	// Test direct dependency
+	tests.GetAndAssertNode(t, rootNode, "pip-example:1.2.3")
 	if len(rootNode) > 0 {
 		assert.NotEmpty(t, rootNode[0].Nodes)
 		if rootNode[0].Nodes != nil {
-			// Test direct dependency
-			directDepNode := tests.GetAndAssertNode(t, rootNode[0].Nodes, "pip-example:1.2.3")
 			// Test child module
-			childNode := tests.GetAndAssertNode(t, directDepNode.Nodes, "pexpect:4.8.0")
+			childNode := tests.GetAndAssertNode(t, rootNode[0].Nodes, "pexpect:4.8.0")
 			// Test sub child module
 			tests.GetAndAssertNode(t, childNode.Nodes, "ptyprocess:0.7.0")
 		}

--- a/sca/bom/scang/plugin/plugin.go
+++ b/sca/bom/scang/plugin/plugin.go
@@ -29,7 +29,7 @@ const (
 	scangPluginRtRepository       = "scang/v1"
 
 	scangPluginDirName        = "scang"
-	ScangPluginExecutableName = "scangplugin"
+	ScangPluginExecutableName = "xray-scan-plugin"
 	pluginName                = "scang"
 
 	scangPluginMagicCookieKey = "SCANG_PLUGIN_MAGIC_COOKIE"

--- a/tests/validations/test_validate_cyclonedx.go
+++ b/tests/validations/test_validate_cyclonedx.go
@@ -59,7 +59,7 @@ func countSbomComponents(content *cyclonedx.BOM) (sbomComponents, rootComponents
 				}
 			}
 		}
-		relation := cdxutils.GetComponentRelation(content, component.BOMRef)
+		relation := cdxutils.GetComponentRelation(content, component.BOMRef, true)
 		if relation == cdxutils.UnknownRelation {
 			continue
 		}

--- a/utils/formats/cdxutils/cyclonedxutils.go
+++ b/utils/formats/cdxutils/cyclonedxutils.go
@@ -90,7 +90,7 @@ func SearchDependencyEntry(dependencies *[]cyclonedx.Dependency, ref string) *cy
 	return nil
 }
 
-func GetComponentRelation(bom *cyclonedx.BOM, componentRef string) ComponentRelation {
+func GetComponentRelation(bom *cyclonedx.BOM, componentRef string, skipDefaultRoot bool) ComponentRelation {
 	if bom == nil || bom.Components == nil {
 		return UnknownRelation
 	}
@@ -105,7 +105,7 @@ func GetComponentRelation(bom *cyclonedx.BOM, componentRef string) ComponentRela
 	}
 	parents := SearchParents(componentRef, *bom.Components, dependencies...)
 	// Calculate the root components
-	for _, root := range GetRootDependenciesEntries(bom, true) {
+	for _, root := range GetRootDependenciesEntries(bom, skipDefaultRoot) {
 		if root.Ref == componentRef {
 			// The component is a root
 			return RootRelation
@@ -283,7 +283,7 @@ func Exclude(bom cyclonedx.BOM, componentsToExclude ...cyclonedx.Component) (fil
 	}
 	filteredSbom = &bom
 	for _, compToExclude := range componentsToExclude {
-		if matchedBomComp := SearchComponentByRef(bom.Components, compToExclude.BOMRef); matchedBomComp == nil || GetComponentRelation(&bom, matchedBomComp.BOMRef) == RootRelation {
+		if matchedBomComp := SearchComponentByRef(bom.Components, compToExclude.BOMRef); matchedBomComp == nil || GetComponentRelation(&bom, matchedBomComp.BOMRef, false) == RootRelation {
 			// If not a match or Root component, skip it
 			continue
 		}

--- a/utils/formats/cdxutils/cyclonedxutils_test.go
+++ b/utils/formats/cdxutils/cyclonedxutils_test.go
@@ -388,7 +388,7 @@ func TestGetComponentRelation(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := GetComponentRelation(tt.bom, tt.componentRef)
+			result := GetComponentRelation(tt.bom, tt.componentRef, true)
 			assert.Equal(t, tt.expected, result, "Expected component relation does not match")
 		})
 	}

--- a/utils/results/common.go
+++ b/utils/results/common.go
@@ -286,7 +286,7 @@ func ForEachSbomComponent(bom *cyclonedx.BOM, handler ParseSbomComponentFunc) (e
 		if err := handler(
 			component,
 			cdxutils.SearchDependencyEntry(bom.Dependencies, component.BOMRef),
-			cdxutils.GetComponentRelation(bom, component.BOMRef),
+			cdxutils.GetComponentRelation(bom, component.BOMRef, true),
 		); err != nil {
 			return err
 		}
@@ -859,7 +859,7 @@ func ExtractCdxDependenciesCves(bom *cyclonedx.BOM) (directCves []string, indire
 			continue
 		}
 		for _, affectedComponent := range *vulnerability.Affects {
-			relation := cdxutils.GetComponentRelation(bom, affectedComponent.Ref)
+			relation := cdxutils.GetComponentRelation(bom, affectedComponent.Ref, true)
 			if relation == cdxutils.TransitiveRelation {
 				indirectCvesSet.Add(vulnerability.BOMRef)
 			} else {


### PR DESCRIPTION
- [ ] The pull request is targeting the `dev` branch.
- [ ] The code has been validated to compile successfully by running `go vet ./...`.
- [ ] The code has been formatted properly using `go fmt ./...`.
- [ ] All [static analysis checks](https://github.com/jfrog/jfrog-cli-security/actions/workflows/analysis.yml) passed.
- [ ] All [tests](https://github.com/jfrog/jfrog-cli-security/actions/workflows/test.yml) have passed. If this feature is not already covered by the tests, new tests have been added.
- [ ] Updated the [Contributing page](https://github.com/jfrog/jfrog-cli-security/blob/main/CONTRIBUTING.md) / [ReadMe page](https://github.com/jfrog/jfrog-cli-security/blob/main/README.md) / [CI Workflow files](https://github.com/jfrog/jfrog-cli-security/tree/main/.github/workflows) if needed.
- [ ] All changes are detailed at the description. if not already covered at [JFrog Documentation](https://github.com/jfrog/documentation), new documentation have been added.

-----

For `Pip` technology, if `setup.py` is used, the generated tree generates a node for the root component with its name.
In this case there is no need to create a dummy root node

Additional changes:
* Update `scang` plugin name
* Allow `GetComponentRelation` to skip dummy root node if needed