### PR TITLE
Fix SARIF Github ingestion rules and SCA runs when not requested

### DIFF
--- a/utils/formats/sarifutils/sarifutils.go
+++ b/utils/formats/sarifutils/sarifutils.go
@@ -372,7 +372,7 @@ func CopyLocation(location *sarif.Location) *sarif.Location {
 	if location.PhysicalLocation != nil {
 		copied.PhysicalLocation = sarif.NewPhysicalLocation()
 		if location.PhysicalLocation.ArtifactLocation != nil {
-			copied.PhysicalLocation.WithArtifactLocation(sarif.NewArtifactLocation().WithIndex(0).WithURI(GetLocationFileName(location)))
+			copied.PhysicalLocation.WithArtifactLocation(sarif.NewArtifactLocation().WithIndex(-1).WithURI(GetLocationFileName(location)))
 			copied.PhysicalLocation.WithRegion(sarif.NewRegion().
 				WithCharOffset(0).
 				WithByteOffset(0).
@@ -387,7 +387,7 @@ func CopyLocation(location *sarif.Location) *sarif.Location {
 	}
 	copied.Properties = location.Properties
 	for _, logicalLocation := range location.LogicalLocations {
-		logicalCopy := sarif.NewLogicalLocation().WithIndex(0).WithParentIndex(0).WithProperties(logicalLocation.Properties)
+		logicalCopy := sarif.NewLogicalLocation().WithIndex(-1).WithParentIndex(-1).WithProperties(logicalLocation.Properties)
 		if logicalLocation.Name != nil {
 			logicalCopy.WithName(*logicalLocation.Name)
 		}


### PR DESCRIPTION
- [ ] The pull request is targeting the `dev` branch.
- [ ] The code has been validated to compile successfully by running `go vet ./...`.
- [ ] The code has been formatted properly using `go fmt ./...`.
- [ ] All [static analysis checks](https://github.com/jfrog/jfrog-cli-security/actions/workflows/analysis.yml) passed.
- [ ] All [tests](https://github.com/jfrog/jfrog-cli-security/actions/workflows/test.yml) have passed. If this feature is not already covered by the tests, new tests have been added.
- [ ] Updated the [Contributing page](https://github.com/jfrog/jfrog-cli-security/blob/main/CONTRIBUTING.md) / [ReadMe page](https://github.com/jfrog/jfrog-cli-security/blob/main/README.md) / [CI Workflow files](https://github.com/jfrog/jfrog-cli-security/tree/main/.github/workflows) if needed.
- [ ] All changes are detailed at the description. if not already covered at [JFrog Documentation](https://github.com/jfrog/documentation), new documentation have been added.

-----

Fix issues when generating SARIF format:
* The default index value should be -1
* When SCA is not reuested, don't generate an empty run entry for it