### PR TITLE
Fix - Race condition in AM path attribute in audit

### DIFF
--- a/commands/audit/audit.go
+++ b/commands/audit/audit.go
@@ -579,12 +579,17 @@ func createJasScansTask(auditParallelRunner *utils.SecurityParallelRunner, scanR
 		}()
 		// First download the analyzer manager if needed
 		if auditParams.customAnalyzerManagerBinaryPath == "" {
-			if err := jas.DownloadAnalyzerManagerIfNeeded(threadId); err != nil {
-				return fmt.Errorf("failed to download analyzer manager: %s", err.Error())
+			if generalError = jas.DownloadAnalyzerManagerIfNeeded(threadId); generalError != nil {
+				return fmt.Errorf("failed to download analyzer manager: %s", generalError.Error())
+			}
+			if scanner.AnalyzerManager.AnalyzerManagerFullPath, generalError = jas.GetAnalyzerManagerExecutable(); generalError != nil {
+				return fmt.Errorf("failed to set analyzer manager executable path: %s", generalError.Error())
 			}
 		} else {
-			log.Debug(fmt.Sprintf(clientutils.GetLogMsgPrefix(threadId, false)+"using custom analyzer manager binary path: %s", auditParams.customAnalyzerManagerBinaryPath))
+			scanner.AnalyzerManager.AnalyzerManagerFullPath = auditParams.customAnalyzerManagerBinaryPath
+			log.Debug(clientutils.GetLogMsgPrefix(threadId, false) + "using custom analyzer manager binary path")
 		}
+		log.Debug(clientutils.GetLogMsgPrefix(threadId, false) + fmt.Sprintf("Using analyzer manager executable at: %s", scanner.AnalyzerManager.AnalyzerManagerFullPath))
 		// Run JAS scanners for each scan target
 		for _, targetResult := range scanResults.Targets {
 			if targetResult.AppsConfigModule == nil {
@@ -593,15 +598,14 @@ func createJasScansTask(auditParallelRunner *utils.SecurityParallelRunner, scanR
 			}
 			appsConfigModule := *targetResult.AppsConfigModule
 			params := runner.JasRunnerParams{
-				Runner:                          auditParallelRunner,
-				ServerDetails:                   serverDetails,
-				Scanner:                         scanner,
-				CustomAnalyzerManagerBinaryPath: auditParams.customAnalyzerManagerBinaryPath,
-				Module:                          appsConfigModule,
-				ConfigProfile:                   auditParams.AuditBasicParams.GetConfigProfile(),
-				ScansToPerform:                  auditParams.ScansToPerform(),
-				SourceResultsToCompare:          scanner.GetResultsToCompareByRelativePath(utils.GetRelativePath(targetResult.Target, scanResults.GetCommonParentPath())),
-				SecretsScanType:                 secrets.SecretsScannerType,
+				Runner:                 auditParallelRunner,
+				ServerDetails:          serverDetails,
+				Scanner:                scanner,
+				Module:                 appsConfigModule,
+				ConfigProfile:          auditParams.AuditBasicParams.GetConfigProfile(),
+				ScansToPerform:         auditParams.ScansToPerform(),
+				SourceResultsToCompare: scanner.GetResultsToCompareByRelativePath(utils.GetRelativePath(targetResult.Target, scanResults.GetCommonParentPath())),
+				SecretsScanType:        secrets.SecretsScannerType,
 				CvesProvider: func() (directCves []string, indirectCves []string) {
 					if len(targetResult.GetScaScansXrayResults()) > 0 {
 						// TODO: remove this once the new SCA flow with cdx is fully implemented.

--- a/commands/scan/scan.go
+++ b/commands/scan/scan.go
@@ -537,6 +537,11 @@ func (scanCmd *ScanCommand) RunBinaryJasScans(cmdType utils.CommandType, msi str
 		log.Debug("Jas scanner was not created, skipping advance security scans...")
 		return
 	}
+	// Set the analyzer manager executable path.
+	if scanner.AnalyzerManager.AnalyzerManagerFullPath, err = jas.GetAnalyzerManagerExecutable(); err != nil {
+		return fmt.Errorf("failed to set analyzer manager executable path: %s", err.Error())
+	}
+	log.Debug(fmt.Sprintf("Using analyzer manager executable at: %s", scanner.AnalyzerManager.AnalyzerManagerFullPath))
 	jasParams := runner.JasRunnerParams{
 		Runner:         jasFileProducerConsumer,
 		ServerDetails:  scanCmd.serverDetails,

--- a/jas/runner/jasrunner.go
+++ b/jas/runner/jasrunner.go
@@ -23,10 +23,9 @@ import (
 )
 
 type JasRunnerParams struct {
-	Runner                          *utils.SecurityParallelRunner
-	ServerDetails                   *config.ServerDetails
-	Scanner                         *jas.JasScanner
-	CustomAnalyzerManagerBinaryPath string
+	Runner        *utils.SecurityParallelRunner
+	ServerDetails *config.ServerDetails
+	Scanner       *jas.JasScanner
 	// Module flags
 	Module        jfrogappsconfig.Module
 	ConfigProfile *services.ConfigProfile
@@ -53,13 +52,6 @@ type JasRunnerParams struct {
 type CveProvider func() (directCves []string, indirectCves []string)
 
 func AddJasScannersTasks(params JasRunnerParams) (generalError error) {
-	// Set the analyzer manager executable path.
-	if params.CustomAnalyzerManagerBinaryPath != "" {
-		params.Scanner.AnalyzerManager.AnalyzerManagerFullPath = params.CustomAnalyzerManagerBinaryPath
-	} else if params.Scanner.AnalyzerManager.AnalyzerManagerFullPath, generalError = jas.GetAnalyzerManagerExecutable(); generalError != nil {
-		return fmt.Errorf("failed to set analyzer manager executable path: %s", generalError.Error())
-	}
-	log.Debug(fmt.Sprintf("Using analyzer manager executable at: %s", params.Scanner.AnalyzerManager.AnalyzerManagerFullPath))
 	// For docker scan we support only secrets and contextual scans.
 	runAllScanners := false
 	if params.ApplicableScanType == applicability.ApplicabilityScannerType || params.SecretsScanType == secrets.SecretsScannerType {

--- a/jas/runner/jasrunner_test.go
+++ b/jas/runner/jasrunner_test.go
@@ -45,6 +45,8 @@ func TestJasRunner(t *testing.T) {
 
 	jasScanner, err := jas.NewJasScanner(&jas.FakeServerDetails, jas.WithEnvVars(false, jas.NotDiffScanEnvValue, jas.GetAnalyzerManagerXscEnvVars("", "", "", []string{}, targetResults.GetTechnologies()...)))
 	assert.NoError(t, err)
+	jasScanner.AnalyzerManager.AnalyzerManagerFullPath, err = jas.GetAnalyzerManagerExecutable()
+	assert.NoError(t, err)
 
 	targetResults.ScaScanResults(0, jas.FakeBasicXrayResults[0])
 	directComponents := []string{"issueId_1_direct_dependency", "issueId_2_direct_dependency"}


### PR DESCRIPTION
- [ ] The pull request is targeting the `dev` branch.
- [ ] The code has been validated to compile successfully by running `go vet ./...`.
- [ ] The code has been formatted properly using `go fmt ./...`.
- [ ] All [static analysis checks](https://github.com/jfrog/jfrog-cli-security/actions/workflows/analysis.yml) passed.
- [ ] All [tests](https://github.com/jfrog/jfrog-cli-security/actions/workflows/test.yml) have passed. If this feature is not already covered by the tests, new tests have been added.
- [ ] Updated the [Contributing page](https://github.com/jfrog/jfrog-cli-security/blob/main/CONTRIBUTING.md) / [ReadMe page](https://github.com/jfrog/jfrog-cli-security/blob/main/README.md) / [CI Workflow files](https://github.com/jfrog/jfrog-cli-security/tree/main/.github/workflows) if needed.
- [ ] All changes are detailed at the description. if not already covered at [JFrog Documentation](https://github.com/jfrog/documentation), new documentation have been added.

-----

If we are running on multiple targets audit. we are only downloading AM once but we were setting its value for each target (same scanner) and that caused 'race condition' to pop up in tests