### PR TITLE
fix panic where version not found in pod dep tree

### DIFF
--- a/sca/bom/buildinfo/technologies/cocoapods/cocoapods.go
+++ b/sca/bom/buildinfo/technologies/cocoapods/cocoapods.go
@@ -142,8 +142,8 @@ func GetPodDependenciesGraph(data string) (map[string][]string, map[string]strin
 		if len(mainDepMatch) == 3 {
 			versionMatch := versionRegex.FindStringSubmatch(line)
 			currentMainDep = mainDepMatch[1]
-			_, ok := dependencyMap[currentMainDep]
-			if !ok {
+			if _, ok := dependencyMap[currentMainDep]; !ok && len(versionMatch) > 1 {
+				// New dependency with version found
 				dependencyMap[currentMainDep] = []string{}
 				versionMap[currentMainDep] = versionMatch[1]
 			}


### PR DESCRIPTION
- [ ] The pull request is targeting the `dev` branch.
- [ ] The code has been validated to compile successfully by running `go vet ./...`.
- [ ] The code has been formatted properly using `go fmt ./...`.
- [ ] All [static analysis checks](https://github.com/jfrog/jfrog-cli-security/actions/workflows/analysis.yml) passed.
- [ ] All [tests](https://github.com/jfrog/jfrog-cli-security/actions/workflows/test.yml) have passed. If this feature is not already covered by the tests, new tests have been added.
- [ ] Updated the [Contributing page](https://github.com/jfrog/jfrog-cli-security/blob/main/CONTRIBUTING.md) / [ReadMe page](https://github.com/jfrog/jfrog-cli-security/blob/main/README.md) / [CI Workflow files](https://github.com/jfrog/jfrog-cli-security/tree/main/.github/workflows) if needed.
- [ ] All changes are detailed at the description. if not already covered at [JFrog Documentation](https://github.com/jfrog/documentation), new documentation have been added.

-----

fixing:
```
14:44:07 14:44:06 [Info] Calculating Cocoapods dependencies...

14:44:07 panic: runtime error: index out of range [1] with length 0

14:44:07 14:44:07 goroutine 1 [running]:14:44:07 github.com/jfrog/jfrog-cli-security/sca/bom/buildinfo/technologies/cocoapods.GetPodDependenciesGraph({0x14000950000?, 0x42?})14:44:07   github.com/jfrog/jfrog-cli-security@v1.21.5/sca/bom/buildinfo/technologies/cocoapods/cocoapods.go:148 +0x39c14:44:07 github.com/jfrog/jfrog-cli-security/sca/bom/buildinfo/technologies/cocoapods.BuildDependencyTree({{0x14000594160, 0x8}, {0x0, 0x0}, {0x140004b5080, 0x54}, 0x0, 0x140007616c0, {0x0, 0x0}, ...})14:44:07   github.com/jfrog/jfrog-cli-security@v1.21.5/sca/bom/buildinfo/technologies/cocoapods/cocoapods.go:214 +0x11814:44:07 github.com/jfrog/jfrog-cli-security/sca/bom/buildinfo.GetTechDependencyTree({{0x14000594160, 0x8}, {0x0, 0x0}, {0x140004b5080, 0x54}, 0x0, 0x140007616c0, {0x0, 0x0}, ...}, 
```