### PR TITLE
Convert remediation error to not fail commands

### DIFF
--- a/sca/scan/enrich/runner.go
+++ b/sca/scan/enrich/runner.go
@@ -19,6 +19,8 @@ import (
 type EnrichScanStrategy struct {
 	serverDetails *config.ServerDetails
 	projectKey    string
+	// Fix version attachment is not critical, so we continue even if it fails without returning an error
+	failOnRemediationError bool
 }
 
 func NewEnrichScanStrategy() *EnrichScanStrategy {
@@ -39,6 +41,14 @@ func (ess *EnrichScanStrategy) WithOptions(options ...scan.SbomScanOption) scan.
 		option(ess)
 	}
 	return ess
+}
+
+func WithFailOnRemediationError(failOnRemediationError bool) scan.SbomScanOption {
+	return func(sss scan.SbomScanStrategy) {
+		if ess, ok := sss.(*EnrichScanStrategy); ok {
+			ess.failOnRemediationError = failOnRemediationError
+		}
+	}
 }
 
 func (ess *EnrichScanStrategy) PrepareStrategy() (err error) {
@@ -65,16 +75,27 @@ func (ess *EnrichScanStrategy) SbomEnrichTask(target *cyclonedx.BOM) (enriched *
 	}
 	log.Debug("SBOM enrichment completed successfully")
 	// Fixed versions are not returned from the enrich API, next we need to enrich with remediation API.
+	if e := ess.attachFixedVersionsToVulnerabilities(enriched); e != nil {
+		e = fmt.Errorf("failed to enrich SBOM with remediation: %w", e)
+		if ess.failOnRemediationError {
+			return enriched, e
+		}
+		log.Error(e.Error())
+	} else {
+		log.Debug("SBOM remediation enrichment completed successfully")
+	}
+	return enriched, nil
+}
+
+func (ess *EnrichScanStrategy) attachFixedVersionsToVulnerabilities(bom *cyclonedx.BOM) error {
 	xrayManager, err := xray.CreateXrayServiceManager(ess.serverDetails, xray.WithScopedProjectKey(ess.projectKey))
 	if err != nil {
-		return enriched, fmt.Errorf("failed to create Xray service manager: %w", err)
+		return fmt.Errorf("failed to create Xray service manager: %w", err)
 	}
-	err = remediation.AttachFixedVersionsToVulnerabilities(xrayManager, enriched)
-	if err != nil {
-		return enriched, fmt.Errorf("failed to attach fixed versions to vulnerabilities: %w", err)
+	if e := remediation.AttachFixedVersionsToVulnerabilities(xrayManager, bom); e != nil {
+		return fmt.Errorf("failed to attach fixed versions to vulnerabilities: %w", e)
 	}
-	log.Debug("SBOM remediation enrichment completed successfully")
-	return
+	return nil
 }
 
 func (ess *EnrichScanStrategy) DeprecatedScanTask(target *cyclonedx.BOM) (techResults services.ScanResponse, err error) {


### PR DESCRIPTION
## Convert remediation error to warning instead of failing commands

Fix version attachment via the remediation API is not critical to SBOM enrichment. Previously, a failure in the remediation step would propagate as a hard error, causing the entire enrich command to fail. This change makes the remediation error non-fatal by default — it is logged as an error but the command continues and returns partial results.

### Changes

- Added a `failOnRemediationError` field to `EnrichScanStrategy` (defaults to `false`) so callers can opt in to strict behaviour when needed.
- Added a `WithFailOnRemediationError` option function to configure the flag.
- Extracted the remediation logic into a dedicated `attachFixedVersionsToVulnerabilities` method for clarity.
- Updated `SbomEnrichTask` to log the remediation error and continue when `failOnRemediationError` is `false`, or propagate it when `true`.

---

- [x] The pull request is targeting the `dev` branch.
- [ ] The code has been validated to compile successfully by running `go vet ./...`.
- [ ] The code has been formatted properly using `go fmt ./...`.
- [ ] All [static analysis checks](https://github.com/jfrog/jfrog-cli-security/actions/workflows/analysis.yml) passed.
- [ ] All [tests](https://github.com/jfrog/jfrog-cli-security/actions/workflows/test.yml) have passed. If this feature is not already covered by the tests, new tests have been added.
- [ ] Updated the [Contributing page](https://github.com/jfrog/jfrog-cli-security/blob/main/CONTRIBUTING.md) / [ReadMe page](https://github.com/jfrog/jfrog-cli-security/blob/main/README.md) / [CI Workflow files](https://github.com/jfrog/jfrog-cli-security/tree/main/.github/workflows) if needed.
- [x] All changes are detailed at the description. if not already covered at [JFrog Documentation](https://github.com/jfrog/documentation), new documentation have been added.

-----