### PR TITLE
Add GIT Context to Cyclonedx format content

### DIFF
--- a/commands/audit/audit.go
+++ b/commands/audit/audit.go
@@ -199,6 +199,7 @@ func (auditCmd *AuditCommand) Run() (err error) {
 			auditCmd.IncludeLicenses,
 			auditCmd.IncludeSbom,
 		)).
+		SetGitContext(auditCmd.GitContext()).
 		SetThirdPartyApplicabilityScan(auditCmd.thirdPartyApplicabilityScan).
 		SetThreads(auditCmd.Threads).
 		SetScansResultsOutputDir(auditCmd.scanResultsOutputDir).SetStartTime(startTime).SetMultiScanId(multiScanId)

--- a/commands/audit/auditparams.go
+++ b/commands/audit/auditparams.go
@@ -19,7 +19,7 @@ import (
 type AuditParams struct {
 	// Common params to all scan routines
 	resultsContext    results.ResultContext
-	gitContext *xscServices.XscGitInfoContext
+	gitContext        *xscServices.XscGitInfoContext
 	workingDirs       []string
 	installFunc       func(tech string) error
 	fixableOnly       bool

--- a/commands/audit/auditparams.go
+++ b/commands/audit/auditparams.go
@@ -13,11 +13,13 @@ import (
 	"github.com/jfrog/jfrog-cli-security/utils/techutils"
 	"github.com/jfrog/jfrog-cli-security/utils/xray/scangraph"
 	"github.com/jfrog/jfrog-client-go/xray/services"
+	xscServices "github.com/jfrog/jfrog-client-go/xsc/services"
 )
 
 type AuditParams struct {
 	// Common params to all scan routines
 	resultsContext    results.ResultContext
+	gitContext *xscServices.XscGitInfoContext
 	workingDirs       []string
 	installFunc       func(tech string) error
 	fixableOnly       bool
@@ -44,6 +46,15 @@ func NewAuditParams() *AuditParams {
 	return &AuditParams{
 		AuditBasicParams: &xrayutils.AuditBasicParams{},
 	}
+}
+
+func (params *AuditParams) SetGitContext(gitContext *xscServices.XscGitInfoContext) *AuditParams {
+	params.gitContext = gitContext
+	return params
+}
+
+func (params *AuditParams) GitContext() *xscServices.XscGitInfoContext {
+	return params.gitContext
 }
 
 func (params *AuditParams) InstallFunc() func(tech string) error {

--- a/commands/git/audit/gitaudit.go
+++ b/commands/git/audit/gitaudit.go
@@ -52,7 +52,7 @@ func (gaCmd *GitAuditCommand) Run() (err error) {
 		// No Error but no git info = project working tree is dirty
 		return fmt.Errorf("detected uncommitted changes in '%s'. Please commit your changes and try again", gaCmd.repositoryLocalPath)
 	}
-	gaCmd.source = *gitInfo
+	gaCmd.gitContext = *gitInfo
 	// Run the scan
 	auditResults := RunGitAudit(gaCmd.GitAuditParams)
 	// Process the results and output
@@ -83,13 +83,15 @@ func toAuditParams(params GitAuditParams) *sourceAudit.AuditParams {
 		params.resultsContext.Watches,
 		params.resultsContext.RepoPath,
 		params.resultsContext.ProjectKey,
-		params.source.Source.GitRepoHttpsCloneUrl,
+		params.gitContext.Source.GitRepoHttpsCloneUrl,
 		params.resultsContext.IncludeVulnerabilities,
 		params.resultsContext.IncludeLicenses,
 		false,
 	)
 	auditParams.SetResultsContext(resultContext)
 	log.Debug(fmt.Sprintf("Results context: %+v", resultContext))
+	// Source control params
+	auditParams.SetGitContext(&params.gitContext)
 	// Scan params
 	auditParams.SetThreads(params.threads).SetWorkingDirs([]string{params.repositoryLocalPath}).SetExclusions(params.exclusions).SetScansToPerform(params.scansToPerform)
 	// Output params
@@ -104,7 +106,7 @@ func toAuditParams(params GitAuditParams) *sourceAudit.AuditParams {
 func RunGitAudit(params GitAuditParams) (scanResults *results.SecurityCommandResults) {
 	// Send scan started event
 	event := xsc.CreateAnalyticsEvent(services.CliProduct, services.CliEventType, params.serverDetails)
-	event.GitInfo = &params.source
+	event.GitInfo = &params.gitContext
 	event.IsGitInfoFlow = true
 	multiScanId, startTime := xsc.SendNewScanEvent(
 		params.xrayVersion,

--- a/commands/git/audit/gitauditparams.go
+++ b/commands/git/audit/gitauditparams.go
@@ -14,7 +14,7 @@ import (
 
 type GitAuditParams struct {
 	// Git Params
-	source services.XscGitInfoContext
+	gitContext services.XscGitInfoContext
 	// Connection params
 	serverDetails *config.ServerDetails
 	// Violations params

--- a/utils/results/conversion/convertor.go
+++ b/utils/results/conversion/convertor.go
@@ -13,6 +13,7 @@ import (
 	"github.com/jfrog/jfrog-cli-security/utils/results/conversion/summaryparser"
 	"github.com/jfrog/jfrog-cli-security/utils/results/conversion/tableparser"
 	"github.com/jfrog/jfrog-client-go/xray/services"
+	xscServices "github.com/jfrog/jfrog-client-go/xsc/services"
 	"github.com/owenrumney/go-sarif/v3/pkg/report/v210/sarif"
 )
 
@@ -52,7 +53,7 @@ func NewCommandResultsConvertor(params ResultConvertParams) *CommandResultsConve
 // Parse a stream of results and convert them to the desired format T
 type ResultsStreamFormatParser[T interface{}] interface {
 	// Reset the convertor to start converting a new command results
-	Reset(cmdType utils.CommandType, multiScanId, xrayVersion string, entitledForJas, multipleTargets bool, generalError error) error
+	Reset(cmdType utils.CommandType, multiScanId, xrayVersion string, entitledForJas, multipleTargets bool, gitContext *xscServices.XscGitInfoContext, generalError error) error
 	// Will be called for each scan target (indicating the current is done parsing and starting to parse a new scan)
 	ParseNewTargetResults(target results.ScanTarget, errors ...error) error
 	// TODO: This method is deprecated and only used for backward compatibility until the new BOM can contain all the information scanResponse contains.
@@ -105,7 +106,7 @@ func parseCommandResults[T interface{}](params ResultConvertParams, parser Resul
 	if params.IsMultipleRoots != nil {
 		multipleTargets = *params.IsMultipleRoots
 	}
-	if err = parser.Reset(cmdResults.CmdType, cmdResults.MultiScanId, cmdResults.XrayVersion, jasEntitled, multipleTargets, cmdResults.GeneralError); err != nil {
+	if err = parser.Reset(cmdResults.CmdType, cmdResults.MultiScanId, cmdResults.XrayVersion, jasEntitled, multipleTargets, cmdResults.GitContext, cmdResults.GeneralError); err != nil {
 		return
 	}
 	for _, targetScansResults := range cmdResults.Targets {

--- a/utils/results/conversion/cyclonedxparser/cyclonedxparser.go
+++ b/utils/results/conversion/cyclonedxparser/cyclonedxparser.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/jfrog/jfrog-client-go/utils/log"
 	"github.com/jfrog/jfrog-client-go/xray/services"
+	xscServices "github.com/jfrog/jfrog-client-go/xsc/services"
 
 	"github.com/jfrog/jfrog-cli-security/utils"
 	"github.com/jfrog/jfrog-cli-security/utils/formats"
@@ -49,7 +50,7 @@ func (cdc *CmdResultsCycloneDxConverter) Get() (bom *cyclonedx.BOM, err error) {
 	return
 }
 
-func (cdc *CmdResultsCycloneDxConverter) Reset(cmdType utils.CommandType, multiScanId, xrayVersion string, entitledForJas, multipleTargets bool, generalError error) (err error) {
+func (cdc *CmdResultsCycloneDxConverter) Reset(cmdType utils.CommandType, multiScanId, xrayVersion string, entitledForJas, multipleTargets bool, gitContext *xscServices.XscGitInfoContext, generalError error) (err error) {
 	cdc.entitledForJas = entitledForJas
 	cdc.xrayVersion = xrayVersion
 	// Reset the BOM

--- a/utils/results/conversion/sarifparser/sarifparser.go
+++ b/utils/results/conversion/sarifparser/sarifparser.go
@@ -22,6 +22,7 @@ import (
 	"github.com/jfrog/jfrog-client-go/utils/io/fileutils"
 	"github.com/jfrog/jfrog-client-go/utils/log"
 	"github.com/jfrog/jfrog-client-go/xray/services"
+	xscServices "github.com/jfrog/jfrog-client-go/xsc/services"
 )
 
 const (
@@ -104,7 +105,7 @@ func (sc *CmdResultsSarifConverter) Get() (*sarif.Report, error) {
 	return sarifutils.CombineMultipleRunsWithSameTool(sc.current), nil
 }
 
-func (sc *CmdResultsSarifConverter) Reset(cmdType utils.CommandType, _, xrayVersion string, entitledForJas, _ bool, _ error) (err error) {
+func (sc *CmdResultsSarifConverter) Reset(cmdType utils.CommandType, _, xrayVersion string, entitledForJas, _ bool, _ *xscServices.XscGitInfoContext, generalError error) (err error) {
 	sc.current = sarif.NewReport()
 	// Reset the current stream general information
 	sc.currentCmdType = cmdType

--- a/utils/results/conversion/simplejsonparser/simplejsonparser.go
+++ b/utils/results/conversion/simplejsonparser/simplejsonparser.go
@@ -13,6 +13,7 @@ import (
 	"github.com/jfrog/jfrog-cli-security/utils/severityutils"
 	"github.com/jfrog/jfrog-cli-security/utils/techutils"
 	"github.com/jfrog/jfrog-client-go/xray/services"
+	xscServices "github.com/jfrog/jfrog-client-go/xsc/services"
 	"github.com/owenrumney/go-sarif/v3/pkg/report/v210/sarif"
 )
 
@@ -44,7 +45,7 @@ func (sjc *CmdResultsSimpleJsonConverter) Get() (formats.SimpleJsonResults, erro
 	return *sjc.current, nil
 }
 
-func (sjc *CmdResultsSimpleJsonConverter) Reset(_ utils.CommandType, multiScanId, _ string, entitledForJas, multipleTargets bool, generalError error) (err error) {
+func (sjc *CmdResultsSimpleJsonConverter) Reset(_ utils.CommandType, multiScanId, _ string, entitledForJas, multipleTargets bool, _ *xscServices.XscGitInfoContext, generalError error) (err error) {
 	sjc.current = &formats.SimpleJsonResults{MultiScanId: multiScanId}
 	sjc.entitledForJas = entitledForJas
 	sjc.multipleRoots = multipleTargets

--- a/utils/results/conversion/summaryparser/summaryparser.go
+++ b/utils/results/conversion/summaryparser/summaryparser.go
@@ -10,6 +10,7 @@ import (
 	"github.com/jfrog/jfrog-cli-security/utils/results"
 	"github.com/jfrog/jfrog-cli-security/utils/severityutils"
 	"github.com/jfrog/jfrog-client-go/xray/services"
+	xscServices "github.com/jfrog/jfrog-client-go/xsc/services"
 	"github.com/owenrumney/go-sarif/v3/pkg/report/v210/sarif"
 )
 
@@ -37,7 +38,7 @@ func (sc *CmdResultsSummaryConverter) Get() (formats.ResultsSummary, error) {
 	return *sc.current, nil
 }
 
-func (sc *CmdResultsSummaryConverter) Reset(_ utils.CommandType, _, _ string, entitledForJas, _ bool, _ error) (err error) {
+func (sc *CmdResultsSummaryConverter) Reset(_ utils.CommandType, _, _ string, entitledForJas, _ bool, _ *xscServices.XscGitInfoContext, generalError error) (err error) {
 	sc.current = &formats.ResultsSummary{}
 	sc.entitledForJas = entitledForJas
 	return

--- a/utils/results/conversion/tableparser/tableparser.go
+++ b/utils/results/conversion/tableparser/tableparser.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/jfrog/jfrog-client-go/utils/log"
 	"github.com/jfrog/jfrog-client-go/xray/services"
+	xscServices "github.com/jfrog/jfrog-client-go/xsc/services"
 )
 
 type CmdResultsTableConverter struct {
@@ -51,8 +52,8 @@ func (tc *CmdResultsTableConverter) Get() (formats.ResultsTables, error) {
 	}, nil
 }
 
-func (tc *CmdResultsTableConverter) Reset(cmdType utils.CommandType, multiScanId, xrayVersion string, entitledForJas, multipleTargets bool, generalError error) (err error) {
-	return tc.simpleJsonConvertor.Reset(cmdType, multiScanId, xrayVersion, entitledForJas, multipleTargets, generalError)
+func (tc *CmdResultsTableConverter) Reset(cmdType utils.CommandType, multiScanId, xrayVersion string, entitledForJas, multipleTargets bool, gitContext *xscServices.XscGitInfoContext, generalError error) (err error) {
+	return tc.simpleJsonConvertor.Reset(cmdType, multiScanId, xrayVersion, entitledForJas, multipleTargets, gitContext, generalError)
 }
 
 func (tc *CmdResultsTableConverter) ParseNewTargetResults(target results.ScanTarget, errors ...error) (err error) {

--- a/utils/results/results.go
+++ b/utils/results/results.go
@@ -23,14 +23,14 @@ import (
 // SecurityCommandResults is a struct that holds the results of a security scan/audit command.
 type SecurityCommandResults struct {
 	// General fields describing the command metadata
-	XrayVersion      string            `json:"xray_version"`
-	XscVersion       string            `json:"xsc_version,omitempty"`
-	EntitledForJas   bool              `json:"jas_entitled"`
-	SecretValidation bool              `json:"secret_validation,omitempty"`
-	CmdType          utils.CommandType `json:"command_type"`
-	ResultContext    ResultContext     `json:"result_context,omitempty"`
+	XrayVersion      string                         `json:"xray_version"`
+	XscVersion       string                         `json:"xsc_version,omitempty"`
+	EntitledForJas   bool                           `json:"jas_entitled"`
+	SecretValidation bool                           `json:"secret_validation,omitempty"`
+	CmdType          utils.CommandType              `json:"command_type"`
+	ResultContext    ResultContext                  `json:"result_context,omitempty"`
 	GitContext       *xscServices.XscGitInfoContext `json:"git_context,omitempty"`
-	StartTime        time.Time         `json:"start_time"`
+	StartTime        time.Time                      `json:"start_time"`
 	// MultiScanId is a unique identifier that is used to group multiple scans together.
 	MultiScanId string `json:"multi_scan_id,omitempty"`
 	// Results for each target in the command

--- a/utils/results/results.go
+++ b/utils/results/results.go
@@ -16,6 +16,7 @@ import (
 	"github.com/jfrog/jfrog-client-go/utils/log"
 	"github.com/jfrog/jfrog-client-go/xray/services"
 	xrayApi "github.com/jfrog/jfrog-client-go/xray/services/utils"
+	xscServices "github.com/jfrog/jfrog-client-go/xsc/services"
 	"github.com/owenrumney/go-sarif/v3/pkg/report/v210/sarif"
 )
 
@@ -28,6 +29,7 @@ type SecurityCommandResults struct {
 	SecretValidation bool              `json:"secret_validation,omitempty"`
 	CmdType          utils.CommandType `json:"command_type"`
 	ResultContext    ResultContext     `json:"result_context,omitempty"`
+	GitContext       *xscServices.XscGitInfoContext `json:"git_context,omitempty"`
 	StartTime        time.Time         `json:"start_time"`
 	// MultiScanId is a unique identifier that is used to group multiple scans together.
 	MultiScanId string `json:"multi_scan_id,omitempty"`
@@ -174,6 +176,11 @@ func (r *SecurityCommandResults) SetMultiScanId(multiScanId string) *SecurityCom
 
 func (r *SecurityCommandResults) SetResultsContext(context ResultContext) *SecurityCommandResults {
 	r.ResultContext = context
+	return r
+}
+
+func (r *SecurityCommandResults) SetGitContext(gitContext *xscServices.XscGitInfoContext) *SecurityCommandResults {
+	r.GitContext = gitContext
 	return r
 }
 


### PR DESCRIPTION
- [ ] The pull request is targeting the `dev` branch.
- [ ] The code has been validated to compile successfully by running `go vet ./...`.
- [ ] The code has been formatted properly using `go fmt ./...`.
- [ ] All [static analysis checks](https://github.com/jfrog/jfrog-cli-security/actions/workflows/analysis.yml) passed.
- [ ] All [tests](https://github.com/jfrog/jfrog-cli-security/actions/workflows/test.yml) have passed. If this feature is not already covered by the tests, new tests have been added.
- [ ] Updated the [Contributing page](https://github.com/jfrog/jfrog-cli-security/blob/main/CONTRIBUTING.md) / [ReadMe page](https://github.com/jfrog/jfrog-cli-security/blob/main/README.md) / [CI Workflow files](https://github.com/jfrog/jfrog-cli-security/tree/main/.github/workflows) if needed.
- [ ] All changes are detailed at the description. if not already covered at [JFrog Documentation](https://github.com/jfrog/documentation), new documentation have been added.

-----

Add the scan GIT context content to the `cyclonedx` format if provided by the command