### PR TITLE
Add partialFingerprints to result sarif

### DIFF
--- a/utils/formats/sarifutils/sarifutils.go
+++ b/utils/formats/sarifutils/sarifutils.go
@@ -298,14 +298,15 @@ func ReadScanRunsFromFile(fileName string) (sarifRuns []*sarif.Run, err error) {
 
 func CopyResult(result *sarif.Result) *sarif.Result {
 	copied := &sarif.Result{
-		RuleID:       result.RuleID,
-		RuleIndex:    result.RuleIndex,
-		Kind:         result.Kind,
-		Fingerprints: result.Fingerprints,
-		CodeFlows:    copyCodeFlows(result.CodeFlows...),
-		Level:        result.Level,
-		Message:      copyMsgAttribute(result.Message),
-		Properties:   result.Properties,
+		RuleID:              result.RuleID,
+		RuleIndex:           result.RuleIndex,
+		Kind:                result.Kind,
+		Fingerprints:        result.Fingerprints,
+		CodeFlows:           copyCodeFlows(result.CodeFlows...),
+		Level:               result.Level,
+		Message:             copyMsgAttribute(result.Message),
+		Properties:          result.Properties,
+		PartialFingerprints: result.PartialFingerprints,
 	}
 	for _, location := range result.Locations {
 		copied.Locations = append(copied.Locations, CopyLocation(location))

--- a/utils/formats/sarifutils/test_sarifutils.go
+++ b/utils/formats/sarifutils/test_sarifutils.go
@@ -93,6 +93,12 @@ func CreateDummyResultInPath(fileName string) *sarif.Result {
 	return CreateResultWithOneLocation(fileName, 0, 0, 0, 0, "snippet", "rule", "level")
 }
 
+func CreateDummyResultInPathWithPartialFingerprint(fileName string, partialFingerprints map[string]string) *sarif.Result {
+	result := CreateResultWithOneLocation(fileName, 0, 0, 0, 0, "snippet", "rule", "level")
+	result.PartialFingerprints = partialFingerprints
+	return result
+}
+
 func CreateDummyResult(markdown, msg, ruleId, level string, locations ...*sarif.Location) *sarif.Result {
 	result := &sarif.Result{
 		Message: &sarif.Message{Text: &msg, Markdown: &markdown},

--- a/utils/results/conversion/sarifparser/sarifparser_test.go
+++ b/utils/results/conversion/sarifparser/sarifparser_test.go
@@ -587,14 +587,14 @@ func TestPatchRunsToPassIngestionRules(t *testing.T) {
 			subScan: utils.SecretsScan,
 			input: []*sarif.Run{
 				sarifutils.CreateRunWithDummyResultsInWd(fmt.Sprintf("file://%s", wd),
-					sarifutils.CreateDummyResultInPath(fmt.Sprintf("file://%s", filepath.Join(wd, "dir", "file"))),
+					sarifutils.CreateDummyResultInPathWithPartialFingerprint(fmt.Sprintf("file://%s", filepath.Join(wd, "dir", "file")), map[string]string{"jfrog-algo": "jfrog-algo-value"}),
 					// No location, should be removed in the output
 					sarifutils.CreateDummyResult("some-markdown", "some-other-msg", "rule", "level"),
 				),
 			},
 			expectedResults: []*sarif.Run{
 				sarifutils.CreateRunWithDummyResultsInWdWithHelp("rule-msg", "rule-markdown", fmt.Sprintf("file://%s", wd),
-					sarifutils.CreateDummyResultInPath(filepath.ToSlash(filepath.Join("dir", "file"))),
+					sarifutils.CreateDummyResultInPathWithPartialFingerprint(filepath.ToSlash(filepath.Join("dir", "file")), map[string]string{"jfrog-algo": "jfrog-algo-value"}),
 				),
 			},
 		},


### PR DESCRIPTION
JAS scanners now provide partialFingerprints, in this change we pass them when those provided to result sarif

- [x] The pull request is targeting the `dev` branch.
- [x] The code has been validated to compile successfully by running `go vet ./...`.
- [x] The code has been formatted properly using `go fmt ./...`.
- [x] All [static analysis checks](https://github.com/jfrog/jfrog-cli-security/actions/workflows/analysis.yml) passed.
- [x] All [tests](https://github.com/jfrog/jfrog-cli-security/actions/workflows/test.yml) have passed. If this feature is not already covered by the tests, new tests have been added.
- [x] Updated the [Contributing page](https://github.com/jfrog/jfrog-cli-security/blob/main/CONTRIBUTING.md) / [ReadMe page](https://github.com/jfrog/jfrog-cli-security/blob/main/README.md) / [CI Workflow files](https://github.com/jfrog/jfrog-cli-security/tree/main/.github/workflows) if needed.
- [x] All changes are detailed at the description. if not already covered at [JFrog Documentation](https://github.com/jfrog/documentation), new documentation have been added.

-----

Passing the generated `PartialFingerprint` attribute in `SARIF` format