### PR TITLE
XRAY-138687 - [Curation] Implementing support for additional flags

### DIFF
--- a/cli/docs/flags.go
+++ b/cli/docs/flags.go
@@ -161,6 +161,7 @@ const (
 	SolutionPath          = "solution-path"
 	IncludeCachedPackages = "include-cached-packages"
 	LegacyPeerDeps        = "legacy-peer-deps"
+	RunNative             = "run-native"
 
 	// Unique git flags
 	InputFile       = "input-file"
@@ -219,7 +220,7 @@ var commandFlags = map[string][]string{
 		StaticSca, XrayLibPluginBinaryCustomPath, AnalyzerManagerCustomPath, AddSastRules,
 	},
 	CurationAudit: {
-		CurationOutput, WorkingDirs, Threads, RequirementsFile, InsecureTls, useWrapperAudit, UseIncludedBuilds, SolutionPath, DockerImageName, IncludeCachedPackages, LegacyPeerDeps,
+		CurationOutput, WorkingDirs, Threads, RequirementsFile, InsecureTls, useWrapperAudit, UseIncludedBuilds, SolutionPath, DockerImageName, IncludeCachedPackages, LegacyPeerDeps, RunNative,
 	},
 	GitCountContributors: {
 		InputFile, ScmType, ScmApiUrl, Token, Owner, RepoName, Months, DetailedSummary, InsecureTls,
@@ -342,6 +343,7 @@ var flagsMap = map[string]components.Flag{
 	SolutionPath:                  components.NewStringFlag(SolutionPath, "Path to the .NET solution file (.sln) to use when multiple solution files are present in the directory."),
 	IncludeCachedPackages:         components.NewBoolFlag(IncludeCachedPackages, "When set to true, the system will audit cached packages. This configuration is mandatory for Curation on-demand workflows, which rely on package caching."),
 	LegacyPeerDeps:                components.NewBoolFlag(LegacyPeerDeps, "[npm] Pass --legacy-peer-deps to npm install to bypass peer-dependency version conflicts."),
+	RunNative:                     components.NewBoolFlag(RunNative, "[npm] Use the native npm client for dependency resolution. Reads Artifactory URL and repository from the project's .npmrc registry — no 'jf npm-config' required. Respects .npmrc and Volta configuration."),
 	binarySca:                     components.NewBoolFlag(Sca, fmt.Sprintf("Selective scanners mode: Execute SCA (Software Composition Analysis) sub-scan. Use --%s to run both SCA and Contextual Analysis. Use --%s --%s to to run SCA. Can be combined with --%s.", Sca, Sca, WithoutCA, Secrets)),
 	binarySecrets:                 components.NewBoolFlag(Secrets, fmt.Sprintf("Selective scanners mode: Execute Secrets sub-scan. Can be combined with --%s.", Sca)),
 	binaryWithoutCA:               components.NewBoolFlag(WithoutCA, fmt.Sprintf("Selective scanners mode: Disable Contextual Analysis scanner after SCA. Relevant only with --%s flag.", Sca)),

--- a/cli/docs/flags.go
+++ b/cli/docs/flags.go
@@ -160,6 +160,7 @@ const (
 	DockerImageName       = "image"
 	SolutionPath          = "solution-path"
 	IncludeCachedPackages = "include-cached-packages"
+	LegacyPeerDeps        = "legacy-peer-deps"
 
 	// Unique git flags
 	InputFile       = "input-file"
@@ -218,7 +219,7 @@ var commandFlags = map[string][]string{
 		StaticSca, XrayLibPluginBinaryCustomPath, AnalyzerManagerCustomPath, AddSastRules,
 	},
 	CurationAudit: {
-		CurationOutput, WorkingDirs, Threads, RequirementsFile, InsecureTls, useWrapperAudit, UseIncludedBuilds, SolutionPath, DockerImageName, IncludeCachedPackages,
+		CurationOutput, WorkingDirs, Threads, RequirementsFile, InsecureTls, useWrapperAudit, UseIncludedBuilds, SolutionPath, DockerImageName, IncludeCachedPackages, LegacyPeerDeps,
 	},
 	GitCountContributors: {
 		InputFile, ScmType, ScmApiUrl, Token, Owner, RepoName, Months, DetailedSummary, InsecureTls,
@@ -340,6 +341,7 @@ var flagsMap = map[string]components.Flag{
 	CurationOutput:                components.NewStringFlag(OutputFormat, "Defines the output format of the command. Acceptable values are: table, json.", components.WithStrDefaultValue("table")),
 	SolutionPath:                  components.NewStringFlag(SolutionPath, "Path to the .NET solution file (.sln) to use when multiple solution files are present in the directory."),
 	IncludeCachedPackages:         components.NewBoolFlag(IncludeCachedPackages, "When set to true, the system will audit cached packages. This configuration is mandatory for Curation on-demand workflows, which rely on package caching."),
+	LegacyPeerDeps:                components.NewBoolFlag(LegacyPeerDeps, "[npm] Pass --legacy-peer-deps to npm install to bypass peer-dependency version conflicts."),
 	binarySca:                     components.NewBoolFlag(Sca, fmt.Sprintf("Selective scanners mode: Execute SCA (Software Composition Analysis) sub-scan. Use --%s to run both SCA and Contextual Analysis. Use --%s --%s to to run SCA. Can be combined with --%s.", Sca, Sca, WithoutCA, Secrets)),
 	binarySecrets:                 components.NewBoolFlag(Secrets, fmt.Sprintf("Selective scanners mode: Execute Secrets sub-scan. Can be combined with --%s.", Sca)),
 	binaryWithoutCA:               components.NewBoolFlag(WithoutCA, fmt.Sprintf("Selective scanners mode: Disable Contextual Analysis scanner after SCA. Relevant only with --%s flag.", Sca)),

--- a/cli/scancommands.go
+++ b/cli/scancommands.go
@@ -740,7 +740,7 @@ func getCurationCommand(c *components.Context) (*curation.CurationAuditCommand, 
 	curationAuditCommand.SetDockerImageName(c.GetStringFlagValue(flags.DockerImageName))
 	curationAuditCommand.SetIncludeCachedPackages(c.GetBoolFlagValue(flags.IncludeCachedPackages))
 	if c.GetBoolFlagValue(flags.LegacyPeerDeps) {
-		curationAuditCommand.SetInstallCommandArgs(append(curationAuditCommand.InstallCommandArgs(), "--legacy-peer-deps"))
+		curationAuditCommand.SetNpmScope("legacyPeerDeps")
 	}
 	return curationAuditCommand, nil
 }

--- a/cli/scancommands.go
+++ b/cli/scancommands.go
@@ -739,9 +739,8 @@ func getCurationCommand(c *components.Context) (*curation.CurationAuditCommand, 
 		SetSolutionFilePath(c.GetStringFlagValue(flags.SolutionPath))
 	curationAuditCommand.SetDockerImageName(c.GetStringFlagValue(flags.DockerImageName))
 	curationAuditCommand.SetIncludeCachedPackages(c.GetBoolFlagValue(flags.IncludeCachedPackages))
-	if c.GetBoolFlagValue(flags.LegacyPeerDeps) {
-		curationAuditCommand.SetNpmScope("legacyPeerDeps")
-	}
+	curationAuditCommand.SetLegacyPeerDeps(c.GetBoolFlagValue(flags.LegacyPeerDeps))
+	curationAuditCommand.SetRunNative(c.GetBoolFlagValue(flags.RunNative))
 	return curationAuditCommand, nil
 }
 

--- a/cli/scancommands.go
+++ b/cli/scancommands.go
@@ -739,6 +739,9 @@ func getCurationCommand(c *components.Context) (*curation.CurationAuditCommand, 
 		SetSolutionFilePath(c.GetStringFlagValue(flags.SolutionPath))
 	curationAuditCommand.SetDockerImageName(c.GetStringFlagValue(flags.DockerImageName))
 	curationAuditCommand.SetIncludeCachedPackages(c.GetBoolFlagValue(flags.IncludeCachedPackages))
+	if c.GetBoolFlagValue(flags.LegacyPeerDeps) {
+		curationAuditCommand.SetInstallCommandArgs(append(curationAuditCommand.InstallCommandArgs(), "--legacy-peer-deps"))
+	}
 	return curationAuditCommand, nil
 }
 

--- a/commands/audit/auditbasicparams.go
+++ b/commands/audit/auditbasicparams.go
@@ -28,6 +28,7 @@ type AuditParamsInterface interface {
 	Args() []string
 	InstallCommandName() string
 	InstallCommandArgs() []string
+	SetInstallCommandArgs(installCommandArgs []string) *AuditBasicParams
 	SetNpmScope(depType string) *AuditBasicParams
 	SetMaxTreeDepth(maxTreeDepth string) *AuditBasicParams
 	MaxTreeDepth() string

--- a/commands/audit/auditbasicparams.go
+++ b/commands/audit/auditbasicparams.go
@@ -29,6 +29,10 @@ type AuditParamsInterface interface {
 	InstallCommandName() string
 	InstallCommandArgs() []string
 	SetNpmScope(depType string) *AuditBasicParams
+	SetRunNative(runNative bool) *AuditBasicParams
+	RunNative() bool
+	SetLegacyPeerDeps(legacyPeerDeps bool) *AuditBasicParams
+	LegacyPeerDeps() bool
 	SetMaxTreeDepth(maxTreeDepth string) *AuditBasicParams
 	MaxTreeDepth() string
 	OutputFormat() format.OutputFormat
@@ -78,6 +82,8 @@ type AuditBasicParams struct {
 	isRecursiveScan                  bool
 	skipAutoInstall                  bool
 	allowPartialResults              bool
+	runNative                        bool
+	legacyPeerDeps                   bool
 	xrayVersion                      string
 	xscVersion                       string
 	configProfile                    *xscservices.ConfigProfile
@@ -221,10 +227,26 @@ func (abp *AuditBasicParams) SetNpmScope(depType string) *AuditBasicParams {
 		abp.args = []string{"--dev"}
 	case "prodOnly":
 		abp.args = []string{"--prod"}
-	case "legacyPeerDeps":
-		abp.installCommandArgs = append(abp.installCommandArgs, "--legacy-peer-deps")
 	}
 	return abp
+}
+
+func (abp *AuditBasicParams) SetRunNative(runNative bool) *AuditBasicParams {
+	abp.runNative = runNative
+	return abp
+}
+
+func (abp *AuditBasicParams) RunNative() bool {
+	return abp.runNative
+}
+
+func (abp *AuditBasicParams) SetLegacyPeerDeps(legacyPeerDeps bool) *AuditBasicParams {
+	abp.legacyPeerDeps = legacyPeerDeps
+	return abp
+}
+
+func (abp *AuditBasicParams) LegacyPeerDeps() bool {
+	return abp.legacyPeerDeps
 }
 
 func (abp *AuditBasicParams) SetConanProfile(file string) *AuditBasicParams {

--- a/commands/audit/auditbasicparams.go
+++ b/commands/audit/auditbasicparams.go
@@ -28,7 +28,6 @@ type AuditParamsInterface interface {
 	Args() []string
 	InstallCommandName() string
 	InstallCommandArgs() []string
-	SetInstallCommandArgs(installCommandArgs []string) *AuditBasicParams
 	SetNpmScope(depType string) *AuditBasicParams
 	SetMaxTreeDepth(maxTreeDepth string) *AuditBasicParams
 	MaxTreeDepth() string
@@ -222,6 +221,8 @@ func (abp *AuditBasicParams) SetNpmScope(depType string) *AuditBasicParams {
 		abp.args = []string{"--dev"}
 	case "prodOnly":
 		abp.args = []string{"--prod"}
+	case "legacyPeerDeps":
+		abp.installCommandArgs = append(abp.installCommandArgs, "--legacy-peer-deps")
 	}
 	return abp
 }

--- a/commands/curation/curationaudit.go
+++ b/commands/curation/curationaudit.go
@@ -12,6 +12,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 
 	"github.com/jfrog/gofrog/datastructures"
 	"github.com/jfrog/gofrog/parallel"
@@ -38,6 +39,7 @@ import (
 	"github.com/jfrog/jfrog-cli-security/sca/bom/buildinfo"
 	"github.com/jfrog/jfrog-cli-security/sca/bom/buildinfo/technologies"
 	"github.com/jfrog/jfrog-cli-security/sca/bom/buildinfo/technologies/docker"
+	npmtech "github.com/jfrog/jfrog-cli-security/sca/bom/buildinfo/technologies/npm"
 	"github.com/jfrog/jfrog-cli-security/sca/bom/buildinfo/technologies/python"
 	"github.com/jfrog/jfrog-cli-security/utils"
 	"github.com/jfrog/jfrog-cli-security/utils/formats"
@@ -214,6 +216,13 @@ type treeAnalyzer struct {
 	parallelRequests      int
 	downloadUrls          map[string]string
 	includeCachedPackages bool
+	// cancelled is set to true when an unrecoverable error (e.g. 401) occurs so that
+	// the producer goroutine stops queuing new tasks and in-flight tasks bail out early.
+	cancelled atomic.Bool
+	// authErr holds the first authentication error encountered during HEAD requests.
+	// Stored via atomic.Value so it can be retrieved after the parallel runner finishes
+	// and returned once — avoiding double-printing via errorsQueue.AddError.
+	authErr atomic.Value
 }
 
 type CurationAuditCommand struct {
@@ -449,6 +458,8 @@ func (ca *CurationAuditCommand) getBuildInfoParamsByTech() (technologies.BuildIn
 		// Npm params
 		NpmIgnoreNodeModules:    true,
 		NpmOverwritePackageLock: true,
+		NpmRunNative:            ca.RunNative(),
+		NpmLegacyPeerDeps:       ca.LegacyPeerDeps(),
 		// Python params
 		PipRequirementsFile: ca.PipRequirementsFile(),
 		// Docker params
@@ -462,6 +473,11 @@ func (ca *CurationAuditCommand) auditTree(tech techutils.Technology, results map
 	params, err := ca.getBuildInfoParamsByTech()
 	if err != nil {
 		return errorutils.CheckErrorf("failed to get build info params for %s: %v", tech.String(), err)
+	}
+	// When --run-native is set for npm, the Artifactory details are already populated from .npmrc.
+	// Skip the npm.yaml config file lookup to avoid requiring 'jf npm-config'.
+	if ca.RunNative() && tech == techutils.Npm {
+		params.IgnoreConfigFile = true
 	}
 	serverDetails, err := buildinfo.SetResolutionRepoInParamsIfExists(&params, tech)
 	if err != nil {
@@ -529,6 +545,10 @@ func (ca *CurationAuditCommand) auditTree(tech techutils.Technology, results map
 	packagesStatusMap := sync.Map{}
 	// if error returned we still want to produce a report, so we don't fail the next step
 	err = analyzer.fetchNodesStatus(depTreeResult.FlatTree, &packagesStatusMap, rootNodes)
+	// Auth errors are unrecoverable — skip building a misleading partial report.
+	if analyzer.cancelled.Load() {
+		return err
+	}
 	analyzer.GraphsRelations(depTreeResult.FullDepTrees, &packagesStatusMap,
 		&packagesStatus)
 	sort.Slice(packagesStatus, func(i, j int) bool {
@@ -756,11 +776,51 @@ func (ca *CurationAuditCommand) SetRepo(tech techutils.Technology) error {
 		return nil
 	}
 
+	// When --run-native is set for npm, read the Artifactory URL and repo name from the
+	// project's .npmrc via native npm config — no jf npm-config/npm.yaml required.
+	if ca.RunNative() && tech == techutils.Npm {
+		return ca.setRepoFromNpmrc()
+	}
+
 	resolverParams, err := ca.getRepoParams(tech.GetProjectType())
 	if err != nil {
 		return err
 	}
 	ca.setPackageManagerConfig(resolverParams)
+	return nil
+}
+
+// setRepoFromNpmrc builds PackageManagerConfig by reading the npm registry URL from the
+// native npm configuration (respecting .npmrc and Volta), then parsing the Artifactory
+// base URL and repository name from it.
+// Authentication is taken from the jfrog-cli.conf server entry (via ca.ServerDetails()) —
+// the same credentials the user configured with 'jf c'. Only the Artifactory URL and
+// repository name are sourced from .npmrc, so 'jf npm-config' is not required.
+func (ca *CurationAuditCommand) setRepoFromNpmrc() error {
+	registryConfig, err := npmtech.GetNativeNpmRegistryConfig()
+	if err != nil {
+		return fmt.Errorf("--run-native: failed to read Artifactory details from .npmrc: %w", err)
+	}
+
+	// Use auth from the jfrog server config (jfrog-cli.conf) — it holds properly stored
+	// credentials. Only override the ArtifactoryUrl with what .npmrc reports so the
+	// Curation HEAD requests go to the right repository.
+	serverDetails, err := ca.ServerDetails()
+	if err != nil || serverDetails == nil {
+		// No server configured — fall back to whatever auth .npmrc provides.
+		serverDetails = &config.ServerDetails{
+			ArtifactoryUrl: registryConfig.ArtifactoryUrl,
+			AccessToken:    registryConfig.AuthToken,
+		}
+	} else {
+		serverDetails.ArtifactoryUrl = registryConfig.ArtifactoryUrl
+	}
+
+	repoConfig := (&project.RepositoryConfig{}).
+		SetTargetRepo(registryConfig.RepoName).
+		SetServerDetails(serverDetails)
+	ca.setPackageManagerConfig(repoConfig)
+	log.Info(fmt.Sprintf("--run-native: using Artifactory URL %q and repository %q from .npmrc", registryConfig.ArtifactoryUrl, registryConfig.RepoName))
 	return nil
 }
 
@@ -831,6 +891,9 @@ func (nc *treeAnalyzer) fetchNodesStatus(graph *xrayUtils.GraphNode, p *sync.Map
 	go func() {
 		defer consumerProducer.Done()
 		for _, node := range graph.Nodes {
+			if nc.cancelled.Load() {
+				break
+			}
 			if _, ok := rootNodeIds[node.Id]; ok {
 				continue
 			}
@@ -848,6 +911,11 @@ func (nc *treeAnalyzer) fetchNodesStatus(graph *xrayUtils.GraphNode, p *sync.Map
 	if err := errorsQueue.GetError(); err != nil {
 		multiErrors = errors.Join(err, multiErrors)
 	}
+	// Auth errors are stored silently (not via errorsQueue) to avoid double-printing.
+	// Surface them here so they propagate as a single error to the caller.
+	if authErr, ok := nc.authErr.Load().(error); ok {
+		multiErrors = errors.Join(authErr, multiErrors)
+	}
 	return multiErrors
 }
 
@@ -860,8 +928,22 @@ func (nc *treeAnalyzer) fetchNodeStatus(node xrayUtils.GraphNode, p *sync.Map) e
 		name = scope + "/" + name
 	}
 	for _, packageUrl := range packageUrls {
+		if nc.cancelled.Load() {
+			return nil
+		}
 		requestDetails := nc.httpClientDetails.Clone()
 		resp, _, err := nc.rtManager.Client().SendHead(packageUrl, requestDetails)
+		if resp != nil && resp.StatusCode == http.StatusUnauthorized {
+			// Store the error silently (not returned) so errorsQueue.AddError is never
+			// called and the message is not logged here. fetchNodesStatus picks it up
+			// after the runner finishes and returns it once to the caller.
+			if nc.cancelled.CompareAndSwap(false, true) {
+				nc.authErr.Store(fmt.Errorf("authentication failed (401 Unauthorized) for Curation request to %s (package %s:%s).\n"+
+					"The credentials configured via 'jf c' are not valid for the Artifactory instance at that URL.\n"+
+					"Run 'jf c' to update your server configuration, or verify that the correct server-id is configured", packageUrl, name, version))
+			}
+			return nil
+		}
 		if err != nil {
 			if resp != nil && resp.StatusCode >= 400 {
 				return errorutils.CheckErrorf(errorTemplateHeadRequest, packageUrl, name, version, resp.StatusCode, err)

--- a/sca/bom/buildinfo/technologies/common.go
+++ b/sca/bom/buildinfo/technologies/common.go
@@ -58,6 +58,8 @@ type BuildInfoBomGeneratorParams struct {
 	// Npm params
 	NpmIgnoreNodeModules    bool
 	NpmOverwritePackageLock bool
+	NpmRunNative            bool
+	NpmLegacyPeerDeps       bool
 	// Pnpm params
 	MaxTreeDepth string
 	// Docker params

--- a/sca/bom/buildinfo/technologies/npm/npm.go
+++ b/sca/bom/buildinfo/technologies/npm/npm.go
@@ -3,6 +3,7 @@ package npm
 import (
 	"errors"
 	"fmt"
+	"strings"
 
 	biutils "github.com/jfrog/build-info-go/build/utils"
 	buildinfo "github.com/jfrog/build-info-go/entities"
@@ -18,8 +19,20 @@ import (
 )
 
 const (
-	IgnoreScriptsFlag = "--ignore-scripts"
+	IgnoreScriptsFlag     = "--ignore-scripts"
+	LegacyPeerDepsFlag    = "--legacy-peer-deps"
+	artifactoryApiNpmPath = "/api/npm/"
+	// npmAuthTokenSuffix is the npm config-key suffix used to look up a registry's auth token in .npmrc
+	// (e.g. //registry.example.com/:_authToken=...). It is a key name, not a credential value.
+	npmAuthTokenSuffix = ":_authToken" // #nosec G101 -- Not credentials, this is the npm config-key suffix.
 )
+
+// NpmrcRegistryConfig holds Artifactory connection details parsed from the native npm registry config.
+type NpmrcRegistryConfig struct {
+	ArtifactoryUrl string
+	RepoName       string
+	AuthToken      string
+}
 
 func BuildDependencyTree(params technologies.BuildInfoBomGeneratorParams) (dependencyTrees []*xrayUtils.GraphNode, uniqueDeps []string, err error) {
 	currentDir, err := coreutils.GetWorkingDirectory()
@@ -65,14 +78,91 @@ func BuildDependencyTree(params technologies.BuildInfoBomGeneratorParams) (depen
 }
 
 // Generates a .npmrc file to configure an Artifactory server as the resolver server.
+// Skipped when NpmRunNative is set — the project's existing .npmrc is used as-is for dependency resolution.
 func configNpmResolutionServerIfNeeded(params *technologies.BuildInfoBomGeneratorParams) (clearResolutionServerFunc func() error, err error) {
-	// If we don't have an artifactory repo's name we don't need to configure any Artifactory server as resolution server
-	if params.DependenciesRepository == "" {
+	if params.DependenciesRepository == "" || params.NpmRunNative {
 		return
 	}
-
 	clearResolutionServerFunc, err = npm.SetArtifactoryAsResolutionServer(params.ServerDetails, params.DependenciesRepository)
 	return
+}
+
+// GetNativeNpmRegistryConfig reads the npm registry URL from the native npm configuration
+// (respecting .npmrc, Volta, and other environment settings) and parses it as an
+// Artifactory npm repository URL to extract the RT base URL, repo name, and auth token.
+func GetNativeNpmRegistryConfig() (*NpmrcRegistryConfig, error) {
+	_, npmExecPath, err := biutils.GetNpmVersionAndExecPath(log.Logger)
+	if err != nil {
+		return nil, fmt.Errorf("failed to locate npm executable: %w", err)
+	}
+
+	registryData, _, err := biutils.RunNpmCmd(npmExecPath, "", []string{"config", "get", "registry"}, log.Logger)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read npm registry from native config: %w", err)
+	}
+	registryUrl := strings.TrimSpace(string(registryData))
+
+	rtBaseUrl, repoName, err := parseArtifactoryNpmRegistryUrl(registryUrl)
+	if err != nil {
+		return nil, err
+	}
+
+	authKey, err := buildNpmAuthTokenKey(registryUrl)
+	if err != nil {
+		return nil, err
+	}
+	tokenData, _, _ := biutils.RunNpmCmd(npmExecPath, "", []string{"config", "get", authKey}, log.Logger)
+	authToken := strings.TrimSpace(string(tokenData))
+	if authToken == "undefined" || authToken == "null" {
+		authToken = ""
+	}
+
+	return &NpmrcRegistryConfig{
+		ArtifactoryUrl: rtBaseUrl,
+		RepoName:       repoName,
+		AuthToken:      authToken,
+	}, nil
+}
+
+// buildNpmAuthTokenKey returns the npm config key used to look up the auth token for a
+// given registry URL — the registry URL with its scheme stripped and ":_authToken" appended,
+// e.g. https://myrt.jfrog.io/artifactory/api/npm/my-repo/ → //myrt.jfrog.io/artifactory/api/npm/my-repo/:_authToken
+//
+// Returns a typed error (without slicing) when the registry value is malformed and lacks
+// the "://" separator, so callers see an actionable message instead of a runtime panic.
+// The original URL is preserved verbatim (including any trailing slash) so the lookup
+// matches exactly what npm stored in .npmrc.
+func buildNpmAuthTokenKey(registryUrl string) (string, error) {
+	_, schemeRelative, ok := strings.Cut(registryUrl, "://")
+	if !ok {
+		return "", fmt.Errorf("npm registry %q is malformed: expected a scheme-prefixed URL (e.g. https://...)", registryUrl)
+	}
+	if schemeRelative == "" {
+		return "", fmt.Errorf("npm registry %q is malformed: missing host", registryUrl)
+	}
+	return "//" + schemeRelative + npmAuthTokenSuffix, nil
+}
+
+// parseArtifactoryNpmRegistryUrl extracts the Artifactory base URL and repository name from
+// a registry URL containing "/api/npm/<repo>/".
+// Supports both standard URLs (https://<host>/artifactory/api/npm/<repo>/) and
+// reverse-proxy URLs where the "/artifactory" context root is stripped
+// (e.g. https://npm.company.com/api/npm/<repo>/).
+func parseArtifactoryNpmRegistryUrl(registryUrl string) (rtBaseUrl, repoName string, err error) {
+	apiNpmIdx := strings.Index(registryUrl, artifactoryApiNpmPath)
+	if apiNpmIdx == -1 {
+		return "", "", fmt.Errorf("npm registry %q does not appear to be an Artifactory npm registry (expected %q in URL)", registryUrl, artifactoryApiNpmPath)
+	}
+	rtBaseUrl = registryUrl[:apiNpmIdx] + "/"
+	afterApiNpm := registryUrl[apiNpmIdx+len(artifactoryApiNpmPath):]
+	repoName = strings.TrimSuffix(afterApiNpm, "/")
+	if slashIdx := strings.Index(repoName, "/"); slashIdx != -1 {
+		repoName = repoName[:slashIdx]
+	}
+	if repoName == "" {
+		return "", "", fmt.Errorf("could not extract repository name from npm registry URL %q", registryUrl)
+	}
+	return rtBaseUrl, repoName, nil
 }
 
 func createTreeDepsParam(params *technologies.BuildInfoBomGeneratorParams) biutils.NpmTreeDepListParam {
@@ -81,9 +171,13 @@ func createTreeDepsParam(params *technologies.BuildInfoBomGeneratorParams) biuti
 			Args: addIgnoreScriptsFlag([]string{}),
 		}
 	}
+	installCommandArgs := params.InstallCommandArgs
+	if params.NpmLegacyPeerDeps {
+		installCommandArgs = appendUniqueFlag(installCommandArgs, LegacyPeerDepsFlag)
+	}
 	npmTreeDepParam := biutils.NpmTreeDepListParam{
 		Args:                 addIgnoreScriptsFlag(params.Args),
-		InstallCommandArgs:   params.InstallCommandArgs,
+		InstallCommandArgs:   installCommandArgs,
 		IgnoreNodeModules:    params.NpmIgnoreNodeModules,
 		OverwritePackageLock: params.NpmOverwritePackageLock,
 	}
@@ -92,10 +186,15 @@ func createTreeDepsParam(params *technologies.BuildInfoBomGeneratorParams) biuti
 
 // Add the --ignore-scripts to prevent execution of npm scripts during npm install.
 func addIgnoreScriptsFlag(npmArgs []string) []string {
-	if !slices.Contains(npmArgs, IgnoreScriptsFlag) {
-		return append(npmArgs, IgnoreScriptsFlag)
+	return appendUniqueFlag(npmArgs, IgnoreScriptsFlag)
+}
+
+// appendUniqueFlag appends flag to npmArgs unless it is already present.
+func appendUniqueFlag(npmArgs []string, flag string) []string {
+	if slices.Contains(npmArgs, flag) {
+		return npmArgs
 	}
-	return npmArgs
+	return append(npmArgs, flag)
 }
 
 // Parse the dependencies into an Xray dependency tree format

--- a/sca/bom/buildinfo/technologies/npm/npm_test.go
+++ b/sca/bom/buildinfo/technologies/npm/npm_test.go
@@ -187,3 +187,130 @@ func TestSkipBuildDepTreeWhenInstallForbidden(t *testing.T) {
 		})
 	}
 }
+
+func TestBuildNpmAuthTokenKey(t *testing.T) {
+	testCases := []struct {
+		name        string
+		registryUrl string
+		expectedKey string
+		expectErr   bool
+		errContains string
+	}{
+		{
+			name:        "https artifactory registry with trailing slash",
+			registryUrl: "https://myrt.jfrog.io/artifactory/api/npm/my-repo/",
+			expectedKey: "//myrt.jfrog.io/artifactory/api/npm/my-repo/:_authToken",
+		},
+		{
+			name:        "http artifactory registry without trailing slash",
+			registryUrl: "http://myrt.jfrog.io/artifactory/api/npm/my-repo",
+			expectedKey: "//myrt.jfrog.io/artifactory/api/npm/my-repo:_authToken",
+		},
+		{
+			name:        "reverse-proxy registry without /artifactory context root",
+			registryUrl: "https://npm.company.com/api/npm/my-repo/",
+			expectedKey: "//npm.company.com/api/npm/my-repo/:_authToken",
+		},
+		{
+			name:        "registry with port",
+			registryUrl: "https://myrt.jfrog.io:8443/artifactory/api/npm/my-repo/",
+			expectedKey: "//myrt.jfrog.io:8443/artifactory/api/npm/my-repo/:_authToken",
+		},
+		{
+			name:        "missing scheme separator",
+			registryUrl: "myrt.jfrog.io/artifactory/api/npm/my-repo/",
+			expectErr:   true,
+			errContains: "expected a scheme-prefixed URL",
+		},
+		{
+			name:        "scheme separator only — no host",
+			registryUrl: "https://",
+			expectErr:   true,
+			errContains: "missing host",
+		},
+		{
+			name:        "empty registry",
+			registryUrl: "",
+			expectErr:   true,
+			errContains: "expected a scheme-prefixed URL",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			authKey, err := buildNpmAuthTokenKey(tc.registryUrl)
+			if tc.expectErr {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), tc.errContains)
+				assert.Empty(t, authKey)
+				return
+			}
+			assert.NoError(t, err)
+			assert.Equal(t, tc.expectedKey, authKey)
+		})
+	}
+}
+
+func TestParseArtifactoryNpmRegistryUrl(t *testing.T) {
+	testCases := []struct {
+		name           string
+		registryUrl    string
+		expectedRtUrl  string
+		expectedRepo   string
+		expectErr      bool
+		errContains    string
+	}{
+		{
+			name:          "standard artifactory registry with trailing slash",
+			registryUrl:   "https://myrt.jfrog.io/artifactory/api/npm/my-repo/",
+			expectedRtUrl: "https://myrt.jfrog.io/artifactory/",
+			expectedRepo:  "my-repo",
+		},
+		{
+			name:          "standard artifactory registry without trailing slash",
+			registryUrl:   "https://myrt.jfrog.io/artifactory/api/npm/my-repo",
+			expectedRtUrl: "https://myrt.jfrog.io/artifactory/",
+			expectedRepo:  "my-repo",
+		},
+		{
+			name:          "reverse-proxy registry without /artifactory context root",
+			registryUrl:   "https://npm.company.com/api/npm/my-repo/",
+			expectedRtUrl: "https://npm.company.com/",
+			expectedRepo:  "my-repo",
+		},
+		{
+			name:          "registry with sub-path after repo (e.g. scoped lookup) ignores extra segments",
+			registryUrl:   "https://myrt.jfrog.io/artifactory/api/npm/my-repo/-/foo",
+			expectedRtUrl: "https://myrt.jfrog.io/artifactory/",
+			expectedRepo:  "my-repo",
+		},
+		{
+			name:        "non-artifactory npm registry",
+			registryUrl: "https://registry.npmjs.org/",
+			expectErr:   true,
+			errContains: "does not appear to be an Artifactory npm registry",
+		},
+		{
+			name:        "artifactory api/npm path with empty repository",
+			registryUrl: "https://myrt.jfrog.io/artifactory/api/npm/",
+			expectErr:   true,
+			errContains: "could not extract repository name",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			rtUrl, repo, err := parseArtifactoryNpmRegistryUrl(tc.registryUrl)
+			if tc.expectErr {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), tc.errContains)
+				assert.Empty(t, rtUrl)
+				assert.Empty(t, repo)
+				return
+			}
+			assert.NoError(t, err)
+			assert.Equal(t, tc.expectedRtUrl, rtUrl)
+			assert.Equal(t, tc.expectedRepo, repo)
+		})
+	}
+}


### PR DESCRIPTION
- [ ] The pull request is targeting the `dev` branch.
- [ ] The code has been validated to compile successfully by running `go vet ./...`.
- [ ] The code has been formatted properly using `go fmt ./...`.
- [ ] All [static analysis checks](https://github.com/jfrog/jfrog-cli-security/actions/workflows/analysis.yml) passed.
- [ ] All [tests](https://github.com/jfrog/jfrog-cli-security/actions/workflows/test.yml) have passed. If this feature is not already covered by the tests, new tests have been added.
- [ ] Updated the [Contributing page](https://github.com/jfrog/jfrog-cli-security/blob/main/CONTRIBUTING.md) / [ReadMe page](https://github.com/jfrog/jfrog-cli-security/blob/main/README.md) / [CI Workflow files](https://github.com/jfrog/jfrog-cli-security/tree/main/.github/workflows) if needed.
- [ ] All changes are detailed at the description. if not already covered at [JFrog Documentation](https://github.com/jfrog/documentation), new documentation have been added.

-----

Added support for --legacy-peer-deps Done 

Benefits :- It unblocks curation auditing for npm projects that can't install cleanly under npm 7+, which is a very common real-world situation — many projects maintain older dependencies or have transitive peer conflicts they haven't resolved. Without this flag, those projects would simply be unable to run jf ca at all.

<img width="1728" height="1083" alt="Screenshot 2026-04-13 at 3 15 48 PM" src="https://github.com/user-attachments/assets/2e7c5c97-56a9-4101-8ad8-bf3f6ca247b9" />
<img width="1711" height="1045" alt="Screenshot 2026-04-13 at 3 16 31 PM" src="https://github.com/user-attachments/assets/4f94663c-38be-46e9-81b3-2ea12fc2efca" />

------------------------------------------------------------------------------------------------
--run-native flag for jf ca (Curation Audit)
Problem it solves
jf ca normally injects Artifactory as the npm registry during dependency resolution (writes .npmrc, runs npm install). This breaks for users who:
1. Use Volta (a Node.js toolchain manager whose npm shim gets bypassed)
2. Have a custom .npmrc that conflicts with JFrog's injection
3. Don't want jf ca to modify their project's node_modules or package-lock.json

What --run-native does
When passed, jf ca hands off dependency resolution entirely to the user's native npm environment:

1. Skips injecting Artifactory as the npm registry — npm runs as-is, respecting the user's .npmrc and Volta configuration
2. Skips deleting node_modules/package-lock.json before running — no destructive side effects on the project
3. No jf npm-config required — reads the Artifactory URL and repository name for Curation HEAD requests directly from the project's .npmrc (via npm config get registry), parsing /api/npm/<repo> from it
4. Auth still comes from jf c — credentials are sourced from ~/.jfrog/jfrog-cli.conf, not from .npmrc

Constraints
npm registry in .npmrc must be an Artifactory npm registry (URL must contain /api/npm/)
Supports both standard (/artifactory/api/npm/) and reverse-proxy URLs (where /artifactory context root is stripped)
If the registry is not Artifactory, the command fails with a clear error

Error handling
If authentication fails (401), the audit stops immediately with a descriptive error pointing the user to run jf c to fix their server configuration — no misleading "0 blocked packages" result is shown
