### PR TITLE
Resolve issues with killing the child process by not doing that

### DIFF
--- a/commands/source_mcp/source_mcp_test.go
+++ b/commands/source_mcp/source_mcp_test.go
@@ -33,7 +33,7 @@ func TestRunSourceMcpHappyFlow(t *testing.T) {
 	}
 
 	err := mcp_cmd.runWithTimeout(5, "mcp-sast")
-	assert.Error(t, err) // returns error because it was terminated upon timeout
+	assert.NoError(t, err) // returns error because it was terminated upon timeout
 	if !assert.Contains(t, error_buffer.String(), "Generated IR") {
 		t.Error(error_buffer.String())
 	}


### PR DESCRIPTION
- [V] The pull request is targeting the `dev` branch.
- [V] The code has been validated to compile successfully by running `go vet ./...`.
- [V] The code has been formatted properly using `go fmt ./...`.
- [ ] All [static analysis checks](https://github.com/jfrog/jfrog-cli-security/actions/workflows/analysis.yml) passed.
- [V] All [tests](https://github.com/jfrog/jfrog-cli-security/actions/workflows/test.yml) have passed. If this feature is not already covered by the tests, new tests have been added.
- [ ] Updated the [Contributing page](https://github.com/jfrog/jfrog-cli-security/blob/main/CONTRIBUTING.md) / [ReadMe page](https://github.com/jfrog/jfrog-cli-security/blob/main/README.md) / [CI Workflow files](https://github.com/jfrog/jfrog-cli-security/tree/main/.github/workflows) if needed.
- [ ] All changes are detailed at the description. if not already covered at [JFrog Documentation](https://github.com/jfrog/documentation), new documentation have been added.

-----