### PR TITLE
Add ScaResults guard on fail build check when no JAS results

### DIFF
--- a/scans_test.go
+++ b/scans_test.go
@@ -274,33 +274,35 @@ func runDockerScan(t *testing.T, testCli *coreTests.JfrogCli, imageName, watchNa
 	imageTag := path.Join(*securityTests.ContainerRegistry, securityTests.DockerVirtualRepo, imageName)
 	dockerPullCommand := container.NewPullCommand(containerUtils.DockerClient)
 	dockerPullCommand.SetCmdParams([]string{"pull", imageTag}).SetImageTag(imageTag).SetRepo(securityTests.DockerVirtualRepo).SetServerDetails(securityTests.XrDetails).SetBuildConfiguration(new(build.BuildConfiguration))
-	if assert.NoError(t, dockerPullCommand.Run()) {
-		defer commonTests.DeleteTestImage(t, imageTag, containerUtils.DockerClient)
-		// Run docker scan on image
-		cmdArgs := []string{"docker", "scan", imageTag, "--server-id=default", "--licenses", "--fail=false", "--min-severity=low", "--fixable-only"}
+	if !assert.NoError(t, dockerPullCommand.Run()) {
+		return
+	}
+	defer commonTests.DeleteTestImage(t, imageTag, containerUtils.DockerClient)
+	// Run docker scan on image
+	cmdArgs := []string{"docker", "scan", imageTag, "--server-id=default", "--licenses", "--fail=false", "--min-severity=low", "--fixable-only"}
+	if validateSecrets {
+		cmdArgs = append(cmdArgs, "--validate-secrets", "--format=simple-json")
+	} else {
+		cmdArgs = append(cmdArgs, "--format=json")
+	}
+	if watchName != "" {
+		cmdArgs = append(cmdArgs, "--watches="+watchName, "--vuln")
+	}
+	output := testCli.WithoutCredentials().RunCliCmdWithOutput(t, cmdArgs...)
+	if assert.NotEmpty(t, output) {
 		if validateSecrets {
-			cmdArgs = append(cmdArgs, "--validate-secrets", "--format=simple-json")
+			validations.VerifySimpleJsonResults(t, output, validations.ValidationParams{
+				Vulnerabilities: &validations.VulnerabilityCount{ValidateApplicabilityStatus: &validations.ApplicabilityStatusCount{Inactive: minInactives}},
+			})
 		} else {
-			cmdArgs = append(cmdArgs, "--format=json")
-		}
-		output := testCli.WithoutCredentials().RunCliCmdWithOutput(t, cmdArgs...)
-		if assert.NotEmpty(t, output) {
-			if validateSecrets {
-				validations.VerifySimpleJsonResults(t, output, validations.ValidationParams{
-					Vulnerabilities: &validations.VulnerabilityCount{ValidateApplicabilityStatus: &validations.ApplicabilityStatusCount{Inactive: minInactives}},
-				})
-			} else {
-				validations.VerifyJsonResults(t, output, validations.ValidationParams{Total: &validations.TotalCount{Vulnerabilities: minVulnerabilities, Licenses: minLicenses}})
+			validationParams := validations.ValidationParams{
+				Total: &validations.TotalCount{
+					Vulnerabilities: minVulnerabilities,
+					Licenses:        minLicenses,
+					Violations:      minViolations,
+				},
 			}
-		}
-		// Run docker scan on image with watch
-		if watchName == "" {
-			return
-		}
-		cmdArgs = append(cmdArgs, "--watches="+watchName)
-		output = testCli.WithoutCredentials().RunCliCmdWithOutput(t, cmdArgs...)
-		if assert.NotEmpty(t, output) {
-			validations.VerifyJsonResults(t, output, validations.ValidationParams{Total: &validations.TotalCount{Violations: minViolations}})
+			validations.VerifyJsonResults(t, output, validationParams)
 		}
 	}
 }

--- a/tests/config.go
+++ b/tests/config.go
@@ -95,7 +95,11 @@ func getTestContainerDefaultValue(jfrogUrl string) string {
 		return os.Getenv(TestJfrogContainerEnvVar)
 	}
 	// remove protocol and trailing slash from the JFrog URL
-	parsedUrl, _ := url.Parse(jfrogUrl)
+	parsedUrl, err := url.Parse(jfrogUrl)
+	if err != nil {
+		log.Error("Failed to parse JFrog URL:", err)
+		return "localhost:8084"
+	}
 	return parsedUrl.Host
 }
 

--- a/tests/config.go
+++ b/tests/config.go
@@ -2,6 +2,7 @@ package tests
 
 import (
 	"flag"
+	"net/url"
 	"os"
 
 	"github.com/jfrog/jfrog-cli-core/v2/plugins/components"
@@ -89,6 +90,15 @@ func getTestPasswordDefaultValue() string {
 	return "password"
 }
 
+func getTestContainerDefaultValue(jfrogUrl string) string {
+	if os.Getenv(TestJfrogContainerEnvVar) != "" {
+		return os.Getenv(TestJfrogContainerEnvVar)
+	}
+	// remove protocol and trailing slash from the JFrog URL
+	parsedUrl, _ := url.Parse(jfrogUrl)
+	return parsedUrl.Host
+}
+
 func init() {
 	TestUnit = flag.Bool("test.unit", false, "Run unit tests")
 	TestArtifactory = flag.Bool("test.artifactory", false, "Run Artifactory integration tests")
@@ -118,7 +128,7 @@ func init() {
 
 	JfrogSshKeyPath = flag.String("jfrog.sshKeyPath", "", "Ssh key file path")
 	JfrogSshPassphrase = flag.String("jfrog.sshPassphrase", "", "Ssh key passphrase")
-	ContainerRegistry = flag.String("test.containerRegistry", "localhost:8084", "Container registry")
+	ContainerRegistry = flag.String("test.containerRegistry", getTestContainerDefaultValue(*JfrogUrl), "Container registry")
 	CiRunId = flag.String("ci.runId", "", "A unique identifier used as a suffix to create repositories and builds in the tests")
 	JfrogTestProjectKey = flag.String("jfrog.projectKey", os.Getenv(TestJfrogPlatformProjectKeyEnvVar), "Project key used for tests")
 }

--- a/tests/consts.go
+++ b/tests/consts.go
@@ -17,6 +17,7 @@ const (
 	TestJfrogTokenEnvVar              = "JFROG_SECURITY_CLI_TESTS_JFROG_ACCESS_TOKEN"
 	TestJfrogUserEnvVar               = "JFROG_SECURITY_CLI_TESTS_JFROG_USER"
 	TestJfrogPasswordEnvVar           = "JFROG_SECURITY_CLI_TESTS_JFROG_PASSWORD"
+	TestJfrogContainerEnvVar          = "JFROG_SECURITY_CLI_TESTS_JFROG_CONTAINER"
 	TestJfrogPlatformProjectKeyEnvVar = "JFROG_SECURITY_CLI_TESTS_JFROG_PLATFORM_PROJECT_KEY"
 
 	MavenCacheRedirectionVal = "-Dmaven.repo.local="

--- a/utils/results/common.go
+++ b/utils/results/common.go
@@ -119,12 +119,14 @@ func checkIfFailBuildConsideringApplicability(target *TargetResults, entitledFor
 }
 
 func checkIfFailBuildWithoutConsideringApplicability(target *TargetResults) bool {
+	if target.ScaResults == nil {
+		return false
+	}
 	for _, newViolation := range target.ScaResults.Violations {
 		if newViolation.FailBuild || newViolation.FailPr {
 			return true
 		}
 	}
-
 	// TODO remove this for loop once the DeprecatedXrayResults are completely removed and no longer in use
 	for _, scanResponse := range target.GetScaScansXrayResults() {
 		for _, oldViolation := range scanResponse.Violations {


### PR DESCRIPTION
- [ ] The pull request is targeting the `dev` branch.
- [ ] The code has been validated to compile successfully by running `go vet ./...`.
- [ ] The code has been formatted properly using `go fmt ./...`.
- [ ] All [static analysis checks](https://github.com/jfrog/jfrog-cli-security/actions/workflows/analysis.yml) passed.
- [ ] All [tests](https://github.com/jfrog/jfrog-cli-security/actions/workflows/test.yml) have passed. If this feature is not already covered by the tests, new tests have been added.
- [ ] Updated the [Contributing page](https://github.com/jfrog/jfrog-cli-security/blob/main/CONTRIBUTING.md) / [ReadMe page](https://github.com/jfrog/jfrog-cli-security/blob/main/README.md) / [CI Workflow files](https://github.com/jfrog/jfrog-cli-security/tree/main/.github/workflows) if needed.
- [ ] All changes are detailed at the description. if not already covered at [JFrog Documentation](https://github.com/jfrog/documentation), new documentation have been added.

-----

Adding additional check following: https://github.com/jfrog/jfrog-cli-security/pull/519

* Also add option to control Container registry in tests and change default value to use value in URL
* Also remove duplicate runs for Docker scan in tests