### PR TITLE
XRAY-128408 - Add Sast rules flag to audit command

### DIFF
--- a/cli/docs/flags.go
+++ b/cli/docs/flags.go
@@ -56,6 +56,9 @@ const (
 	Sast      = "sast"
 	Secrets   = "secrets"
 	WithoutCA = "without-contextual-analysis"
+
+	// Sast related flags
+	AddSastRules = "add-sast-rules"
 )
 
 const (
@@ -171,7 +174,7 @@ var commandFlags = map[string][]string{
 		useWrapperAudit, DepType, RequirementsFile, Fail, ExtendedTable, WorkingDirs, ExclusionsAudit, Mvn, Gradle, Npm,
 		Pnpm, Yarn, Go, Swift, Cocoapods, Nuget, Pip, Pipenv, Poetry, MinSeverity, FixableOnly, ThirdPartyContextualAnalysis, Threads,
 		Sca, Iac, Sast, Secrets, WithoutCA, ScanVuln, SecretValidation, OutputDir, SkipAutoInstall, AllowPartialResults, MaxTreeDepth,
-		StaticSca, XrayLibPluginBinaryCustomPath, AnalyzerManagerCustomPath,
+		StaticSca, XrayLibPluginBinaryCustomPath, AnalyzerManagerCustomPath, AddSastRules,
 	},
 	UploadCdx: {
 		UploadRepoPath, uploadProjectKey,
@@ -187,7 +190,7 @@ var commandFlags = map[string][]string{
 		// Output params
 		Licenses, OutputFormat, ExtendedTable, OutputDir,
 		// Scan Logic params
-		StaticSca, XrayLibPluginBinaryCustomPath, AnalyzerManagerCustomPath,
+		StaticSca, XrayLibPluginBinaryCustomPath, AnalyzerManagerCustomPath, AddSastRules,
 	},
 	CurationAudit: {
 		CurationOutput, WorkingDirs, Threads, RequirementsFile, InsecureTls, useWrapperAudit,
@@ -306,6 +309,8 @@ var flagsMap = map[string]components.Flag{
 	Secrets:                       components.NewBoolFlag(Secrets, fmt.Sprintf("Selective scanners mode: Execute Secrets sub-scan. Can be combined with --%s, --%s and --%s.", Sca, Sast, Iac)),
 	WithoutCA:                     components.NewBoolFlag(WithoutCA, fmt.Sprintf("Selective scanners mode: Disable Contextual Analysis scanner after SCA. Relevant only with --%s flag.", Sca)),
 	SecretValidation:              components.NewBoolFlag(SecretValidation, fmt.Sprintf("Selective scanners mode: Triggers token validation on found secrets. Relevant only with --%s flag.", Secrets)),
+
+	AddSastRules: components.NewStringFlag(AddSastRules, "Incorporate any additional SAST rules (in JSON format, with absolute path) into this local scan."),
 
 	// Git flags
 	InputFile:       components.NewStringFlag(InputFile, "Path to an input file in YAML format contains multiple git providers. With this option, all other scm flags will be ignored and only git servers mentioned in the file will be examined.."),

--- a/cli/scancommands.go
+++ b/cli/scancommands.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"slices"
 	"strings"
 
 	buildInfoUtils "github.com/jfrog/build-info-go/utils"
@@ -27,11 +28,13 @@ import (
 	dockerScanDocs "github.com/jfrog/jfrog-cli-security/cli/docs/scan/dockerscan"
 	scanDocs "github.com/jfrog/jfrog-cli-security/cli/docs/scan/scan"
 	uploadCdxDocs "github.com/jfrog/jfrog-cli-security/cli/docs/upload"
+	"github.com/jfrog/jfrog-cli-security/utils"
 
 	"github.com/jfrog/jfrog-cli-security/commands/enrich"
 	"github.com/jfrog/jfrog-cli-security/commands/source_mcp"
 	"github.com/jfrog/jfrog-cli-security/sca/bom/indexer"
 	"github.com/jfrog/jfrog-cli-security/utils/xray"
+	"github.com/jfrog/jfrog-client-go/utils/io/fileutils"
 	"github.com/jfrog/jfrog-client-go/utils/log"
 	"github.com/urfave/cli"
 
@@ -410,6 +413,21 @@ func AuditCmd(c *components.Context) error {
 		return err
 	} else if len(subScans) > 0 {
 		auditCmd.SetScansToPerform(subScans)
+	}
+
+	// Validate that there is a sast scan before setting the sast rules
+	if sastRulesFile := c.GetStringFlagValue(flags.AddSastRules); sastRulesFile != "" {
+		// Check if file exists
+		if exists, err := fileutils.IsFileExists(sastRulesFile, false); err != nil || !exists {
+			return pluginsCommon.PrintHelpAndReturnError(fmt.Sprintf("file '%s' does not exist: %s", sastRulesFile, err.Error()), c)
+		}
+
+		// Validate scan is performed
+		if len(auditCmd.ScansToPerform()) > 0 && !slices.Contains(auditCmd.ScansToPerform(), utils.SastScan) {
+			return pluginsCommon.PrintHelpAndReturnError(fmt.Sprintf("flag '--%s' can only be used with '--%s'", flags.AddSastRules, flags.Sast), c)
+		}
+
+		auditCmd.SetSastRules(sastRulesFile)
 	}
 
 	threads, err := pluginsCommon.GetThreadsCount(c)

--- a/commands/audit/audit.go
+++ b/commands/audit/audit.go
@@ -625,6 +625,7 @@ func createJasScansTask(auditParallelRunner *utils.SecurityParallelRunner, scanR
 				ThirdPartyApplicabilityScan: auditParams.thirdPartyApplicabilityScan,
 				ApplicableScanType:          applicability.ApplicabilityScannerType,
 				SignedDescriptions:          getSignedDescriptions(auditParams.OutputFormat()),
+				SastRules:                   auditParams.SastRules(),
 				ScanResults:                 targetResult,
 				TargetOutputDir:             auditParams.scanResultsOutputDir,
 				AllowPartialResults:         auditParams.AllowPartialResults(),

--- a/commands/audit/auditparams.go
+++ b/commands/audit/auditparams.go
@@ -35,6 +35,7 @@ type AuditParams struct {
 	bomGenerator                    bom.SbomGenerator
 	customBomGenBinaryPath          string
 	scaScanStrategy                 scan.SbomScanStrategy
+	sastRules                       string
 	// Diff mode, scan only the files affected by the diff.
 	diffMode         bool
 	filesToScan      []string
@@ -98,6 +99,15 @@ func (params *AuditParams) SetCustomAnalyzerManagerBinaryPath(customAnalyzerMana
 
 func (params *AuditParams) CustomAnalyzerManagerBinaryPath() string {
 	return params.customAnalyzerManagerBinaryPath
+}
+
+func (params *AuditParams) SetSastRules(sastRules string) *AuditParams {
+	params.sastRules = sastRules
+	return params
+}
+
+func (params *AuditParams) SastRules() string {
+	return params.sastRules
 }
 
 func (params *AuditParams) SetScaScanStrategy(scaScanStrategy scan.SbomScanStrategy) *AuditParams {

--- a/jas/runner/jasrunner.go
+++ b/jas/runner/jasrunner.go
@@ -43,6 +43,7 @@ type JasRunnerParams struct {
 	ThirdPartyApplicabilityScan bool
 	// SAST scan flags
 	SignedDescriptions bool
+	SastRules          string
 	// Outputs
 	ScanResults     *results.TargetResults
 	TargetOutputDir string
@@ -177,7 +178,7 @@ func runSastScan(params *JasRunnerParams) parallel.TaskFunc {
 		defer func() {
 			params.Runner.JasScannersWg.Done()
 		}()
-		vulnerabilitiesResults, violationsResults, err := sast.RunSastScan(params.Scanner, params.Module, params.SignedDescriptions, threadId, getSourceRunsToCompare(params, jasutils.Sast)...)
+		vulnerabilitiesResults, violationsResults, err := sast.RunSastScan(params.Scanner, params.Module, params.SignedDescriptions, params.SastRules, threadId, getSourceRunsToCompare(params, jasutils.Sast)...)
 		params.Runner.ResultsMu.Lock()
 		defer params.Runner.ResultsMu.Unlock()
 		// We first add the scan results and only then check for errors, so we can store the exit code in order to report it in the end

--- a/jas/sast/sastscanner.go
+++ b/jas/sast/sastscanner.go
@@ -24,18 +24,19 @@ const (
 type SastScanManager struct {
 	scanner            *jas.JasScanner
 	signedDescriptions bool
+	sastRules          string
 
 	resultsToCompareFileName string
 	configFileName           string
 	resultsFileName          string
 }
 
-func RunSastScan(scanner *jas.JasScanner, module jfrogappsconfig.Module, signedDescriptions bool, threadId int, resultsToCompare ...*sarif.Run) (vulnerabilitiesResults []*sarif.Run, violationsResults []*sarif.Run, err error) {
+func RunSastScan(scanner *jas.JasScanner, module jfrogappsconfig.Module, signedDescriptions bool, sastRules string, threadId int, resultsToCompare ...*sarif.Run) (vulnerabilitiesResults []*sarif.Run, violationsResults []*sarif.Run, err error) {
 	var scannerTempDir string
 	if scannerTempDir, err = jas.CreateScannerTempDirectory(scanner, jasutils.Sast.String(), threadId); err != nil {
 		return
 	}
-	sastScanManager, err := newSastScanManager(scanner, scannerTempDir, signedDescriptions, resultsToCompare...)
+	sastScanManager, err := newSastScanManager(scanner, scannerTempDir, signedDescriptions, sastRules, resultsToCompare...)
 	if err != nil {
 		return
 	}
@@ -47,10 +48,11 @@ func RunSastScan(scanner *jas.JasScanner, module jfrogappsconfig.Module, signedD
 	return
 }
 
-func newSastScanManager(scanner *jas.JasScanner, scannerTempDir string, signedDescriptions bool, resultsToCompare ...*sarif.Run) (manager *SastScanManager, err error) {
+func newSastScanManager(scanner *jas.JasScanner, scannerTempDir string, signedDescriptions bool, sastRules string, resultsToCompare ...*sarif.Run) (manager *SastScanManager, err error) {
 	manager = &SastScanManager{
 		scanner:            scanner,
 		signedDescriptions: signedDescriptions,
+		sastRules:          sastRules,
 		configFileName:     filepath.Join(scannerTempDir, "config.yaml"),
 		resultsFileName:    filepath.Join(scannerTempDir, "results.sarif"),
 	}
@@ -94,6 +96,7 @@ type scanConfiguration struct {
 	ExcludePatterns        []string       `yaml:"exclude_patterns,omitempty"`
 	ExcludedRules          []string       `yaml:"excluded-rules,omitempty"`
 	SastParameters         sastParameters `yaml:"sast_parameters,omitempty"`
+	UserRules              string         `yaml:"user_rules,omitempty"`
 }
 
 type sastParameters struct {
@@ -122,6 +125,7 @@ func (ssm *SastScanManager) createConfigFile(module jfrogappsconfig.Module, sign
 					SignedDescriptions: signedDescriptions,
 				},
 				ExcludePatterns: jas.GetExcludePatterns(module, &sastScanner.Scanner, exclusions...),
+				UserRules:       ssm.sastRules,
 			},
 		},
 	}

--- a/jas/sast/sastscanner_test.go
+++ b/jas/sast/sastscanner_test.go
@@ -23,7 +23,7 @@ func TestNewSastScanManager(t *testing.T) {
 	jfrogAppsConfigForTest, err := jas.CreateJFrogAppsConfig([]string{"currentDir"})
 	assert.NoError(t, err)
 	// Act
-	sastScanManager, err := newSastScanManager(scanner, "temoDirPath", true)
+	sastScanManager, err := newSastScanManager(scanner, "temoDirPath", true, "")
 	assert.NoError(t, err)
 
 	// Assert
@@ -33,6 +33,7 @@ func TestNewSastScanManager(t *testing.T) {
 		assert.NotEmpty(t, sastScanManager.resultsFileName)
 		assert.NotEmpty(t, jfrogAppsConfigForTest.Modules[0].SourceRoot)
 		assert.Equal(t, &jas.FakeServerDetails, sastScanManager.scanner.ServerDetails)
+		assert.Empty(t, sastScanManager.sastRules)
 	}
 }
 
@@ -46,7 +47,7 @@ func TestNewSastScanManagerWithFilesToCompare(t *testing.T) {
 	scannerTempDir, err := jas.CreateScannerTempDirectory(scanner, jasutils.Secrets.String(), 0)
 	require.NoError(t, err)
 
-	sastScanManager, err := newSastScanManager(scanner, scannerTempDir, false, sarifutils.CreateRunWithDummyResults(sarifutils.CreateDummyResult("test-markdown", "test-msg", "test-rule-id", "note")))
+	sastScanManager, err := newSastScanManager(scanner, scannerTempDir, false, "", sarifutils.CreateRunWithDummyResults(sarifutils.CreateDummyResult("test-markdown", "test-msg", "test-rule-id", "note")))
 	require.NoError(t, err)
 
 	// Check if path value exists and file is created
@@ -61,7 +62,7 @@ func TestSastParseResults_EmptyResults(t *testing.T) {
 	assert.NoError(t, err)
 
 	// Arrange
-	sastScanManager, err := newSastScanManager(scanner, "temoDirPath", true)
+	sastScanManager, err := newSastScanManager(scanner, "temoDirPath", true, "")
 	assert.NoError(t, err)
 	sastScanManager.resultsFileName = filepath.Join(jas.GetTestDataPath(), "sast-scan", "no-violations.sarif")
 
@@ -84,7 +85,7 @@ func TestSastParseResults_ResultsContainIacViolations(t *testing.T) {
 	jfrogAppsConfigForTest, err := jas.CreateJFrogAppsConfig([]string{})
 	assert.NoError(t, err)
 	// Arrange
-	sastScanManager, err := newSastScanManager(scanner, "temoDirPath", false)
+	sastScanManager, err := newSastScanManager(scanner, "temoDirPath", false, "")
 	assert.NoError(t, err)
 	sastScanManager.resultsFileName = filepath.Join(jas.GetTestDataPath(), "sast-scan", "contains-sast-violations.sarif")
 
@@ -185,4 +186,21 @@ func TestGroupResultsByLocation(t *testing.T) {
 		groupResultsByLocation([]*sarif.Run{test.run})
 		assert.ElementsMatch(t, test.expectedOutput.Results, test.run.Results)
 	}
+}
+
+func TestSastRules(t *testing.T) {
+	scanner, cleanUp := jas.InitJasTest(t)
+	defer cleanUp()
+	tempDir, cleanUpTempDir := coreTests.CreateTempDirWithCallbackAndAssert(t)
+	defer cleanUpTempDir()
+
+	scanner.TempDir = tempDir
+	scannerTempDir, err := jas.CreateScannerTempDirectory(scanner, jasutils.Sast.String(), 0)
+	require.NoError(t, err)
+
+	sastScanManager, err := newSastScanManager(scanner, scannerTempDir, false, "test-rules.json")
+	require.NoError(t, err)
+	assert.Equal(t, "test-rules.json", sastScanManager.sastRules)
+	assert.Equal(t, filepath.Join(scannerTempDir, "config.yaml"), sastScanManager.configFileName)
+	assert.Equal(t, filepath.Join(scannerTempDir, "results.sarif"), sastScanManager.resultsFileName)
 }


### PR DESCRIPTION
Resolves [XRAY-128408](https://jfrog-int.atlassian.net/browse/XRAY-128408)

## Add Custom rules to the SAST scan
Prepare a custom json rules file with your rules:
```
[
  {
    "name": "custom-rule",
    "message": "User-controlled data used as argument to math.sqrt",
    "finder": {
      "type": "FlowFinder",
      "sources": {
        "type": "calls",
        "names": [
          "input"
        ]
      },
      "sinks": {
        "type": "calls",
        "names": [
          "math.sqrt"
        ]
      }
    },
    "cwe": null,
    "description": "User-controlled square root",
    "severity": "high",
    "tags": []
  }
]
```

Run with the flag `--add-sast-rules=/path/to/file.json`