### PR TITLE
make GetFinalApplicabilityStatus public

### DIFF
--- a/utils/results/common.go
+++ b/utils/results/common.go
@@ -709,7 +709,7 @@ func GetCveApplicabilityField(cveId string, applicabilityScanResults []*sarif.Ru
 	}
 	switch {
 	case len(applicabilityStatuses) > 0:
-		applicability.Status = string(getFinalApplicabilityStatus(applicabilityStatuses))
+		applicability.Status = string(GetFinalApplicabilityStatus(applicabilityStatuses))
 	case !resultFound:
 		applicability.Status = string(jasutils.ApplicabilityUndetermined)
 	case len(applicability.Evidence) == 0:
@@ -766,7 +766,7 @@ func GetApplicableCveStatus(entitledForJas bool, applicabilityScanResults []*sar
 			applicableStatuses = append(applicableStatuses, jasutils.ApplicabilityStatus(cve.Applicability.Status))
 		}
 	}
-	return getFinalApplicabilityStatus(applicableStatuses)
+	return GetFinalApplicabilityStatus(applicableStatuses)
 }
 
 // We only care to update the status if it's the first time we see it or if status is 0 (completed) and the new status is not (failed)
@@ -852,7 +852,7 @@ func shouldDisqualifyEvidence(components map[string]services.Component, evidence
 // Else if at least one cve is missing context -> final value is missing context
 // Else if all cves are not covered -> final value is not covered
 // Else (case when all cves aren't applicable) -> final value is not applicable
-func getFinalApplicabilityStatus(applicabilityStatuses []jasutils.ApplicabilityStatus) jasutils.ApplicabilityStatus {
+func GetFinalApplicabilityStatus(applicabilityStatuses []jasutils.ApplicabilityStatus) jasutils.ApplicabilityStatus {
 	if len(applicabilityStatuses) == 0 {
 		return jasutils.NotScanned
 	}

--- a/utils/results/common_test.go
+++ b/utils/results/common_test.go
@@ -928,7 +928,7 @@ func TestGetFinalApplicabilityStatus(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			assert.Equal(t, tc.expectedOutput, getFinalApplicabilityStatus(tc.input))
+			assert.Equal(t, tc.expectedOutput, GetFinalApplicabilityStatus(tc.input))
 		})
 	}
 }


### PR DESCRIPTION
- [ ] The pull request is targeting the `dev` branch.
- [ ] The code has been validated to compile successfully by running `go vet ./...`.
- [ ] The code has been formatted properly using `go fmt ./...`.
- [ ] All [static analysis checks](https://github.com/jfrog/jfrog-cli-security/actions/workflows/analysis.yml) passed.
- [ ] All [tests](https://github.com/jfrog/jfrog-cli-security/actions/workflows/test.yml) have passed. If this feature is not already covered by the tests, new tests have been added.
- [ ] Updated the [Contributing page](https://github.com/jfrog/jfrog-cli-security/blob/main/CONTRIBUTING.md) / [ReadMe page](https://github.com/jfrog/jfrog-cli-security/blob/main/README.md) / [CI Workflow files](https://github.com/jfrog/jfrog-cli-security/tree/main/.github/workflows) if needed.
- [ ] All changes are detailed at the description. if not already covered at [JFrog Documentation](https://github.com/jfrog/documentation), new documentation have been added.

-----