### PR TITLE
Show vulnerabilities in Build-Scan SARIF format when project not provided

### DIFF
--- a/cli/scancommands.go
+++ b/cli/scancommands.go
@@ -365,6 +365,7 @@ func BuildScan(c *components.Context) error {
 	}
 	buildScanCmd := scan.NewBuildScanCommand().
 		SetServerDetails(serverDetails).
+		// Sarif shouldn't include the additional all-vulnerabilities info that received by adding the vuln flag
 		SetIncludeVulnerabilities(getProject(c) == "" || (format != outputFormat.Sarif && c.GetBoolFlagValue(flags.Vuln))).
 		SetFailBuild(c.GetBoolFlagValue(flags.Fail)).
 		SetBuildConfiguration(buildConfiguration).

--- a/cli/scancommands.go
+++ b/cli/scancommands.go
@@ -365,15 +365,12 @@ func BuildScan(c *components.Context) error {
 	}
 	buildScanCmd := scan.NewBuildScanCommand().
 		SetServerDetails(serverDetails).
+		SetIncludeVulnerabilities(getProject(c) == "" || (format != outputFormat.Sarif && c.GetBoolFlagValue(flags.Vuln))).
 		SetFailBuild(c.GetBoolFlagValue(flags.Fail)).
 		SetBuildConfiguration(buildConfiguration).
 		SetOutputFormat(format).
 		SetPrintExtendedTable(c.GetBoolFlagValue(flags.ExtendedTable)).
 		SetRescan(c.GetBoolFlagValue(flags.Rescan))
-	if format != outputFormat.Sarif {
-		// Sarif shouldn't include the additional all-vulnerabilities info that received by adding the vuln flag
-		buildScanCmd.SetIncludeVulnerabilities(c.GetBoolFlagValue(flags.Vuln))
-	}
 	return commandsCommon.Exec(buildScanCmd)
 }
 


### PR DESCRIPTION
- [ ] The pull request is targeting the `dev` branch.
- [ ] The code has been validated to compile successfully by running `go vet ./...`.
- [ ] The code has been formatted properly using `go fmt ./...`.
- [ ] All [static analysis checks](https://github.com/jfrog/jfrog-cli-security/actions/workflows/analysis.yml) passed.
- [ ] All [tests](https://github.com/jfrog/jfrog-cli-security/actions/workflows/test.yml) have passed. If this feature is not already covered by the tests, new tests have been added.
- [ ] Updated the [Contributing page](https://github.com/jfrog/jfrog-cli-security/blob/main/CONTRIBUTING.md) / [ReadMe page](https://github.com/jfrog/jfrog-cli-security/blob/main/README.md) / [CI Workflow files](https://github.com/jfrog/jfrog-cli-security/tree/main/.github/workflows) if needed.
- [ ] All changes are detailed at the description. if not already covered at [JFrog Documentation](https://github.com/jfrog/documentation), new documentation have been added.

-----

When running `build scan` without violation context (project key not provided and the only context for build scan) the scan should display vulnerabilities in SARIF format.