### PR TITLE
Fix TestGradleTreesWithConfig compatibility on Windows

### DIFF
--- a/.github/actions/install-and-setup/action.yml
+++ b/.github/actions/install-and-setup/action.yml
@@ -102,3 +102,11 @@ runs:
         branch: swift-6.1-release
         tag: 6.1-RELEASE
       if: ${{ inputs.install-swift == 'true' && runner.os == 'Windows'}}
+
+    # Ensure Java 11 remains active after all installations (Swift setup might override it)
+    - name: Force Java 11 on Windows
+      if: runner.os == 'Windows'
+      shell: powershell
+      run: |
+        echo "JAVA_HOME=$env:JAVA_HOME_11_X64" >> $env:GITHUB_ENV
+        echo "$env:JAVA_HOME_11_X64\bin" >> $env:GITHUB_PATH

--- a/tests/testdata/projects/package-managers/gradle/gradle-example-config/gradle/wrapper/gradle-wrapper.properties
+++ b/tests/testdata/projects/package-managers/gradle/gradle-example-config/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.4-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.6-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
- [x] The pull request is targeting the `dev` branch.
- [x] The code has been validated to compile successfully by running `go vet ./...`.
- [x] The code has been formatted properly using `go fmt ./...`.
- [x] All [static analysis checks](https://github.com/jfrog/jfrog-cli-security/actions/workflows/analysis.yml) passed.
- [x] All [tests](https://github.com/jfrog/jfrog-cli-security/actions/workflows/test.yml) have passed. If this feature is not already covered by the tests, new tests have been added.
- [ ] Updated the [Contributing page](https://github.com/jfrog/jfrog-cli-security/blob/main/CONTRIBUTING.md) / [ReadMe page](https://github.com/jfrog/jfrog-cli-security/blob/main/README.md) / [CI Workflow files](https://github.com/jfrog/jfrog-cli-security/tree/main/.github/workflows) if needed.
- [ ] All changes are detailed at the description. if not already covered at [JFrog Documentation](https://github.com/jfrog/documentation), new documentation have been added.

Update Gradle wrapper from 5.6.4 to 7.6 in gradle-example-config test data to resolve 'Could not initialize class org.codehaus.groovy.classgen.Verifier' error that occurs when CI uses Java 17 instead of Java 11(certain actions override us and use 17)

Gradle 7.6 is compatible with both Java 11 and Java 17, making tests more robust across different CI environments.

Fixes Windows CI test failures while maintaining backwards compatibility.


Also, made sure the swift action wont override the java version in windows anymore
