### PR TITLE
Warn on missing components parsing issue

### DIFF
--- a/utils/results/common.go
+++ b/utils/results/common.go
@@ -243,6 +243,7 @@ func ForEachSbomComponent(bom *cyclonedx.BOM, handler ParseSbomComponentFunc) (e
 
 func SplitComponents(target string, impactedPackages map[string]services.Component) (impactedPackagesIds []string, fixedVersions [][]string, directComponents [][]formats.ComponentRow, impactPaths [][][]formats.ComponentRow, err error) {
 	if len(impactedPackages) == 0 {
+		log.Warn(fmt.Sprintf("Failed while parsing the response from Xray: components map is empty for target '%s'", target))
 		err = errorutils.CheckErrorf("failed while parsing the response from Xray: components map is empty")
 		return
 	}

--- a/utils/results/common.go
+++ b/utils/results/common.go
@@ -20,7 +20,6 @@ import (
 	"github.com/jfrog/jfrog-cli-security/utils/severityutils"
 	"github.com/jfrog/jfrog-cli-security/utils/techutils"
 	"github.com/jfrog/jfrog-cli-security/utils/xray"
-	"github.com/jfrog/jfrog-client-go/utils/errorutils"
 	"github.com/jfrog/jfrog-client-go/utils/log"
 	"github.com/jfrog/jfrog-client-go/xray/services"
 	xrayUtils "github.com/jfrog/jfrog-client-go/xray/services/utils"
@@ -244,8 +243,6 @@ func ForEachSbomComponent(bom *cyclonedx.BOM, handler ParseSbomComponentFunc) (e
 func SplitComponents(target string, impactedPackages map[string]services.Component) (impactedPackagesIds []string, fixedVersions [][]string, directComponents [][]formats.ComponentRow, impactPaths [][][]formats.ComponentRow, err error) {
 	if len(impactedPackages) == 0 {
 		log.Warn(fmt.Sprintf("Failed while parsing the response from Xray: components map is empty for target '%s'", target))
-		err = errorutils.CheckErrorf("failed while parsing the response from Xray: components map is empty")
-		return
 	}
 	for currCompId, currComp := range impactedPackages {
 		impactedPackagesIds = append(impactedPackagesIds, currCompId)

--- a/utils/results/common.go
+++ b/utils/results/common.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"path/filepath"
+	"sort"
 	"strconv"
 	"strings"
 
@@ -244,7 +245,10 @@ func SplitComponents(target string, impactedPackages map[string]services.Compone
 	if len(impactedPackages) == 0 {
 		log.Warn(fmt.Sprintf("Failed while parsing the response from Xray: components map is empty for target '%s'", target))
 	}
-	for currCompId, currComp := range impactedPackages {
+	impactedKeys := maps.Keys(impactedPackages)
+	slices.Sort(impactedKeys)
+	for _, currCompId := range impactedKeys {
+		currComp := impactedPackages[currCompId]
 		impactedPackagesIds = append(impactedPackagesIds, currCompId)
 		fixedVersions = append(fixedVersions, currComp.FixedVersions)
 		currDirectComponents, currImpactPaths := getDirectComponentsAndImpactPaths(target, currComp.ImpactPaths)
@@ -257,6 +261,11 @@ func SplitComponents(target string, impactedPackages map[string]services.Compone
 // Gets a slice of the direct dependencies or packages of the scanned component, that depends on the vulnerable package, and converts the impact paths.
 func getDirectComponentsAndImpactPaths(target string, impactPaths [][]services.ImpactPathNode) (components []formats.ComponentRow, impactPathsRows [][]formats.ComponentRow) {
 	componentsMap := make(map[string]formats.ComponentRow)
+	type directImpactPath struct {
+		directId string
+		rows     []formats.ComponentRow
+	}
+	var perPath []directImpactPath
 
 	// The first node in the impact path is the scanned component itself. The second one is the direct dependency.
 	impactPathLevel := 1
@@ -287,11 +296,17 @@ func getDirectComponentsAndImpactPaths(target string, impactPaths [][]services.I
 				PreferredLocation: getComponentLocation(pathNode.FullPath),
 			})
 		}
-		impactPathsRows = append(impactPathsRows, compImpactPathRows)
+		perPath = append(perPath, directImpactPath{directId: componentId, rows: compImpactPathRows})
 	}
 
-	for _, row := range componentsMap {
-		components = append(components, row)
+	keys := maps.Keys(componentsMap)
+	slices.Sort(keys)
+	for _, k := range keys {
+		components = append(components, componentsMap[k])
+	}
+	sort.SliceStable(perPath, func(i, j int) bool { return perPath[i].directId < perPath[j].directId })
+	for _, p := range perPath {
+		impactPathsRows = append(impactPathsRows, p.rows)
 	}
 	return
 }

--- a/utils/results/common_test.go
+++ b/utils/results/common_test.go
@@ -3076,3 +3076,149 @@ func TestCdxEvidencesToLocations(t *testing.T) {
 		})
 	}
 }
+
+func TestSplitComponents(t *testing.T) {
+	emptyMap := make(map[string]services.Component)
+	targetNpmApp := "npm://myapp:1.0.0"
+	loc := func(f string) *formats.Location { return &formats.Location{File: f} }
+	tests := []struct {
+		name            string
+		target          string
+		impacted        map[string]services.Component
+		wantPackageIds  []string
+		wantFixedV      [][]string
+		wantDirect      [][]formats.ComponentRow
+		wantImpactPaths [][][]formats.ComponentRow
+	}{
+		{
+			name:     "empty map returns no error and empty slices",
+			target:   "mvn://org.example:app:1.0.0",
+			impacted: nil,
+		},
+		{
+			name:     "empty non-nil map returns no error and empty slices",
+			target:   "npm://@scope/lib:1.0.0",
+			impacted: emptyMap,
+		},
+		{
+			name:   "single component without impact paths",
+			target: "mvn://com.example:lib:2.0.0",
+			impacted: map[string]services.Component{
+				"pkg:generic/foo@1": {
+					FixedVersions: []string{"1.0.1"},
+					ImpactPaths:   nil,
+				},
+			},
+			wantPackageIds:  []string{"pkg:generic/foo@1"},
+			wantFixedV:      [][]string{{"1.0.1"}},
+			wantDirect:      [][]formats.ComponentRow{nil},
+			wantImpactPaths: [][][]formats.ComponentRow{nil},
+		},
+		{
+			name:   "multiple components each with one 2-node impact path",
+			target: targetNpmApp,
+			impacted: map[string]services.Component{
+				"npm://a-vuln:1.0.0": {
+					FixedVersions: []string{"1.0.1"},
+					ImpactPaths: [][]services.ImpactPathNode{{
+						{ComponentId: "npm://myapp:1.0.0", FullPath: "package.json"},
+						{ComponentId: "npm://a-vuln:1.0.0", FullPath: "node_modules/a"},
+					}},
+				},
+				"npm://b-vuln:1.0.0": {
+					FixedVersions: []string{"1.0.0"},
+					ImpactPaths: [][]services.ImpactPathNode{{
+						{ComponentId: "npm://myapp:1.0.0", FullPath: "package.json"},
+						{ComponentId: "npm://b-vuln:1.0.0", FullPath: "node_modules/b"},
+					}},
+				},
+			},
+			wantPackageIds: []string{"npm://a-vuln:1.0.0", "npm://b-vuln:1.0.0"},
+			wantFixedV:     [][]string{{"1.0.1"}, {"1.0.0"}},
+			wantDirect: [][]formats.ComponentRow{
+				{{
+					Id:                "npm://a-vuln:1.0.0",
+					Name:              "a-vuln",
+					Version:           "1.0.0",
+					PreferredLocation: loc("node_modules/a"),
+				}},
+				{{
+					Id:                "npm://b-vuln:1.0.0",
+					Name:              "b-vuln",
+					Version:           "1.0.0",
+					PreferredLocation: loc("node_modules/b"),
+				}},
+			},
+			wantImpactPaths: [][][]formats.ComponentRow{
+				{{
+					{Id: "npm://myapp:1.0.0", Name: "myapp", Version: "1.0.0", PreferredLocation: loc("package.json")},
+					{Id: "npm://a-vuln:1.0.0", Name: "a-vuln", Version: "1.0.0", PreferredLocation: loc("node_modules/a")},
+				}},
+				{{
+					{Id: "npm://myapp:1.0.0", Name: "myapp", Version: "1.0.0", PreferredLocation: loc("package.json")},
+					{Id: "npm://b-vuln:1.0.0", Name: "b-vuln", Version: "1.0.0", PreferredLocation: loc("node_modules/b")},
+				}},
+			},
+		},
+		{
+			name:   "one vulnerable component with two impact paths, two different direct dependencies",
+			target: targetNpmApp,
+			impacted: map[string]services.Component{
+				"npm://a-vuln:1.0.0": {
+					FixedVersions: nil,
+					ImpactPaths: [][]services.ImpactPathNode{
+						{
+							{ComponentId: "npm://myapp:1.0.0", FullPath: "package.json"},
+							{ComponentId: "npm://dep-zzz:0.0.0", FullPath: "node_modules/zzz"},
+							{ComponentId: "npm://a-vuln:1.0.0", FullPath: "node_modules/a"},
+						},
+						{
+							{ComponentId: "npm://myapp:1.0.0", FullPath: "package.json"},
+							{ComponentId: "npm://dep-aaa:0.0.0", FullPath: "node_modules/aaa"},
+							{ComponentId: "npm://a-vuln:1.0.0", FullPath: "node_modules/a"},
+						},
+					},
+				},
+			},
+			wantPackageIds: []string{"npm://a-vuln:1.0.0"},
+			wantFixedV:     [][]string{nil},
+			wantDirect: [][]formats.ComponentRow{{
+				{
+					Id:                "npm://dep-aaa:0.0.0",
+					Name:              "dep-aaa",
+					Version:           "0.0.0",
+					PreferredLocation: loc("node_modules/aaa"),
+				},
+				{
+					Id:                "npm://dep-zzz:0.0.0",
+					Name:              "dep-zzz",
+					Version:           "0.0.0",
+					PreferredLocation: loc("node_modules/zzz"),
+				},
+			}},
+			// Direct deps and path rows are sorted by direct-dependency id (dep-aaa before dep-zzz).
+			wantImpactPaths: [][][]formats.ComponentRow{{
+				{
+					{Id: "npm://myapp:1.0.0", Name: "myapp", Version: "1.0.0", PreferredLocation: loc("package.json")},
+					{Id: "npm://dep-aaa:0.0.0", Name: "dep-aaa", Version: "0.0.0", PreferredLocation: loc("node_modules/aaa")},
+					{Id: "npm://a-vuln:1.0.0", Name: "a-vuln", Version: "1.0.0", PreferredLocation: loc("node_modules/a")},
+				},
+				{
+					{Id: "npm://myapp:1.0.0", Name: "myapp", Version: "1.0.0", PreferredLocation: loc("package.json")},
+					{Id: "npm://dep-zzz:0.0.0", Name: "dep-zzz", Version: "0.0.0", PreferredLocation: loc("node_modules/zzz")},
+					{Id: "npm://a-vuln:1.0.0", Name: "a-vuln", Version: "1.0.0", PreferredLocation: loc("node_modules/a")},
+				},
+			}},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ids, fixed, direct, impPaths, err := SplitComponents(tt.target, tt.impacted)
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantPackageIds, ids, "package ids")
+			assert.Equal(t, tt.wantFixedV, fixed, "fixed versions")
+			assert.ElementsMatch(t, tt.wantDirect, direct, "direct components")
+			assert.ElementsMatch(t, tt.wantImpactPaths, impPaths, "impact paths")
+		})
+	}
+}


### PR DESCRIPTION
## fix(results): warn on empty Xray components and stabilize `SplitComponents` ordering


**Summary**
When the Xray response has no impacted components, parsing no longer returns an error; it logs a warning and continues. Component iteration and direct-dependency / impact-path output are ordered deterministically (sorted keys and stable `directId` ordering) so results are consistent and testable.

**Changes**
- `SplitComponents`: on empty `impactedPackages`, log a warning with the target context instead of `errorutils.CheckErrorf`; iterate impacted packages by sorted map keys.
- `getDirectComponentsAndImpactPaths`: build direct component rows in sorted map key order; collect impact path rows per direct dependency, then sort by `directId` before appending to `impactPathsRows`.
- Add `TestSplitComponents` in `common_test.go` (empty map, single/multiple components, multiple impact paths, ordering assertions using `assert.ElementsMatch` where order is semantically set-level).
- Remove unused `errorutils` import; add `sort` for stable ordering.

**Notes**
- **User-visible behavior:** Scans with an empty component map are no longer treated as a hard parse failure; callers get empty slices and a log warning. If any workflow depended on the previous error, that contract changes.
