### PR TITLE
Add nil check for ScaResults when SCA scan is not performed in audit

### DIFF
--- a/utils/results/common.go
+++ b/utils/results/common.go
@@ -81,7 +81,10 @@ func checkIfFailBuildConsideringApplicability(target *TargetResults, entitledFor
 	jasApplicabilityResults := target.JasResults.GetApplicabilityScanResults()
 
 	// Get new violations from the target
-	newViolations := target.ScaResults.Violations
+	var newViolations []services.Violation
+	if target.ScaResults != nil {
+		newViolations = target.ScaResults.Violations
+	}
 
 	// Here we iterate the new violation results and check if any of them should fail the build.
 	_, _, err := ForEachScanGraphViolation(
@@ -98,18 +101,20 @@ func checkIfFailBuildConsideringApplicability(target *TargetResults, entitledFor
 
 	// Here we iterate the deprecated violation results to check if any of them should fail the build.
 	// TODO remove this part once the DeprecatedXrayResults are completely removed and no longer in use
-	for _, result := range target.ScaResults.DeprecatedXrayResults {
-		deprecatedViolations := result.Scan.Violations
-		_, _, err = ForEachScanGraphViolation(
-			target.ScanTarget,
-			deprecatedViolations,
-			entitledForJas,
-			jasApplicabilityResults,
-			checkIfShouldFailBuildAccordingToPolicy(shouldFailBuild),
-			nil,
-			nil)
-		if err != nil {
-			return err
+	if target.ScaResults != nil {
+		for _, result := range target.ScaResults.DeprecatedXrayResults {
+			deprecatedViolations := result.Scan.Violations
+			_, _, err = ForEachScanGraphViolation(
+				target.ScanTarget,
+				deprecatedViolations,
+				entitledForJas,
+				jasApplicabilityResults,
+				checkIfShouldFailBuildAccordingToPolicy(shouldFailBuild),
+				nil,
+				nil)
+			if err != nil {
+				return err
+			}
 		}
 	}
 	return nil


### PR DESCRIPTION
- [ ] The pull request is targeting the `dev` branch.
- [ ] The code has been validated to compile successfully by running `go vet ./...`.
- [ ] The code has been formatted properly using `go fmt ./...`.
- [ ] All [static analysis checks](https://github.com/jfrog/jfrog-cli-security/actions/workflows/analysis.yml) passed.
- [ ] All [tests](https://github.com/jfrog/jfrog-cli-security/actions/workflows/test.yml) have passed. If this feature is not already covered by the tests, new tests have been added.
- [ ] Updated the [Contributing page](https://github.com/jfrog/jfrog-cli-security/blob/main/CONTRIBUTING.md) / [ReadMe page](https://github.com/jfrog/jfrog-cli-security/blob/main/README.md) / [CI Workflow files](https://github.com/jfrog/jfrog-cli-security/tree/main/.github/workflows) if needed.
- [ ] All changes are detailed at the description. if not already covered at [JFrog Documentation](https://github.com/jfrog/documentation), new documentation have been added.

-----

- Added a missing nil check before accessing ScaResults to properly handle audit scans that are run without SCA enabled. This prevents potential runtime errors when ScaResults is nil.