### PR TITLE
Fix empty Target JAS Results

### DIFF
--- a/utils/results/common.go
+++ b/utils/results/common.go
@@ -78,6 +78,16 @@ func CheckIfFailBuild(auditResults *SecurityCommandResults) (bool, error) {
 }
 
 func checkIfFailBuildConsideringApplicability(target *TargetResults, entitledForJas bool, shouldFailBuild *bool) error {
+	if target == nil {
+		log.Debug("checkIfFailBuildConsideringApplicability: target is nil, returning early")
+		return nil
+	}
+	if target.JasResults == nil {
+		log.Debug(fmt.Sprintf("checkIfFailBuildConsideringApplicability: JasResults is nil for target %s, falling back to check without applicability", target.ScanTarget.Target))
+		*shouldFailBuild = checkIfFailBuildWithoutConsideringApplicability(target)
+		return nil
+	}
+
 	jasApplicabilityResults := target.JasResults.GetApplicabilityScanResults()
 
 	if target.ScaResults == nil {

--- a/utils/results/common_test.go
+++ b/utils/results/common_test.go
@@ -183,6 +183,30 @@ func TestViolationFailBuild(t *testing.T) {
 			},
 			expectedResult: false,
 		},
+		{
+			name: "nil JasResults with violations - should fallback to check without applicability",
+			auditResults: &SecurityCommandResults{
+				EntitledForJas: true,
+				Targets: []*TargetResults{
+					{
+						ScanTarget: ScanTarget{Target: "test-target"},
+						ScaResults: &ScaScanResults{
+							Violations: []services.Violation{
+								{
+									Components:    map[string]services.Component{"gav://antparent:ant:1.6.5": {}},
+									ViolationType: utils.ViolationTypeSecurity.String(),
+									FailBuild:     true,
+									Cves:          []services.Cve{{Id: "CVE-2024-1234"}},
+									Severity:      "High",
+								},
+							},
+						},
+						JasResults: nil,
+					},
+				},
+			},
+			expectedResult: true, // Should fail because violation has FailBuild=true
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
- [x] The pull request is targeting the `dev` branch.
- [ ] The code has been validated to compile successfully by running `go vet ./...`.
- [ ] The code has been formatted properly using `go fmt ./...`.
- [ ] All [static analysis checks](https://github.com/jfrog/jfrog-cli-security/actions/workflows/analysis.yml) passed.
- [ ] All [tests](https://github.com/jfrog/jfrog-cli-security/actions/workflows/test.yml) have passed. If this feature is not already covered by the tests, new tests have been added.
- [ ] Updated the [Contributing page](https://github.com/jfrog/jfrog-cli-security/blob/main/CONTRIBUTING.md) / [ReadMe page](https://github.com/jfrog/jfrog-cli-security/blob/main/README.md) / [CI Workflow files](https://github.com/jfrog/jfrog-cli-security/tree/main/.github/workflows) if needed.
- [ ] All changes are detailed at the description. if not already covered at [JFrog Documentation](https://github.com/jfrog/documentation), new documentation have been added.

-----

Fix `nil pointer` when trying to scan a docker container when no JAS results exits for the target