### PR TITLE
Don't break project into folders for scans which don't require sca

### DIFF
--- a/commands/audit/audit.go
+++ b/commands/audit/audit.go
@@ -470,7 +470,22 @@ func getTargetResultsToCompare(cmdResults, resultsToCompare *results.SecurityCom
 	return
 }
 
+func scaIndependentScans(scans []utils.SubScanType) bool {
+	for _, scan_type := range scans {
+		if (scan_type != utils.SecretsScan && scan_type != utils.SastScan && scan_type != utils.IacScan) {
+			return false
+		}
+	}
+	return true
+}
+
 func detectScanTargets(cmdResults *results.SecurityCommandResults, params *AuditParams) {
+
+	if scaIndependentScans(params.ScansToPerform()) {
+		cmdResults.NewScanResults(results.ScanTarget{Target: params.workingDirs[0]})
+		return
+	}
+
 	for _, requestedDirectory := range params.workingDirs {
 		if !fileutils.IsPathExists(requestedDirectory, false) {
 			log.Warn("The working directory", requestedDirectory, "doesn't exist. Skipping SCA scan...")


### PR DESCRIPTION
…need sca

- [V] The pull request is targeting the `dev` branch.
- [V ] The code has been validated to compile successfully by running `go vet ./...`.
- [V] The code has been formatted properly using `go fmt ./...`.
- [x] All [static analysis checks](https://github.com/jfrog/jfrog-cli-security/actions/workflows/analysis.yml) passed.
- [x] All [tests](https://github.com/jfrog/jfrog-cli-security/actions/workflows/test.yml) have passed. If this feature is not already covered by the tests, new tests have been added.
- [V] Updated the [Contributing page](https://github.com/jfrog/jfrog-cli-security/blob/main/CONTRIBUTING.md) / [ReadMe page](https://github.com/jfrog/jfrog-cli-security/blob/main/README.md) / [CI Workflow files](https://github.com/jfrog/jfrog-cli-security/tree/main/.github/workflows) if needed.
- [V] All changes are detailed at the description. if not already covered at [JFrog Documentation](https://github.com/jfrog/documentation), new documentation have been added.

-----