### PR TITLE
Fix nil dereference issue regarding Applicability Scan results

### DIFF
--- a/policy/enforcer/policyenforcer.go
+++ b/policy/enforcer/policyenforcer.go
@@ -264,7 +264,7 @@ func locateBomVulnerabilityInfo(cmdResults *results.SecurityCommandResults, issu
 				if affected.Ref == impactedComponent.BOMRef {
 					// Found the relevant component in a vulnerability
 					relevantVulnerability = &vulnerability
-					contextualAnalysis = results.GetCveApplicabilityField(vulnerability.BOMRef, target.JasResults.ApplicabilityScanResults)
+					contextualAnalysis = results.GetCveApplicabilityField(vulnerability.BOMRef, target.JasResults.GetApplicabilityScanResults())
 					break
 				}
 			}

--- a/utils/results/results.go
+++ b/utils/results/results.go
@@ -677,7 +677,10 @@ func (ssr *ScaScanResults) HasFindings() bool {
 	return ssr.Sbom != nil && ssr.Sbom.Vulnerabilities != nil && len(*ssr.Sbom.Vulnerabilities) > 0
 }
 
-func (jsr *JasScansResults) GetApplicabilityScanResults() (results []*sarif.Run) {
+func (jsr *JasScansResults) GetApplicabilityScanResults() []*sarif.Run {
+	if jsr == nil {
+		return nil
+	}
 	return jsr.ApplicabilityScanResults
 }
 


### PR DESCRIPTION
- [ ] The pull request is targeting the `dev` branch.
- [ ] The code has been validated to compile successfully by running `go vet ./...`.
- [ ] The code has been formatted properly using `go fmt ./...`.
- [ ] All [static analysis checks](https://github.com/jfrog/jfrog-cli-security/actions/workflows/analysis.yml) passed.
- [ ] All [tests](https://github.com/jfrog/jfrog-cli-security/actions/workflows/test.yml) have passed. If this feature is not already covered by the tests, new tests have been added.
- [ ] Updated the [Contributing page](https://github.com/jfrog/jfrog-cli-security/blob/main/CONTRIBUTING.md) / [ReadMe page](https://github.com/jfrog/jfrog-cli-security/blob/main/README.md) / [CI Workflow files](https://github.com/jfrog/jfrog-cli-security/tree/main/.github/workflows) if needed.
- [ ] All changes are detailed at the description. if not already covered at [JFrog Documentation](https://github.com/jfrog/documentation), new documentation have been added.

-----