### PR TITLE
Add ConvertTargetToSimpleJson for per-target conversion

### DIFF
--- a/utils/results/conversion/convertor.go
+++ b/utils/results/conversion/convertor.go
@@ -84,6 +84,18 @@ func (c *CommandResultsConvertor) ConvertToSimpleJson(cmdResults *results.Securi
 	return parseCommandResults(c.Params, parser, cmdResults)
 }
 
+// ConvertTargetToSimpleJson converts a single TargetResults to SimpleJson format without flattening multiple targets.
+func (c *CommandResultsConvertor) ConvertTargetToSimpleJson(target *results.TargetResults, cmdResults *results.SecurityCommandResults) (simpleJsonResults formats.SimpleJsonResults, err error) {
+	if target == nil {
+		return formats.SimpleJsonResults{}, nil
+	}
+	singleTargetResults := &results.SecurityCommandResults{
+		ResultsMetaData: cmdResults.ResultsMetaData,
+		Targets:         []*results.TargetResults{target},
+	}
+	return c.ConvertToSimpleJson(singleTargetResults)
+}
+
 func (c *CommandResultsConvertor) ConvertToSarif(cmdResults *results.SecurityCommandResults) (sarifReport *sarif.Report, err error) {
 	parser := sarifparser.NewCmdResultsSarifConverter(c.Params.PlatformUrl, c.Params.PatchBinaryPaths)
 	return parseCommandResults(c.Params, parser, cmdResults)


### PR DESCRIPTION
This method allows converting a single TargetResults to SimpleJson format without flattening multiple targets together. Useful for tools like Frogbot that need to process each auto-detected target separately to maintain working directory associations when applying fixes.

- [ ] The pull request is targeting the `dev` branch.
- [ ] The code has been validated to compile successfully by running `go vet ./...`.
- [ ] The code has been formatted properly using `go fmt ./...`.
- [ ] All [static analysis checks](https://github.com/jfrog/jfrog-cli-security/actions/workflows/analysis.yml) passed.
- [ ] All [tests](https://github.com/jfrog/jfrog-cli-security/actions/workflows/test.yml) have passed. If this feature is not already covered by the tests, new tests have been added.
- [ ] Updated the [Contributing page](https://github.com/jfrog/jfrog-cli-security/blob/main/CONTRIBUTING.md) / [ReadMe page](https://github.com/jfrog/jfrog-cli-security/blob/main/README.md) / [CI Workflow files](https://github.com/jfrog/jfrog-cli-security/tree/main/.github/workflows) if needed.
- [ ] All changes are detailed at the description. if not already covered at [JFrog Documentation](https://github.com/jfrog/documentation), new documentation have been added.

-----