### PR TITLE
Added-support-for-Wrapper-using-curation-audit

### DIFF
--- a/cli/docs/flags.go
+++ b/cli/docs/flags.go
@@ -189,7 +189,7 @@ var commandFlags = map[string][]string{
 		NewSca, ScangBinaryCustomPath, AnalyzerManagerCustomPath,
 	},
 	CurationAudit: {
-		CurationOutput, WorkingDirs, Threads, RequirementsFile, InsecureTls,
+		CurationOutput, WorkingDirs, Threads, RequirementsFile, InsecureTls, useWrapperAudit,
 	},
 	GitCountContributors: {
 		InputFile, ScmType, ScmApiUrl, Token, Owner, RepoName, Months, DetailedSummary, InsecureTls,

--- a/cli/scancommands_test.go
+++ b/cli/scancommands_test.go
@@ -2,11 +2,6 @@ package cli
 
 import (
 	"errors"
-	commonCommands "github.com/jfrog/jfrog-cli-core/v2/common/commands"
-	coretests "github.com/jfrog/jfrog-cli-core/v2/common/tests"
-	"github.com/jfrog/jfrog-cli-core/v2/utils/config"
-	"github.com/jfrog/jfrog-client-go/utils/io/fileutils"
-	clienttestutils "github.com/jfrog/jfrog-client-go/utils/tests"
 	"net/http"
 	"os"
 	"path"
@@ -15,9 +10,16 @@ import (
 	"strings"
 	"testing"
 
+	commonCommands "github.com/jfrog/jfrog-cli-core/v2/common/commands"
+	coretests "github.com/jfrog/jfrog-cli-core/v2/common/tests"
+	"github.com/jfrog/jfrog-cli-core/v2/utils/config"
+	"github.com/jfrog/jfrog-client-go/utils/io/fileutils"
+	clienttestutils "github.com/jfrog/jfrog-client-go/utils/tests"
+
 	"github.com/jfrog/build-info-go/utils"
 	"github.com/jfrog/jfrog-cli-core/v2/plugins/components"
 	"github.com/jfrog/jfrog-cli-core/v2/utils/coreutils"
+	flags "github.com/jfrog/jfrog-cli-security/cli/docs"
 	"github.com/jfrog/jfrog-cli-security/utils/techutils"
 	"github.com/stretchr/testify/assert"
 )
@@ -150,4 +152,17 @@ func createCliConfig(t *testing.T, url string, configPath string) string {
 		SetDetails(server).SetUseBasicAuthOnly(true).SetInteractive(false)
 	assert.NoError(t, configCmd.Run())
 	return filepath.Join(configPath, "jfrog-cli.conf.v"+strconv.Itoa(coreutils.GetCliConfigVersion()))
+}
+
+func TestCurationAuditCommandFlags_UseWrapperAuditFlag(t *testing.T) {
+	// Test that the useWrapperAudit flag is included in the CurationAudit command flags
+	curationAuditFlags := flags.GetCommandFlags(flags.CurationAudit)
+	found := false
+	for _, flag := range curationAuditFlags {
+		if flag.GetName() == flags.UseWrapper {
+			found = true
+			break
+		}
+	}
+	assert.True(t, found, "useWrapperAudit flag should be present in CurationAudit command flags. If this test fails, it means the flag was removed from cli/docs/flags.go")
 }


### PR DESCRIPTION
Resolved an issue where running jf ca with the Gradle wrapper (without a standalone Gradle installation) failed with the following error:

-----
`jf ca
00:38:03 [🔵Info] Log path: /Users/basselm/.jfrog/logs/jfrog-cli.2025-08-08.00-38-03.67251.log  
00:38:05 [🔵Info] Trace ID for JFrog Platform logs: 928f8f08dff6fe6b  
00:38:05 [🚨Error] exec: "gradle": executable file not found in $PATH`

The issue was resolved by adding support for the wrapper in the curation audit functionality.
jf ca now successfully works when using the wrapper.
Example test with gradle:
`00:40:30 [Debug] Preparing to read the config file /Users/basselm/Downloads/gradle-hello/.jfrog/projects/gradle.yaml
00:40:30 [Debug] Found resolver in the config file /Users/basselm/Downloads/gradle-hello/.jfrog/projects/gradle.yaml
00:40:30 [Debug] Using resolver config from /Users/basselm/Downloads/gradle-hello/.jfrog/projects/gradle.yaml
00:40:30 [Info] Calculating Gradle dependencies...
00:40:30 [Debug] JFROG_CLI_RELEASES_REPO is not set
00:40:30 [Debug] The project dependencies will be resolved from https://hts1.jfrog.io/artifactory/ from the bassel-remote repository
00:40:31 [Info] Running gradle deps tree command: ./gradlew clean generateDepTrees -I /var/folders/nx/ftcs5htj1ds_gyx5j6hbjjs00000gn/T/jfrog.cli.temp.-1754602830-271470065/gradledeptree.init -q -Dorg.gradle.configuration-cache=false -Dcom.jfrog.depsTreeOutputFile=/var/folders/nx/ftcs5htj1ds_gyx5j6hbjjs00000gn/T/jfrog.cli.temp.-1754602830-271470065/gradledeptree.out -Dcom.jfrog.includeAllBuildFiles=true
00:40:32 [Debug] Created 'Gradle' dependency tree with 13 nodes. Elapsed time: 1.4 seconds.`

