### PR TITLE
Feature/xray 138688 add pnpm support for jf ca

### DIFF
--- a/.github/actions/install-and-setup/action.yml
+++ b/.github/actions/install-and-setup/action.yml
@@ -31,11 +31,11 @@ runs:
     - name: Install npm
       uses: actions/setup-node@v6
       with:
-        node-version: "16"
+        node-version: "18"
     - name: Setup Pnpm
       uses: pnpm/action-setup@v4
       with:
-        version: 8
+        version: 10.34.1
 
     - name: Install Java
       uses: actions/setup-java@v5

--- a/commands/curation/curationaudit.go
+++ b/commands/curation/curationaudit.go
@@ -394,13 +394,13 @@ func getPolicyAndConditionId(policy, condition string) string {
 	return fmt.Sprintf("%s:%s", policy, condition)
 }
 
-// promotePnpmWorkspaceMember replaces "npm" with "pnpm" in the detected
-// technologies list when the current directory is a pnpm workspace member
-// (i.e., it has no pnpm indicators itself but an ancestor directory contains
-// pnpm-workspace.yaml or pnpm-lock.yaml).
+// promotePnpmWorkspaceMember replaces "npm" with "pnpm" in the detected technologies
+// list when the current directory is a pnpm workspace member — it has no pnpm marker
+// itself, but an ancestor directory contains pnpm-workspace.yaml or pnpm-lock.yaml.
+// This lets `jf ca --working-dirs=<member>` audit the member as part of its pnpm
+// workspace, consistently with the lockfile resolution which also walks up to the root.
 func promotePnpmWorkspaceMember(techs []string) []string {
-	hasPnpm := false
-	hasNpm := false
+	hasPnpm, hasNpm := false, false
 	for _, t := range techs {
 		switch t {
 		case techutils.Pnpm.String():
@@ -412,7 +412,6 @@ func promotePnpmWorkspaceMember(techs []string) []string {
 	if hasPnpm || !hasNpm {
 		return techs
 	}
-	// Walk up to find a pnpm workspace root.
 	dir, err := os.Getwd()
 	if err != nil {
 		return techs
@@ -420,25 +419,23 @@ func promotePnpmWorkspaceMember(techs []string) []string {
 	for {
 		parent := filepath.Dir(dir)
 		if parent == dir {
-			break
+			return techs
 		}
 		dir = parent
 		for _, indicator := range []string{"pnpm-workspace.yaml", "pnpm-lock.yaml"} {
 			if _, statErr := os.Stat(filepath.Join(dir, indicator)); statErr == nil {
 				log.Debug(fmt.Sprintf("Detected pnpm workspace root at %s via %s; promoting current directory from npm to pnpm.", dir, indicator))
-				result := make([]string, 0, len(techs))
+				promoted := make([]string, 0, len(techs))
 				for _, t := range techs {
 					if t == techutils.Npm.String() {
-						result = append(result, techutils.Pnpm.String())
-					} else {
-						result = append(result, t)
+						t = techutils.Pnpm.String()
 					}
+					promoted = append(promoted, t)
 				}
-				return result
+				return promoted
 			}
 		}
 	}
-	return techs
 }
 
 func (ca *CurationAuditCommand) doCurateAudit(results map[string]*CurationReport) error {
@@ -1003,12 +1000,14 @@ func (ca *CurationAuditCommand) setRepoFromNpmrc() error {
 func (ca *CurationAuditCommand) setRepoFromNpmrcForPnpm() error {
 	registryConfig, err := pnpmtech.GetNativePnpmRegistryConfig()
 	if err != nil {
-		return fmt.Errorf("pnpm: failed to read Artifactory details from .npmrc: %w\nEnsure the registry is configured in .npmrc (e.g. registry=https://<host>/artifactory/api/npm/<repo>/)", err)
+		log.Warn("Ensure the pnpm registry is configured in .npmrc (e.g. registry=https://<host>/artifactory/api/npm/<repo>/)")
+		return fmt.Errorf("pnpm: failed to read Artifactory details from .npmrc: %w", err)
 	}
 
 	var serverDetails *config.ServerDetails
 	if registryConfig.AuthToken != "" {
 		// .npmrc has an auth token that matches the registry — use it directly.
+		log.Debug("pnpm: using auth token from .npmrc")
 		serverDetails = &config.ServerDetails{
 			ArtifactoryUrl: registryConfig.ArtifactoryUrl,
 			AccessToken:    registryConfig.AuthToken,
@@ -1016,6 +1015,7 @@ func (ca *CurationAuditCommand) setRepoFromNpmrcForPnpm() error {
 	} else {
 		// No token in .npmrc — fall back to whatever 'jf c' has stored, overriding
 		// only the Artifactory URL so requests go to the correct registry.
+		log.Debug("pnpm: no token in .npmrc — using 'jf c' server credentials")
 		serverDetails, err = ca.ServerDetails()
 		if err != nil || serverDetails == nil {
 			return fmt.Errorf("pnpm: no auth token found in .npmrc and no 'jf c' server configured: %w", err)

--- a/commands/curation/curationaudit.go
+++ b/commands/curation/curationaudit.go
@@ -39,7 +39,8 @@ import (
 	"github.com/jfrog/jfrog-cli-security/sca/bom/buildinfo"
 	"github.com/jfrog/jfrog-cli-security/sca/bom/buildinfo/technologies"
 	"github.com/jfrog/jfrog-cli-security/sca/bom/buildinfo/technologies/docker"
-	npmtech "github.com/jfrog/jfrog-cli-security/sca/bom/buildinfo/technologies/npm"
+	npmtech  "github.com/jfrog/jfrog-cli-security/sca/bom/buildinfo/technologies/npm"
+	pnpmtech "github.com/jfrog/jfrog-cli-security/sca/bom/buildinfo/technologies/pnpm"
 	"github.com/jfrog/jfrog-cli-security/sca/bom/buildinfo/technologies/python"
 	"github.com/jfrog/jfrog-cli-security/utils"
 	"github.com/jfrog/jfrog-cli-security/utils/formats"
@@ -91,6 +92,7 @@ var CurationOutputFormats = []string{string(outFormat.Table), string(outFormat.J
 var supportedTech = map[techutils.Technology]func(ca *CurationAuditCommand) (bool, error){
 	techutils.Npm:  func(ca *CurationAuditCommand) (bool, error) { return true, nil },
 	techutils.Yarn: func(ca *CurationAuditCommand) (bool, error) { return true, nil },
+	techutils.Pnpm: func(ca *CurationAuditCommand) (bool, error) { return true, nil },
 	techutils.Pip: func(ca *CurationAuditCommand) (bool, error) {
 		return ca.checkSupportByVersionOrEnv(techutils.Pip, MinArtiPassThroughSupport)
 	},
@@ -392,8 +394,55 @@ func getPolicyAndConditionId(policy, condition string) string {
 	return fmt.Sprintf("%s:%s", policy, condition)
 }
 
+// promotePnpmWorkspaceMember replaces "npm" with "pnpm" in the detected
+// technologies list when the current directory is a pnpm workspace member
+// (i.e., it has no pnpm indicators itself but an ancestor directory contains
+// pnpm-workspace.yaml or pnpm-lock.yaml).
+func promotePnpmWorkspaceMember(techs []string) []string {
+	hasPnpm := false
+	hasNpm := false
+	for _, t := range techs {
+		switch t {
+		case techutils.Pnpm.String():
+			hasPnpm = true
+		case techutils.Npm.String():
+			hasNpm = true
+		}
+	}
+	if hasPnpm || !hasNpm {
+		return techs
+	}
+	// Walk up to find a pnpm workspace root.
+	dir, err := os.Getwd()
+	if err != nil {
+		return techs
+	}
+	for {
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			break
+		}
+		dir = parent
+		for _, indicator := range []string{"pnpm-workspace.yaml", "pnpm-lock.yaml"} {
+			if _, statErr := os.Stat(filepath.Join(dir, indicator)); statErr == nil {
+				log.Debug(fmt.Sprintf("Detected pnpm workspace root at %s via %s; promoting current directory from npm to pnpm.", dir, indicator))
+				result := make([]string, 0, len(techs))
+				for _, t := range techs {
+					if t == techutils.Npm.String() {
+						result = append(result, techutils.Pnpm.String())
+					} else {
+						result = append(result, t)
+					}
+				}
+				return result
+			}
+		}
+	}
+	return techs
+}
+
 func (ca *CurationAuditCommand) doCurateAudit(results map[string]*CurationReport) error {
-	techs := techutils.DetectedTechnologiesListForCurationAudit()
+	techs := promotePnpmWorkspaceMember(techutils.DetectedTechnologiesListForCurationAudit())
 	if ca.DockerImageName() != "" {
 		log.Debug(fmt.Sprintf("Docker image name '%s' was provided, running Docker curation audit.", ca.DockerImageName()))
 		techs = []string{techutils.Docker.String()}
@@ -519,6 +568,8 @@ func (ca *CurationAuditCommand) getBuildInfoParamsByTech() (technologies.BuildIn
 		NpmLegacyPeerDeps:       ca.LegacyPeerDeps(),
 		// Yarn: always refresh yarn.lock when older than package.json (mirrors NpmOverwritePackageLock).
 		YarnOverwriteYarnLock: true,
+		// Pnpm params
+		MaxTreeDepth: ca.MaxTreeDepth(),
 		// Python params
 		PipRequirementsFile: ca.PipRequirementsFile(),
 		// Docker params
@@ -529,7 +580,7 @@ func (ca *CurationAuditCommand) getBuildInfoParamsByTech() (technologies.BuildIn
 }
 
 func (ca *CurationAuditCommand) auditTree(tech techutils.Technology, results map[string]*CurationReport) error {
-	// --run-native is only supported for npm today; reject it early for all other techs.
+	// --run-native is only meaningful for npm/pnpm (.npmrc-based); reject it early for other techs.
 	if err := validateRunNativeForTech(tech, ca.RunNative()); err != nil {
 		return err
 	}
@@ -537,10 +588,14 @@ func (ca *CurationAuditCommand) auditTree(tech techutils.Technology, results map
 	if err != nil {
 		return errorutils.CheckErrorf("failed to get build info params for %s: %v", tech.String(), err)
 	}
-	// When --run-native is set for npm, the Artifactory details are already populated from .npmrc.
-	// Skip the npm.yaml config file lookup to avoid requiring 'jf npm-config'.
-	if ca.RunNative() && tech == techutils.Npm {
+	// When --run-native is set for npm, or for pnpm (always .npmrc-based), the Artifactory
+	// details are already populated from .npmrc. Skip the yaml config file lookup.
+	if (ca.RunNative() && tech == techutils.Npm) || tech == techutils.Pnpm {
 		params.IgnoreConfigFile = true
+	}
+	// Pnpm always resolves natively from .npmrc — --run-native is redundant and has no effect.
+	if ca.RunNative() && tech == techutils.Pnpm {
+		log.Warn("--run-native has no effect for pnpm; pnpm always resolves natively from .npmrc")
 	}
 	// For yarn with no yarn.yaml, fall back to npm.yaml — npm and yarn share the same Artifactory npm API.
 	resolverTech := resolveResolverTechForCuration(tech)
@@ -846,6 +901,12 @@ func (ca *CurationAuditCommand) SetRepo(tech techutils.Technology) error {
 		return ca.setRepoFromNpmrc()
 	}
 
+	// Pnpm always reads from .npmrc — there is no 'jf pnpm-config' command.
+	// pnpm shares the npm registry protocol, so the same .npmrc key/URL format applies.
+	if tech == techutils.Pnpm {
+		return ca.setRepoFromNpmrcForPnpm()
+	}
+
 	resolverParams, err := ca.getRepoParams(tech.GetProjectType())
 	if err != nil {
 		// npm and yarn share the same Artifactory npm API for curation, so their
@@ -873,8 +934,9 @@ func (ca *CurationAuditCommand) SetRepo(tech techutils.Technology) error {
 }
 
 // validateRunNativeForTech rejects --run-native for techs that don't implement
-// native-config semantics. Only npm is supported today; extend the allow-list
-// below when a new tech adds the matching native-config flow.
+// native-config semantics. npm uses it to read Artifactory details from .npmrc;
+// pnpm accepts it as a no-op (it always resolves from .npmrc). Extend the
+// allow-list below when a new tech adds the matching native-config flow.
 func validateRunNativeForTech(tech techutils.Technology, runNative bool) error {
 	if !runNative {
 		return nil
@@ -883,6 +945,9 @@ func validateRunNativeForTech(tech techutils.Technology, runNative bool) error {
 	// both 'jf <tech>' and 'jf ca'.
 	supported := map[techutils.Technology]struct{}{
 		techutils.Npm: {},
+		// pnpm always resolves from .npmrc, so --run-native is a redundant no-op
+		// rather than an error (a warning is emitted in auditTree).
+		techutils.Pnpm: {},
 	}
 	if _, ok := supported[tech]; ok {
 		return nil
@@ -924,6 +989,45 @@ func (ca *CurationAuditCommand) setRepoFromNpmrc() error {
 		SetServerDetails(serverDetails)
 	ca.setPackageManagerConfig(repoConfig)
 	log.Info(fmt.Sprintf("--run-native: using Artifactory URL %q and repository %q from .npmrc", registryConfig.ArtifactoryUrl, registryConfig.RepoName))
+	return nil
+}
+
+// setRepoFromNpmrcForPnpm reads Artifactory connection details from the project's .npmrc
+// via the pnpm CLI. pnpm uses the same .npmrc format and registry protocol as npm, so the
+// URL parsing logic is identical. This is always called for pnpm — there is no 'jf pnpm-config'.
+//
+// Auth priority:
+//  1. Token from .npmrc — preferred, because it is scoped to the exact registry URL.
+//  2. Token from 'jf c' server config — used as fallback when .npmrc carries no token
+//     (e.g. user relies on a jf-managed credential store).
+func (ca *CurationAuditCommand) setRepoFromNpmrcForPnpm() error {
+	registryConfig, err := pnpmtech.GetNativePnpmRegistryConfig()
+	if err != nil {
+		return fmt.Errorf("pnpm: failed to read Artifactory details from .npmrc: %w\nEnsure the registry is configured in .npmrc (e.g. registry=https://<host>/artifactory/api/npm/<repo>/)", err)
+	}
+
+	var serverDetails *config.ServerDetails
+	if registryConfig.AuthToken != "" {
+		// .npmrc has an auth token that matches the registry — use it directly.
+		serverDetails = &config.ServerDetails{
+			ArtifactoryUrl: registryConfig.ArtifactoryUrl,
+			AccessToken:    registryConfig.AuthToken,
+		}
+	} else {
+		// No token in .npmrc — fall back to whatever 'jf c' has stored, overriding
+		// only the Artifactory URL so requests go to the correct registry.
+		serverDetails, err = ca.ServerDetails()
+		if err != nil || serverDetails == nil {
+			return fmt.Errorf("pnpm: no auth token found in .npmrc and no 'jf c' server configured: %w", err)
+		}
+		serverDetails.ArtifactoryUrl = registryConfig.ArtifactoryUrl
+	}
+
+	repoConfig := (&project.RepositoryConfig{}).
+		SetTargetRepo(registryConfig.RepoName).
+		SetServerDetails(serverDetails)
+	ca.setPackageManagerConfig(repoConfig)
+	log.Info(fmt.Sprintf("pnpm: using Artifactory URL %q and repository %q from .npmrc", registryConfig.ArtifactoryUrl, registryConfig.RepoName))
 	return nil
 }
 
@@ -1194,8 +1298,8 @@ func makeLegiblePolicyDetails(explanation, recommendation string) (string, strin
 
 func getUrlNameAndVersionByTech(tech techutils.Technology, node *xrayUtils.GraphNode, downloadUrlsMap map[string]string, artiUrl, repo string) (downloadUrls []string, name string, scope string, version string) {
 	switch tech {
-	case techutils.Npm, techutils.Yarn:
-		// Yarn packages use npm:// node IDs and the same Artifactory npm API endpoint.
+	case techutils.Npm, techutils.Yarn, techutils.Pnpm:
+		// Yarn and pnpm both use npm:// node IDs and the same Artifactory /api/npm/ endpoint as npm.
 		return getNpmNameScopeAndVersion(node.Id, artiUrl, repo, techutils.Npm.String())
 	case techutils.Maven:
 		return getMavenNameScopeAndVersion(node.Id, artiUrl, repo, node)

--- a/commands/curation/curationaudit_test.go
+++ b/commands/curation/curationaudit_test.go
@@ -1802,11 +1802,14 @@ func TestFetchNodesStatusConcurrentMapWrite(t *testing.T) {
 }
 
 // TestValidateRunNativeForTech checks that --run-native is accepted for npm and
-// rejected for all other techs with an error that names the offending tech.
+// pnpm (both .npmrc-based) and rejected for all other techs with an error that
+// names the offending tech.
 func TestValidateRunNativeForTech(t *testing.T) {
-	// Sanity: npm is the currently allow-listed tech. Both flag states pass.
+	// Sanity: npm and pnpm are the allow-listed techs. Both flag states pass.
 	assert.NoError(t, validateRunNativeForTech(techutils.Npm, true))
 	assert.NoError(t, validateRunNativeForTech(techutils.Npm, false))
+	assert.NoError(t, validateRunNativeForTech(techutils.Pnpm, true))
+	assert.NoError(t, validateRunNativeForTech(techutils.Pnpm, false))
 
 	// The failing-test scenario from the bug report: yarn + --run-native
 	// must exit non-zero with a yarn-named error that points the user at
@@ -1838,7 +1841,6 @@ func TestValidateRunNativeForTech(t *testing.T) {
 		techutils.Nuget,
 		techutils.Dotnet,
 		techutils.Conan,
-		techutils.Pnpm,
 		techutils.Cocoapods,
 		techutils.Swift,
 		techutils.Docker,
@@ -2035,5 +2037,98 @@ func changeDirForTest(t *testing.T, dir string) func() {
 		// Restore CWD even if the test fails partway, so the next
 		// subtest's GetProjectConfFilePath walk starts from a known dir.
 		require.NoError(t, os.Chdir(origCwd))
+	}
+}
+
+func TestPromotePnpmWorkspaceMember(t *testing.T) {
+	npm := "npm"
+	pnpm := "pnpm"
+	other := "maven"
+
+	tests := []struct {
+		name             string
+		techs            []string
+		ancestorFile     string // file to create in the ancestor dir ("" = none)
+		expectedHasPnpm  bool
+		expectedHasNpm   bool
+		expectNpmRemoved bool // npm was present in input and should be replaced by pnpm
+	}{
+		{
+			// pnpm already present: function returns early, npm is NOT replaced.
+			name:            "already has pnpm — no change",
+			techs:           []string{pnpm, npm},
+			expectedHasPnpm: true,
+			expectedHasNpm:  true,
+		},
+		{
+			name:            "no npm — no change",
+			techs:           []string{other},
+			expectedHasPnpm: false,
+			expectedHasNpm:  false,
+		},
+		{
+			name:            "npm only, no ancestor indicator — no promotion",
+			techs:           []string{npm},
+			ancestorFile:    "",
+			expectedHasPnpm: false,
+			expectedHasNpm:  true,
+		},
+		{
+			name:             "npm only, ancestor has pnpm-workspace.yaml — promote",
+			techs:            []string{npm},
+			ancestorFile:     "pnpm-workspace.yaml",
+			expectedHasPnpm:  true,
+			expectedHasNpm:   false,
+			expectNpmRemoved: true,
+		},
+		{
+			name:             "npm only, ancestor has pnpm-lock.yaml — promote",
+			techs:            []string{npm},
+			ancestorFile:     "pnpm-lock.yaml",
+			expectedHasPnpm:  true,
+			expectedHasNpm:   false,
+			expectNpmRemoved: true,
+		},
+		{
+			name:             "npm + other, ancestor has pnpm-workspace.yaml — npm promoted, other kept",
+			techs:            []string{npm, other},
+			ancestorFile:     "pnpm-workspace.yaml",
+			expectedHasPnpm:  true,
+			expectedHasNpm:   false,
+			expectNpmRemoved: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			// Build a two-level temp dir: root/sub — we run from sub so the walk finds root.
+			root := t.TempDir()
+			sub := filepath.Join(root, "sub")
+			require.NoError(t, os.MkdirAll(sub, 0o755))
+
+			if tc.ancestorFile != "" {
+				require.NoError(t, os.WriteFile(filepath.Join(root, tc.ancestorFile), []byte{}, 0o644))
+			}
+
+			t.Chdir(sub)
+
+			result := promotePnpmWorkspaceMember(tc.techs)
+
+			hasPnpm, hasNpm := false, false
+			for _, tech := range result {
+				switch tech {
+				case pnpm:
+					hasPnpm = true
+				case npm:
+					hasNpm = true
+				}
+			}
+			assert.Equal(t, tc.expectedHasPnpm, hasPnpm, "pnpm presence mismatch")
+			assert.Equal(t, tc.expectedHasNpm, hasNpm, "npm presence mismatch")
+			if tc.expectNpmRemoved {
+				assert.False(t, hasNpm, "npm should have been replaced by pnpm")
+				assert.True(t, hasPnpm, "pnpm should be present after promotion")
+			}
+		})
 	}
 }

--- a/sca/bom/buildinfo/technologies/java/mvn.go
+++ b/sca/bom/buildinfo/technologies/java/mvn.go
@@ -97,6 +97,7 @@ func buildMavenDependencyTree(params *DepTreeParams) (dependencyTree []*xrayUtil
 	// They are downloaded during mvn install but never appear in mvn dependency:tree,
 	// so without this step jf ca would miss curation violations that block the build.
 	// Skip if the tree is empty — no roots to attach to and no point running extra subprocesses.
+	// To move this logic to maven-dep-tree - XRAY-145307
 	if manager.mvnIncludePluginDeps && len(dependencyTree) > 0 {
 		injectPluginDeps(uniqueDeps, dependencyTree, manager.resolvePluginDeps())
 	}

--- a/sca/bom/buildinfo/technologies/npm/npm.go
+++ b/sca/bom/buildinfo/technologies/npm/npm.go
@@ -104,12 +104,12 @@ func GetNativeNpmRegistryConfig() (*NpmrcRegistryConfig, error) {
 	}
 	registryUrl := strings.TrimSpace(string(registryData))
 
-	rtBaseUrl, repoName, err := parseArtifactoryNpmRegistryUrl(registryUrl)
+	rtBaseUrl, repoName, err := ParseArtifactoryNpmRegistryUrl(registryUrl)
 	if err != nil {
 		return nil, err
 	}
 
-	authKey, err := buildNpmAuthTokenKey(registryUrl)
+	authKey, err := BuildNpmAuthTokenKey(registryUrl)
 	if err != nil {
 		return nil, err
 	}
@@ -135,7 +135,7 @@ func npmConfigGetArgs(key string, disableWorkspaces bool) []string {
 	return args
 }
 
-// buildNpmAuthTokenKey returns the npm config key used to look up the auth token for a
+// BuildNpmAuthTokenKey returns the npm config key used to look up the auth token for a
 // given registry URL — the registry URL with its scheme stripped and ":_authToken" appended,
 // e.g. https://myrt.jfrog.io/artifactory/api/npm/my-repo/ → //myrt.jfrog.io/artifactory/api/npm/my-repo/:_authToken
 //
@@ -143,7 +143,8 @@ func npmConfigGetArgs(key string, disableWorkspaces bool) []string {
 // the "://" separator, so callers see an actionable message instead of a runtime panic.
 // The original URL is preserved verbatim (including any trailing slash) so the lookup
 // matches exactly what npm stored in .npmrc.
-func buildNpmAuthTokenKey(registryUrl string) (string, error) {
+// Exported so that other package-manager clients (e.g. pnpm) can reuse the same logic.
+func BuildNpmAuthTokenKey(registryUrl string) (string, error) {
 	_, schemeRelative, ok := strings.Cut(registryUrl, "://")
 	if !ok {
 		return "", fmt.Errorf("npm registry %q is malformed: expected a scheme-prefixed URL (e.g. https://...)", registryUrl)
@@ -154,12 +155,14 @@ func buildNpmAuthTokenKey(registryUrl string) (string, error) {
 	return "//" + schemeRelative + npmAuthTokenSuffix, nil
 }
 
-// parseArtifactoryNpmRegistryUrl extracts the Artifactory base URL and repository name from
+// ParseArtifactoryNpmRegistryUrl extracts the Artifactory base URL and repository name from
 // a registry URL containing "/api/npm/<repo>/".
 // Supports both standard URLs (https://<host>/artifactory/api/npm/<repo>/) and
 // reverse-proxy URLs where the "/artifactory" context root is stripped
 // (e.g. https://npm.company.com/api/npm/<repo>/).
-func parseArtifactoryNpmRegistryUrl(registryUrl string) (rtBaseUrl, repoName string, err error) {
+// Exported so that other package-manager clients (e.g. pnpm) can reuse the same
+// Artifactory URL parsing without duplicating logic.
+func ParseArtifactoryNpmRegistryUrl(registryUrl string) (rtBaseUrl, repoName string, err error) {
 	apiNpmIdx := strings.Index(registryUrl, artifactoryApiNpmPath)
 	if apiNpmIdx == -1 {
 		return "", "", fmt.Errorf("npm registry %q does not appear to be an Artifactory npm registry (expected %q in URL)", registryUrl, artifactoryApiNpmPath)

--- a/sca/bom/buildinfo/technologies/npm/npm_test.go
+++ b/sca/bom/buildinfo/technologies/npm/npm_test.go
@@ -238,7 +238,7 @@ func TestBuildNpmAuthTokenKey(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			authKey, err := buildNpmAuthTokenKey(tc.registryUrl)
+			authKey, err := BuildNpmAuthTokenKey(tc.registryUrl)
 			if tc.expectErr {
 				assert.Error(t, err)
 				assert.Contains(t, err.Error(), tc.errContains)
@@ -332,7 +332,7 @@ func TestParseArtifactoryNpmRegistryUrl(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			rtUrl, repo, err := parseArtifactoryNpmRegistryUrl(tc.registryUrl)
+			rtUrl, repo, err := ParseArtifactoryNpmRegistryUrl(tc.registryUrl)
 			if tc.expectErr {
 				assert.Error(t, err)
 				assert.Contains(t, err.Error(), tc.errContains)

--- a/sca/bom/buildinfo/technologies/pnpm/pnpm.go
+++ b/sca/bom/buildinfo/technologies/pnpm/pnpm.go
@@ -133,7 +133,10 @@ func GetNativePnpmRegistryConfig() (*npm.NpmrcRegistryConfig, error) {
 	}, nil
 }
 
-const minPnpmMajorVersion = 10
+const (
+	minPnpmMajorVersion = 10
+	maxPnpmMajorVersion = 10
+)
 
 func getPnpmExecPath() (pnpmExecPath string, err error) {
 	if pnpmExecPath, err = exec.LookPath("pnpm"); errorutils.CheckError(err) != nil {
@@ -157,7 +160,7 @@ func getPnpmExecPath() (pnpmExecPath string, err error) {
 	return
 }
 
-// validatePnpmMinVersion returns an error if the installed pnpm major version is below minPnpmMajorVersion.
+// validatePnpmMinVersion returns an error if the installed pnpm major version is outside the supported range [minPnpmMajorVersion, maxPnpmMajorVersion].
 func validatePnpmMinVersion(versionStr string) error {
 	// Version string may include extra lines (warnings on incompatible Node); take first token.
 	firstLine := strings.SplitN(versionStr, "\n", 2)[0]
@@ -166,8 +169,8 @@ func validatePnpmMinVersion(versionStr string) error {
 	if _, scanErr := fmt.Sscanf(parts[0], "%d", &major); scanErr != nil {
 		return fmt.Errorf("could not parse pnpm version %q: %w", versionStr, scanErr)
 	}
-	if major < minPnpmMajorVersion {
-		return fmt.Errorf("pnpm version %s is not supported. Minimum required version is %d.x", versionStr, minPnpmMajorVersion)
+	if major < minPnpmMajorVersion || major > maxPnpmMajorVersion {
+		return fmt.Errorf("Resolving Pnpm dependencies from Artifactory is currently not supported for Pnpm versions outside the %d.x range. The current Pnpm version is: %s", minPnpmMajorVersion, versionStr)
 	}
 	return nil
 }

--- a/sca/bom/buildinfo/technologies/pnpm/pnpm.go
+++ b/sca/bom/buildinfo/technologies/pnpm/pnpm.go
@@ -1,11 +1,13 @@
 package pnpm
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strconv"
 	"strings"
 
 	biutils "github.com/jfrog/build-info-go/utils"
@@ -24,12 +26,20 @@ import (
 	xrayUtils "github.com/jfrog/jfrog-client-go/xray/services/utils"
 )
 
-const lockfileOnlyFlag = "--lockfile-only"
+const (
+	lockfileOnlyFlag = "--lockfile-only"
+	// Suppresses .pnpmfile.cjs hooks during lockfile generation — hooks run arbitrary JS.
+	ignorePnpmfileFlag = "--ignore-pnpmfile"
+)
 
 type pnpmLsDependency struct {
 	From         string                      `json:"from"`
 	Version      string                      `json:"version"`
 	Dependencies map[string]pnpmLsDependency `json:"dependencies,omitempty"`
+	// Local marks a node that is a local workspace member (not a published package).
+	// Such nodes stay in the tree for attribution but are excluded from the curation
+	// HEAD-check, mirroring how the root project node is skipped.
+	Local bool `json:"-"`
 }
 
 type pnpmLsProject struct {
@@ -44,20 +54,40 @@ func BuildDependencyTree(params technologies.BuildInfoBomGeneratorParams) (depen
 	if err != nil {
 		return
 	}
-	pnpmExecPath, err := getPnpmExecPath()
+	pnpmExecPath, pnpmVersion, err := getPnpmExecPath()
 	if err != nil {
 		return
 	}
+	if params.IsCurationCmd {
+		return buildDependencyTreeFromLockfile(pnpmExecPath, pnpmVersion, currentDir, params)
+	}
+	return buildDependencyTreeFromPnpmLs(pnpmExecPath, currentDir, params)
+}
 
-	if err = ensureLockfile(pnpmExecPath, currentDir); err != nil {
+// buildDependencyTreeFromLockfile is the curation-audit path: parses pnpm-lock.yaml
+// directly without running pnpm ls or downloading tarballs.
+func buildDependencyTreeFromLockfile(pnpmExecPath, pnpmVersion, currentDir string, params technologies.BuildInfoBomGeneratorParams) (dependencyTrees []*xrayUtils.GraphNode, uniqueDeps []string, err error) {
+	if err = validateSupportedPnpmVersion(pnpmVersion); err != nil {
 		return
 	}
-
-	projects, err := parsePnpmLockFile(currentDir)
+	if params.MaxTreeDepth != "" && params.MaxTreeDepth != "Infinity" {
+		log.Warn("The --max-tree-depth flag is not supported for pnpm curation audit (lockfile-based resolution always produces the full tree). The flag will be ignored.")
+	}
+	// In a workspace, the lockfile lives at the root and records every member under its
+	// own importer. Resolve from the root, then scope to the importer matching currentDir:
+	// "." (the root) audits the whole workspace; a member audits only that member.
+	workspaceRoot, importer := resolveWorkspaceRoot(currentDir)
+	lockfileDir, cleanup, err := resolveLockfileDir(pnpmExecPath, workspaceRoot)
 	if err != nil {
 		return
 	}
-	// Apply scope filter (dev-only / prod-only) to the raw project list if requested.
+	defer func() {
+		err = errors.Join(err, cleanup())
+	}()
+	projects, err := parsePnpmLockFile(lockfileDir, importer)
+	if err != nil {
+		return
+	}
 	if len(params.Args) > 0 {
 		projects = filterProjectsByScope(projects, params.Args)
 	}
@@ -65,8 +95,82 @@ func BuildDependencyTree(params technologies.BuildInfoBomGeneratorParams) (depen
 	return
 }
 
-// filterProjectsByScope removes dev or prod dependencies from each project
-// based on the --dev or --prod flags passed via params.Args (set by SetNpmScope).
+// buildDependencyTreeFromPnpmLs is the audit/scan path: installs into a temp dir
+// if needed, then calls `pnpm ls --json` to obtain the full dependency tree.
+func buildDependencyTreeFromPnpmLs(pnpmExecPath, currentDir string, params technologies.BuildInfoBomGeneratorParams) (dependencyTrees []*xrayUtils.GraphNode, uniqueDeps []string, err error) {
+	var dirForDependenciesCalculation string
+	if dirForDependenciesCalculation, err = installProjectIfNeeded(pnpmExecPath, currentDir); errorutils.CheckError(err) != nil {
+		return
+	}
+	if dirForDependenciesCalculation == "" {
+		// Lockfile and node_modules already present — run ls in the original dir.
+		dirForDependenciesCalculation = currentDir
+	} else {
+		defer func() {
+			err = errors.Join(err, biutils.RemoveTempDir(dirForDependenciesCalculation))
+		}()
+	}
+	return calculateDependencies(pnpmExecPath, dirForDependenciesCalculation, params)
+}
+
+// installProjectIfNeeded runs `pnpm install --ignore-scripts` in a temp copy of the
+// project when pnpm-lock.yaml or node_modules/.pnpm is missing.
+// Returns the temp dir path, or "" if no install was needed.
+func installProjectIfNeeded(pnpmExecPath, workingDir string) (dirForDependenciesCalculation string, err error) {
+	lockFileExists, err := fileutils.IsFileExists(filepath.Join(workingDir, "pnpm-lock.yaml"), false)
+	if err != nil {
+		return
+	}
+	pnpmDirExists, err := fileutils.IsDirExists(filepath.Join(workingDir, "node_modules", ".pnpm"), false)
+	if err != nil || (lockFileExists && pnpmDirExists) {
+		return
+	}
+	log.Debug("Installing Pnpm project:", workingDir)
+	dirForDependenciesCalculation, err = fileutils.CreateTempDir()
+	if err != nil {
+		err = fmt.Errorf("failed to create a temporary dir: %w", err)
+		return
+	}
+	defer func() {
+		if err != nil {
+			err = errors.Join(err, fileutils.RemoveTempDir(dirForDependenciesCalculation))
+		}
+	}()
+	// Exclude Visual Studio inner directory — not needed for scanning and may cause race conditions.
+	err = biutils.CopyDir(workingDir, dirForDependenciesCalculation, true, []string{technologies.DotVsRepoSuffix})
+	if err != nil {
+		err = fmt.Errorf("failed copying project to temp dir: %w", err)
+		return
+	}
+	output, err := getPnpmCmd(pnpmExecPath, dirForDependenciesCalculation, "install", npm.IgnoreScriptsFlag).GetCmd().CombinedOutput()
+	if err != nil {
+		err = fmt.Errorf("failed to install project: %w\n%s", err, string(output))
+	}
+	return
+}
+
+// calculateDependencies runs `pnpm ls --json` in workingDir (which must already be
+// installed) and converts the output into an Xray dependency tree.
+func calculateDependencies(executablePath, workingDir string, params technologies.BuildInfoBomGeneratorParams) (dependencyTrees []*xrayUtils.GraphNode, uniqueDeps []string, err error) {
+	lsArgs := append([]string{"--depth", params.MaxTreeDepth, "--json", "--long"}, params.Args...)
+	log.Debug("Running Pnpm ls command with args:", lsArgs)
+	npmLsCmdContent, err := getPnpmCmd(executablePath, workingDir, "ls", lsArgs...).RunWithOutput()
+	if err != nil {
+		return
+	}
+	log.Verbose("Pnpm ls command output:\n", string(npmLsCmdContent))
+	output := &[]pnpmLsProject{}
+	if err = json.Unmarshal(npmLsCmdContent, output); err != nil {
+		return
+	}
+	dependencyTrees, uniqueDeps = parsePnpmLSContent(*output)
+	return
+}
+
+// filterProjectsByScope returns a shallow copy of projects with dev or prod
+// dependencies cleared based on the --dev or --prod flags passed via params.Args
+// (set by SetNpmScope). It does not mutate the caller's slice, so the original
+// pre-filter state stays intact.
 func filterProjectsByScope(projects []pnpmLsProject, args []string) []pnpmLsProject {
 	devOnly, prodOnly := false, false
 	for _, arg := range args {
@@ -80,15 +184,17 @@ func filterProjectsByScope(projects []pnpmLsProject, args []string) []pnpmLsProj
 	if !devOnly && !prodOnly {
 		return projects
 	}
-	for i := range projects {
+	result := make([]pnpmLsProject, len(projects))
+	copy(result, projects)
+	for i := range result {
 		if devOnly {
-			projects[i].Dependencies = nil
+			result[i].Dependencies = nil
 		}
 		if prodOnly {
-			projects[i].DevDependencies = nil
+			result[i].DevDependencies = nil
 		}
 	}
-	return projects
+	return result
 }
 
 // GetNativePnpmRegistryConfig reads the Artifactory registry URL and auth token
@@ -96,7 +202,7 @@ func filterProjectsByScope(projects []pnpmLsProject, args []string) []pnpmLsProj
 // hierarchy and semantics as npm, so this mirrors GetNativeNpmRegistryConfig
 // without requiring an npm binary on pnpm-only machines.
 func GetNativePnpmRegistryConfig() (*npm.NpmrcRegistryConfig, error) {
-	pnpmExecPath, err := getPnpmExecPath()
+	pnpmExecPath, _, err := getPnpmExecPath()
 	if err != nil {
 		return nil, fmt.Errorf("failed to locate pnpm executable: %w", err)
 	}
@@ -133,12 +239,11 @@ func GetNativePnpmRegistryConfig() (*npm.NpmrcRegistryConfig, error) {
 	}, nil
 }
 
-const (
-	minPnpmMajorVersion = 10
-	maxPnpmMajorVersion = 10
-)
+const supportedPnpmMajorVersion = 10
 
-func getPnpmExecPath() (pnpmExecPath string, err error) {
+// getPnpmExecPath locates the pnpm executable and returns it together with its version,
+// so callers needing the version (e.g. the curation version check) need not re-spawn it.
+func getPnpmExecPath() (pnpmExecPath, pnpmVersion string, err error) {
 	if pnpmExecPath, err = exec.LookPath("pnpm"); errorutils.CheckError(err) != nil {
 		return
 	}
@@ -152,27 +257,89 @@ func getPnpmExecPath() (pnpmExecPath string, err error) {
 		err = versionErr
 		return
 	}
-	versionStr := strings.TrimSpace(string(versionOut))
-	log.Debug("Pnpm version:", versionStr)
-	if err = validatePnpmMinVersion(versionStr); err != nil {
-		return
-	}
+	pnpmVersion = strings.TrimSpace(string(versionOut))
+	log.Debug("Pnpm version:", pnpmVersion)
 	return
 }
 
-// validatePnpmMinVersion returns an error if the installed pnpm major version is outside the supported range [minPnpmMajorVersion, maxPnpmMajorVersion].
-func validatePnpmMinVersion(versionStr string) error {
+// validateSupportedPnpmVersion returns an error unless the installed pnpm major
+// version is exactly supportedPnpmMajorVersion. Curation supports only that major,
+// so both older and newer majors are rejected.
+func validateSupportedPnpmVersion(versionStr string) error {
 	// Version string may include extra lines (warnings on incompatible Node); take first token.
 	firstLine := strings.SplitN(versionStr, "\n", 2)[0]
 	parts := strings.SplitN(strings.TrimSpace(firstLine), ".", 2)
-	var major int
-	if _, scanErr := fmt.Sscanf(parts[0], "%d", &major); scanErr != nil {
-		return fmt.Errorf("could not parse pnpm version %q: %w", versionStr, scanErr)
+	major, err := strconv.Atoi(parts[0])
+	if err != nil {
+		return fmt.Errorf("could not parse pnpm version %q: %w", versionStr, err)
 	}
-	if major < minPnpmMajorVersion || major > maxPnpmMajorVersion {
-		return fmt.Errorf("Resolving Pnpm dependencies from Artifactory is currently not supported for Pnpm versions outside the %d.x range. The current Pnpm version is: %s", minPnpmMajorVersion, versionStr)
+	if major != supportedPnpmMajorVersion {
+		return fmt.Errorf("resolving pnpm dependencies from Artifactory is currently not supported for pnpm versions other than %d.x. The current pnpm version is: %s", supportedPnpmMajorVersion, versionStr)
 	}
 	return nil
+}
+
+// wrapLockfileRegenError checks the pnpm output for ERR_PNPM_NO_MATCHING_VERSION
+// (raised when CVS removes a blocked version from the packument) and returns a
+// curation-flavoured message. Any other failure is returned with the raw output.
+func wrapLockfileRegenError(out []byte, runErr error) error {
+	output := string(out)
+	if !strings.Contains(output, "ERR_PNPM_NO_MATCHING_VERSION") {
+		return fmt.Errorf("'pnpm install --lockfile-only' failed: %w\n%s", runErr, output)
+	}
+	pkgs := parsePnpmCvsFailedPackages(output)
+	return errors.New(formatPnpmCvsBlockedMessage(pkgs))
+}
+
+// pnpmNoMatchPrefix is the literal that precedes the failed "<name>@<version>"
+// reference in pnpm's ERR_PNPM_NO_MATCHING_VERSION output line, e.g.
+// "No matching version found for @scope/pkg@^1.0.0 while fetching it from ...".
+const pnpmNoMatchPrefix = "No matching version found for "
+
+// parsePnpmCvsFailedPackages extracts every name@version pair that pnpm
+// reported as unresolvable so only the actual blockers are listed.
+// It uses splitPnpmRef (last-'@' split) so scoped names like "@scope/pkg@1.0.0"
+// are parsed correctly — a leading '@' would defeat a naive name regex.
+func parsePnpmCvsFailedPackages(output string) []string {
+	seen := map[string]bool{}
+	var pkgs []string
+	for _, line := range strings.Split(output, "\n") {
+		idx := strings.Index(line, pnpmNoMatchPrefix)
+		if idx < 0 {
+			continue
+		}
+		// The package reference is the first whitespace-delimited token after the
+		// prefix; pnpm appends trailing text such as "while fetching it from ...".
+		fields := strings.Fields(line[idx+len(pnpmNoMatchPrefix):])
+		if len(fields) == 0 {
+			continue
+		}
+		name, version := splitPnpmRef(fields[0])
+		if version == "" {
+			continue
+		}
+		key := version
+		if name != "" {
+			key = name + "@" + version
+		}
+		if !seen[key] {
+			seen[key] = true
+			pkgs = append(pkgs, key)
+		}
+	}
+	return pkgs
+}
+
+func formatPnpmCvsBlockedMessage(pkgs []string) string {
+	var b strings.Builder
+	b.WriteString("Curation audit failed: one or more pinned package versions were unavailable during dependency resolution, so the corresponding curation policy violations could not be evaluated.")
+	if len(pkgs) > 0 {
+		b.WriteString("\n\nAffected package(s):\n")
+		for _, p := range pkgs {
+			fmt.Fprintf(&b, " - %s\n", p)
+		}
+	}
+	return b.String()
 }
 
 func getPnpmCmd(pnpmExecPath, workingDir, cmd string, args ...string) *io.Command {
@@ -181,54 +348,101 @@ func getPnpmCmd(pnpmExecPath, workingDir, cmd string, args ...string) *io.Comman
 	return command
 }
 
-// ensureLockfile guarantees that pnpm-lock.yaml exists in workingDir.
-// If it is already present, nothing is done — the existing lockfile is used as-is.
-// If it is absent, `pnpm install --lockfile-only --ignore-scripts` is run in a
-// temporary copy of workingDir so the original directory is not mutated.
-//
-// This mirrors the npm path (--package-lock-only) and yarn V3 path (--mode=update-lockfile):
-// no tarballs are downloaded, only resolution metadata is written.
-func ensureLockfile(pnpmExecPath, workingDir string) error {
+// resolveLockfileDir returns the directory whose pnpm-lock.yaml should be parsed, plus a
+// cleanup the caller must always invoke. An up-to-date lockfile returns workingDir and a
+// no-op; a missing/stale one is regenerated in a temp copy (returned for cleanup) so the
+// user's project is never modified and read-only checkouts still work.
+// resolveWorkspaceRoot walks up from workingDir to find the pnpm workspace root — the
+// nearest ancestor (workingDir included) containing pnpm-lock.yaml or pnpm-workspace.yaml.
+// It returns that root and the importer path of workingDir relative to it ("." when
+// workingDir is the root). When no marker is found, workingDir is treated as a standalone
+// project (root=workingDir, importer="."). This mirrors promotePnpmWorkspaceMember so
+// detection and lockfile resolution agree on what the workspace root is.
+func resolveWorkspaceRoot(workingDir string) (rootDir, importer string) {
+	dir := workingDir
+	for {
+		for _, marker := range []string{"pnpm-lock.yaml", "pnpm-workspace.yaml"} {
+			if exists, _ := fileutils.IsFileExists(filepath.Join(dir, marker), false); exists {
+				rel, err := filepath.Rel(dir, workingDir)
+				if err != nil {
+					rel = "."
+				}
+				return dir, filepath.ToSlash(rel)
+			}
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			return workingDir, "."
+		}
+		dir = parent
+	}
+}
+
+func resolveLockfileDir(pnpmExecPath, workingDir string) (lockfileDir string, cleanup func() error, err error) {
+	noop := func() error { return nil }
 	lockPath := filepath.Join(workingDir, "pnpm-lock.yaml")
 	lockExists, err := fileutils.IsFileExists(lockPath, false)
 	if err != nil {
-		return err
+		return "", noop, err
 	}
-	if lockExists {
-		// Re-run install if package.json is newer than pnpm-lock.yaml (stale lockfile).
-		pkgStat, pkgErr := os.Stat(filepath.Join(workingDir, "package.json"))
-		lockStat, lockErr := os.Stat(lockPath)
-		if pkgErr == nil && lockErr == nil && pkgStat.ModTime().After(lockStat.ModTime()) {
-			log.Debug(fmt.Sprintf("package.json is newer than pnpm-lock.yaml — running '%s install %s %s' to refresh it", pnpmExecPath, lockfileOnlyFlag, npm.IgnoreScriptsFlag))
-		} else {
-			return nil
-		}
-	} else {
-		log.Debug(fmt.Sprintf("pnpm-lock.yaml not found — running '%s install %s %s' in a temporary directory", pnpmExecPath, lockfileOnlyFlag, npm.IgnoreScriptsFlag))
+	if lockExists && !lockfileNeedsRefresh(pnpmExecPath, workingDir, lockPath) {
+		return workingDir, noop, nil
 	}
+	if !lockExists {
+		log.Debug(fmt.Sprintf("pnpm-lock.yaml not found — generating it in a temporary directory via '%s install %s %s'", pnpmExecPath, lockfileOnlyFlag, npm.IgnoreScriptsFlag))
+	}
+
 	tmpDir, err := fileutils.CreateTempDir()
 	if err != nil {
-		return fmt.Errorf("failed to create a temporary dir: %w", err)
+		return "", noop, fmt.Errorf("failed to create a temporary dir: %w", err)
 	}
+	cleanup = func() error { return fileutils.RemoveTempDir(tmpDir) }
+	// On failure, remove the temp dir now and downgrade cleanup so the caller won't re-remove.
 	defer func() {
-		err = errors.Join(err, fileutils.RemoveTempDir(tmpDir))
+		if err != nil {
+			err = errors.Join(err, cleanup())
+			cleanup = noop
+		}
 	}()
 
-	if copyErr := copyProjectToDir(workingDir, tmpDir); copyErr != nil {
-		return copyErr
+	if err = copyProjectToDir(workingDir, tmpDir); err != nil {
+		return "", cleanup, err
 	}
 
-	out, runErr := getPnpmCmd(pnpmExecPath, tmpDir, "install", lockfileOnlyFlag, npm.IgnoreScriptsFlag).GetCmd().CombinedOutput()
+	out, runErr := getPnpmCmd(pnpmExecPath, tmpDir, "install", lockfileOnlyFlag, npm.IgnoreScriptsFlag, ignorePnpmfileFlag).GetCmd().CombinedOutput()
 	if runErr != nil {
-		return fmt.Errorf("'pnpm install --lockfile-only' failed: %w\n%s", runErr, string(out))
+		log.Debug("pnpm install --lockfile-only failed:\n" + string(out))
+		err = wrapLockfileRegenError(out, runErr)
+		return "", cleanup, err
 	}
 
-	// Copy the generated lockfile back so parsePnpmLockFile can read it from workingDir.
-	generatedLock, readErr := fileutils.ReadFile(filepath.Join(tmpDir, "pnpm-lock.yaml"))
-	if readErr != nil {
-		return fmt.Errorf("lockfile not produced after 'pnpm install --lockfile-only': %w", readErr)
+	lockProduced, err := fileutils.IsFileExists(filepath.Join(tmpDir, "pnpm-lock.yaml"), false)
+	if err != nil {
+		return "", cleanup, err
 	}
-	return os.WriteFile(filepath.Join(workingDir, "pnpm-lock.yaml"), generatedLock, 0644)
+	if !lockProduced {
+		err = errors.New("lockfile not produced after 'pnpm install --lockfile-only'")
+		return "", cleanup, err
+	}
+	return tmpDir, cleanup, nil
+}
+
+// lockfileNeedsRefresh reports whether pnpm-lock.yaml is stale versus package.json,
+// by mtime or by drift in the recorded dependency specifiers.
+func lockfileNeedsRefresh(pnpmExecPath, workingDir, lockPath string) bool {
+	pkgStat, pkgErr := os.Stat(filepath.Join(workingDir, "package.json"))
+	lockStat, lockErr := os.Stat(lockPath)
+	mtimeStale := pkgErr == nil && lockErr == nil && pkgStat.ModTime().After(lockStat.ModTime())
+	switch {
+	case mtimeStale:
+		log.Debug(fmt.Sprintf("package.json is newer than pnpm-lock.yaml — regenerating the lockfile in a temporary directory via '%s install %s %s'", pnpmExecPath, lockfileOnlyFlag, npm.IgnoreScriptsFlag))
+		return true
+	case lockfileSpecifiersDrift(workingDir, lockPath):
+		log.Debug(fmt.Sprintf("pnpm-lock.yaml specifiers do not match package.json — regenerating the lockfile in a temporary directory via '%s install %s %s'", pnpmExecPath, lockfileOnlyFlag, npm.IgnoreScriptsFlag))
+		return true
+	default:
+		return false
+	}
 }
 
 func copyProjectToDir(src, dst string) error {
@@ -244,6 +458,14 @@ func parsePnpmLSContent(projectInfo []pnpmLsProject) (dependencyTrees []*xrayUti
 		dependencyTree, uniqueProjectDeps := xray.BuildXrayDependencyTree(createProjectDependenciesTree(project), getDependencyId(project.Name, project.Version))
 		dependencyTrees = append(dependencyTrees, dependencyTree)
 		uniqueDepsSet.AddElements(maps.Keys(uniqueProjectDeps)...)
+		// Local workspace members are project roots, not published packages: keep them
+		// in the tree for attribution but drop them from the HEAD-check set so we don't
+		// query Artifactory for a package that doesn't exist (404).
+		for name, dependency := range project.Dependencies {
+			if dependency.Local {
+				_ = uniqueDepsSet.Remove(getDependencyId(name, dependency.Version))
+			}
+		}
 	}
 	uniqueDeps = uniqueDepsSet.ToSlice()
 	return

--- a/sca/bom/buildinfo/technologies/pnpm/pnpm.go
+++ b/sca/bom/buildinfo/technologies/pnpm/pnpm.go
@@ -1,12 +1,14 @@
 package pnpm
 
 import (
-	"encoding/json"
 	"errors"
 	"fmt"
+	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 
+	biutils "github.com/jfrog/build-info-go/utils"
 	"github.com/jfrog/gofrog/datastructures"
 	"github.com/jfrog/gofrog/io"
 	"github.com/jfrog/jfrog-cli-core/v2/utils/coreutils"
@@ -19,9 +21,10 @@ import (
 	"github.com/jfrog/jfrog-client-go/utils/log"
 	"golang.org/x/exp/maps"
 
-	biutils "github.com/jfrog/build-info-go/utils"
 	xrayUtils "github.com/jfrog/jfrog-client-go/xray/services/utils"
 )
+
+const lockfileOnlyFlag = "--lockfile-only"
 
 type pnpmLsDependency struct {
 	From         string                      `json:"from"`
@@ -37,7 +40,6 @@ type pnpmLsProject struct {
 }
 
 func BuildDependencyTree(params technologies.BuildInfoBomGeneratorParams) (dependencyTrees []*xrayUtils.GraphNode, uniqueDeps []string, err error) {
-	// Prepare
 	currentDir, err := coreutils.GetWorkingDirectory()
 	if err != nil {
 		return
@@ -46,22 +48,89 @@ func BuildDependencyTree(params technologies.BuildInfoBomGeneratorParams) (depen
 	if err != nil {
 		return
 	}
-	// Build
-	var dirForDependenciesCalculation string
-	if dirForDependenciesCalculation, err = installProjectIfNeeded(pnpmExecPath, currentDir); errorutils.CheckError(err) != nil {
+
+	if err = ensureLockfile(pnpmExecPath, currentDir); err != nil {
 		return
 	}
 
-	if dirForDependenciesCalculation == "" {
-		// If we didn't execute 'install' dirForDependenciesCalculation contains an empty value and the dependencies calculation should be performed on the original cloned dir
-		dirForDependenciesCalculation = currentDir
-	} else {
-		// If tempDirForDependenciesCalculation contains a non-empty value, it means we created a temporary directory during the execution of 'install' command, and it needs to removed at the end
-		defer func() {
-			err = errors.Join(err, biutils.RemoveTempDir(dirForDependenciesCalculation))
-		}()
+	projects, err := parsePnpmLockFile(currentDir)
+	if err != nil {
+		return
 	}
-	return calculateDependencies(pnpmExecPath, dirForDependenciesCalculation, params)
+	// Apply scope filter (dev-only / prod-only) to the raw project list if requested.
+	if len(params.Args) > 0 {
+		projects = filterProjectsByScope(projects, params.Args)
+	}
+	dependencyTrees, uniqueDeps = parsePnpmLSContent(projects)
+	return
+}
+
+// filterProjectsByScope removes dev or prod dependencies from each project
+// based on the --dev or --prod flags passed via params.Args (set by SetNpmScope).
+func filterProjectsByScope(projects []pnpmLsProject, args []string) []pnpmLsProject {
+	devOnly, prodOnly := false, false
+	for _, arg := range args {
+		switch arg {
+		case "--dev":
+			devOnly = true
+		case "--prod":
+			prodOnly = true
+		}
+	}
+	if !devOnly && !prodOnly {
+		return projects
+	}
+	for i := range projects {
+		if devOnly {
+			projects[i].Dependencies = nil
+		}
+		if prodOnly {
+			projects[i].DevDependencies = nil
+		}
+	}
+	return projects
+}
+
+// GetNativePnpmRegistryConfig reads the Artifactory registry URL and auth token
+// from the project's .npmrc via the pnpm CLI. pnpm reads .npmrc with the same
+// hierarchy and semantics as npm, so this mirrors GetNativeNpmRegistryConfig
+// without requiring an npm binary on pnpm-only machines.
+func GetNativePnpmRegistryConfig() (*npm.NpmrcRegistryConfig, error) {
+	pnpmExecPath, err := getPnpmExecPath()
+	if err != nil {
+		return nil, fmt.Errorf("failed to locate pnpm executable: %w", err)
+	}
+
+	registryData, err := getPnpmCmd(pnpmExecPath, "", "config", "get", "registry").RunWithOutput()
+	if err != nil {
+		return nil, fmt.Errorf("failed to read registry from pnpm config: %w", err)
+	}
+	registryUrl := strings.TrimSpace(string(registryData))
+
+	rtBaseUrl, repoName, err := npm.ParseArtifactoryNpmRegistryUrl(registryUrl)
+	if err != nil {
+		return nil, err
+	}
+
+	authKey, err := npm.BuildNpmAuthTokenKey(registryUrl)
+	if err != nil {
+		return nil, err
+	}
+
+	tokenData, tokenErr := getPnpmCmd(pnpmExecPath, "", "config", "get", authKey).RunWithOutput()
+	authToken := ""
+	if tokenErr == nil {
+		authToken = strings.TrimSpace(string(tokenData))
+		if authToken == "undefined" || authToken == "null" {
+			authToken = ""
+		}
+	}
+
+	return &npm.NpmrcRegistryConfig{
+		ArtifactoryUrl: rtBaseUrl,
+		RepoName:       repoName,
+		AuthToken:      authToken,
+	}, nil
 }
 
 func getPnpmExecPath() (pnpmExecPath string, err error) {
@@ -73,7 +142,6 @@ func getPnpmExecPath() (pnpmExecPath string, err error) {
 		return
 	}
 	log.Debug("Using Pnpm executable:", pnpmExecPath)
-	// Validate pnpm version command
 	version, err := getPnpmCmd(pnpmExecPath, "", "--version").RunWithOutput()
 	if errorutils.CheckError(err) != nil {
 		return
@@ -88,68 +156,59 @@ func getPnpmCmd(pnpmExecPath, workingDir, cmd string, args ...string) *io.Comman
 	return command
 }
 
-// Installation is necessary when either the "pnpm-lock.yaml" lock file or the "node_modules/.pnpm" directory does not exist.
-// If install is needed, we duplicate the project to a temporary directory and conduct the 'install' operation on the duplicate, to ensure that the original clone does not retain the node_modules directory if it didn't exist previously.
-// Upon 'install' the path to the duplicate directory will be returned.
-func installProjectIfNeeded(pnpmExecPath, workingDir string) (dirForDependenciesCalculation string, err error) {
-	lockFileExists, err := fileutils.IsFileExists(filepath.Join(workingDir, "pnpm-lock.yaml"), false)
+// ensureLockfile guarantees that pnpm-lock.yaml exists in workingDir.
+// If it is already present, nothing is done — the existing lockfile is used as-is.
+// If it is absent, `pnpm install --lockfile-only --ignore-scripts` is run in a
+// temporary copy of workingDir so the original directory is not mutated.
+//
+// This mirrors the npm path (--package-lock-only) and yarn V3 path (--mode=update-lockfile):
+// no tarballs are downloaded, only resolution metadata is written.
+func ensureLockfile(pnpmExecPath, workingDir string) error {
+	lockExists, err := fileutils.IsFileExists(filepath.Join(workingDir, "pnpm-lock.yaml"), false)
 	if err != nil {
-		return
+		return err
 	}
-	pnpmDirExists, err := fileutils.IsDirExists(filepath.Join(workingDir, "node_modules", ".pnpm"), false)
-	if err != nil || (lockFileExists && pnpmDirExists) {
-		return
+	if lockExists {
+		return nil
 	}
-	// Install is needed and will be performed on a copy of the cloned dir
-	log.Debug("Installing Pnpm project:", workingDir)
-	dirForDependenciesCalculation, err = fileutils.CreateTempDir()
+
+	log.Debug("pnpm-lock.yaml not found — running 'pnpm install --lockfile-only' in a temporary directory")
+	tmpDir, err := fileutils.CreateTempDir()
 	if err != nil {
-		err = fmt.Errorf("failed to create a temporary dir: %w", err)
-		return
+		return fmt.Errorf("failed to create a temporary dir: %w", err)
 	}
 	defer func() {
-		// If an error occurs for any reason, we proceed to delete the temporary directory.
-		if err != nil {
-			err = errors.Join(err, fileutils.RemoveTempDir(dirForDependenciesCalculation))
-		}
+		err = errors.Join(err, fileutils.RemoveTempDir(tmpDir))
 	}()
 
-	// Exclude Visual Studio inner directory since it is not necessary for the scan process and may cause race condition.
-	err = biutils.CopyDir(workingDir, dirForDependenciesCalculation, true, []string{technologies.DotVsRepoSuffix})
-	if err != nil {
-		err = fmt.Errorf("failed copying project to temp dir: %w", err)
-		return
+	if copyErr := copyProjectToDir(workingDir, tmpDir); copyErr != nil {
+		return copyErr
 	}
-	output, err := getPnpmCmd(pnpmExecPath, dirForDependenciesCalculation, "install", npm.IgnoreScriptsFlag).GetCmd().CombinedOutput()
-	if err != nil {
-		err = fmt.Errorf("failed to install project: %w\n%s", err, string(output))
+
+	out, runErr := getPnpmCmd(pnpmExecPath, tmpDir, "install", lockfileOnlyFlag, npm.IgnoreScriptsFlag).GetCmd().CombinedOutput()
+	if runErr != nil {
+		return fmt.Errorf("'pnpm install --lockfile-only' failed: %w\n%s", runErr, string(out))
 	}
-	return
+
+	// Copy the generated lockfile back so parsePnpmLockFile can read it from workingDir.
+	generatedLock, readErr := fileutils.ReadFile(filepath.Join(tmpDir, "pnpm-lock.yaml"))
+	if readErr != nil {
+		return fmt.Errorf("lockfile not produced after 'pnpm install --lockfile-only': %w", readErr)
+	}
+	return os.WriteFile(filepath.Join(workingDir, "pnpm-lock.yaml"), generatedLock, 0644)
 }
 
-// Run 'pnpm ls ...' command (project must be installed) and parse the returned result to create a dependencies trees for the projects.
-func calculateDependencies(executablePath, workingDir string, params technologies.BuildInfoBomGeneratorParams) (dependencyTrees []*xrayUtils.GraphNode, uniqueDeps []string, err error) {
-	lsArgs := append([]string{"--depth", params.MaxTreeDepth, "--json", "--long"}, params.Args...)
-	log.Debug("Running Pnpm ls command with args:", lsArgs)
-	npmLsCmdContent, err := getPnpmCmd(executablePath, workingDir, "ls", lsArgs...).RunWithOutput()
-	if err != nil {
-		return
+func copyProjectToDir(src, dst string) error {
+	if err := biutils.CopyDir(src, dst, true, []string{technologies.DotVsRepoSuffix}); err != nil {
+		return fmt.Errorf("failed copying project to temp dir: %w", err)
 	}
-	log.Verbose("Pnpm ls command output:\n", string(npmLsCmdContent))
-	output := &[]pnpmLsProject{}
-	if err = json.Unmarshal(npmLsCmdContent, output); err != nil {
-		return
-	}
-	dependencyTrees, uniqueDeps = parsePnpmLSContent(*output)
-	return
+	return nil
 }
 
 func parsePnpmLSContent(projectInfo []pnpmLsProject) (dependencyTrees []*xrayUtils.GraphNode, uniqueDeps []string) {
 	uniqueDepsSet := datastructures.MakeSet[string]()
 	for _, project := range projectInfo {
-		// Parse the dependencies into Xray dependency tree format
 		dependencyTree, uniqueProjectDeps := xray.BuildXrayDependencyTree(createProjectDependenciesTree(project), getDependencyId(project.Name, project.Version))
-		// Add results
 		dependencyTrees = append(dependencyTrees, dependencyTree)
 		uniqueDepsSet.AddElements(maps.Keys(uniqueProjectDeps)...)
 	}
@@ -159,14 +218,12 @@ func parsePnpmLSContent(projectInfo []pnpmLsProject) (dependencyTrees []*xrayUti
 
 func createProjectDependenciesTree(project pnpmLsProject) map[string]xray.DepTreeNode {
 	treeMap := make(map[string]xray.DepTreeNode)
-	directDependencies := []string{}
-	// Handle production-dependencies
+	var directDependencies []string
 	for depName, dependency := range project.Dependencies {
 		directDependency := getDependencyId(depName, dependency.Version)
 		directDependencies = append(directDependencies, directDependency)
 		appendTransitiveDependencies(directDependency, dependency.Dependencies, &treeMap)
 	}
-	// Handle dev-dependencies
 	for depName, dependency := range project.DevDependencies {
 		directDependency := getDependencyId(depName, dependency.Version)
 		directDependencies = append(directDependencies, directDependency)
@@ -178,7 +235,6 @@ func createProjectDependenciesTree(project pnpmLsProject) map[string]xray.DepTre
 	return treeMap
 }
 
-// Return npm://<name>:<version> of a dependency
 func getDependencyId(depName, version string) string {
 	return techutils.Npm.GetXrayPackageTypeId() + depName + ":" + version
 }

--- a/sca/bom/buildinfo/technologies/pnpm/pnpm.go
+++ b/sca/bom/buildinfo/technologies/pnpm/pnpm.go
@@ -133,6 +133,8 @@ func GetNativePnpmRegistryConfig() (*npm.NpmrcRegistryConfig, error) {
 	}, nil
 }
 
+const minPnpmMajorVersion = 10
+
 func getPnpmExecPath() (pnpmExecPath string, err error) {
 	if pnpmExecPath, err = exec.LookPath("pnpm"); errorutils.CheckError(err) != nil {
 		return
@@ -142,12 +144,32 @@ func getPnpmExecPath() (pnpmExecPath string, err error) {
 		return
 	}
 	log.Debug("Using Pnpm executable:", pnpmExecPath)
-	version, err := getPnpmCmd(pnpmExecPath, "", "--version").RunWithOutput()
-	if errorutils.CheckError(err) != nil {
+	versionOut, versionErr := getPnpmCmd(pnpmExecPath, "", "--version").RunWithOutput()
+	if errorutils.CheckError(versionErr) != nil {
+		err = versionErr
 		return
 	}
-	log.Debug("Pnpm version:", string(version))
+	versionStr := strings.TrimSpace(string(versionOut))
+	log.Debug("Pnpm version:", versionStr)
+	if err = validatePnpmMinVersion(versionStr); err != nil {
+		return
+	}
 	return
+}
+
+// validatePnpmMinVersion returns an error if the installed pnpm major version is below minPnpmMajorVersion.
+func validatePnpmMinVersion(versionStr string) error {
+	// Version string may include extra lines (warnings on incompatible Node); take first token.
+	firstLine := strings.SplitN(versionStr, "\n", 2)[0]
+	parts := strings.SplitN(strings.TrimSpace(firstLine), ".", 2)
+	var major int
+	if _, scanErr := fmt.Sscanf(parts[0], "%d", &major); scanErr != nil {
+		return fmt.Errorf("could not parse pnpm version %q: %w", versionStr, scanErr)
+	}
+	if major < minPnpmMajorVersion {
+		return fmt.Errorf("pnpm version %s is not supported. Minimum required version is %d.x", versionStr, minPnpmMajorVersion)
+	}
+	return nil
 }
 
 func getPnpmCmd(pnpmExecPath, workingDir, cmd string, args ...string) *io.Command {
@@ -164,15 +186,23 @@ func getPnpmCmd(pnpmExecPath, workingDir, cmd string, args ...string) *io.Comman
 // This mirrors the npm path (--package-lock-only) and yarn V3 path (--mode=update-lockfile):
 // no tarballs are downloaded, only resolution metadata is written.
 func ensureLockfile(pnpmExecPath, workingDir string) error {
-	lockExists, err := fileutils.IsFileExists(filepath.Join(workingDir, "pnpm-lock.yaml"), false)
+	lockPath := filepath.Join(workingDir, "pnpm-lock.yaml")
+	lockExists, err := fileutils.IsFileExists(lockPath, false)
 	if err != nil {
 		return err
 	}
 	if lockExists {
-		return nil
+		// Re-run install if package.json is newer than pnpm-lock.yaml (stale lockfile).
+		pkgStat, pkgErr := os.Stat(filepath.Join(workingDir, "package.json"))
+		lockStat, lockErr := os.Stat(lockPath)
+		if pkgErr == nil && lockErr == nil && pkgStat.ModTime().After(lockStat.ModTime()) {
+			log.Debug(fmt.Sprintf("package.json is newer than pnpm-lock.yaml — running '%s install %s %s' to refresh it", pnpmExecPath, lockfileOnlyFlag, npm.IgnoreScriptsFlag))
+		} else {
+			return nil
+		}
+	} else {
+		log.Debug(fmt.Sprintf("pnpm-lock.yaml not found — running '%s install %s %s' in a temporary directory", pnpmExecPath, lockfileOnlyFlag, npm.IgnoreScriptsFlag))
 	}
-
-	log.Debug("pnpm-lock.yaml not found — running 'pnpm install --lockfile-only' in a temporary directory")
 	tmpDir, err := fileutils.CreateTempDir()
 	if err != nil {
 		return fmt.Errorf("failed to create a temporary dir: %w", err)

--- a/sca/bom/buildinfo/technologies/pnpm/pnpm_test.go
+++ b/sca/bom/buildinfo/technologies/pnpm/pnpm_test.go
@@ -166,7 +166,7 @@ func TestValidatePnpmMinVersion(t *testing.T) {
 		{name: "v10 minor accepted", version: "10.27.0", expectError: false},
 		{name: "v9 rejected", version: "9.15.0", expectError: true},
 		{name: "v8 rejected", version: "8.15.9", expectError: true},
-		{name: "v11 accepted", version: "11.0.0", expectError: false},
+		{name: "v11 rejected", version: "11.0.0", expectError: true},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/sca/bom/buildinfo/technologies/pnpm/pnpm_test.go
+++ b/sca/bom/buildinfo/technologies/pnpm/pnpm_test.go
@@ -1,14 +1,19 @@
 package pnpm
 
 import (
+	"errors"
+	"os"
 	"path/filepath"
 	"sort"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/jfrog/jfrog-cli-core/v2/utils/coreutils"
 	"github.com/jfrog/jfrog-cli-core/v2/utils/tests"
+	"github.com/jfrog/jfrog-client-go/utils/io/fileutils"
 	xrayUtils "github.com/jfrog/jfrog-client-go/xray/services/utils"
 
 	"github.com/jfrog/jfrog-cli-security/sca/bom/buildinfo/technologies"
@@ -129,7 +134,7 @@ func TestBuildDependencyTreePnpmLockfile(t *testing.T) {
 
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
-			params := technologies.BuildInfoBomGeneratorParams{}
+			params := technologies.BuildInfoBomGeneratorParams{IsCurationCmd: true}
 			rootNode, uniqueDeps, err := BuildDependencyTree(*params.SetNpmScope(testCase.depScope))
 			require.NoError(t, err)
 			sort.Slice(uniqueDeps, func(i, j int) bool { return uniqueDeps[i] < uniqueDeps[j] })
@@ -144,19 +149,190 @@ func TestBuildDependencyTreePnpmLockfile(t *testing.T) {
 	}
 }
 
-func TestEnsureLockfileExisting(t *testing.T) {
+func TestResolveLockfileDirExisting(t *testing.T) {
 	_, cleanUp := technologies.CreateTestWorkspace(t, filepath.Join("projects", "package-managers", "pnpm", "pnpm-project"))
 	defer cleanUp()
 
-	pnpmExecPath, err := getPnpmExecPath()
+	pnpmExecPath, _, err := getPnpmExecPath()
 	require.NoError(t, err)
 
-	// Workspace already contains pnpm-lock.yaml — ensureLockfile should be a no-op.
-	err = ensureLockfile(pnpmExecPath, ".")
-	assert.NoError(t, err)
+	// Workspace already contains an up-to-date pnpm-lock.yaml — resolveLockfileDir
+	// should return the working dir itself (no temp copy, no project modification).
+	lockfileDir, cleanup, err := resolveLockfileDir(pnpmExecPath, ".")
+	require.NoError(t, err)
+	defer func() { assert.NoError(t, cleanup()) }()
+	assert.Equal(t, ".", lockfileDir)
 }
 
-func TestValidatePnpmMinVersion(t *testing.T) {
+// TestBuildDependencyTree exercises the audit/scan path (pnpm ls --json) which is
+// the pre-existing behaviour unmodified by the curation-audit feature.
+func TestBuildDependencyTree(t *testing.T) {
+	_, cleanUp := technologies.CreateTestWorkspace(t, filepath.Join("projects", "package-managers", "npm", "npm-no-lock"))
+	defer cleanUp()
+
+	testCases := []struct {
+		name               string
+		depScope           string
+		expectedUniqueDeps []string
+		expectedTree       *xrayUtils.GraphNode
+	}{
+		{
+			name:     "All",
+			depScope: "all",
+			expectedUniqueDeps: []string{
+				"npm://jfrog-cli-tests:v1.0.0",
+				"npm://xml:1.0.1",
+				"npm://json:9.0.6",
+			},
+			expectedTree: &xrayUtils.GraphNode{
+				Id: "npm://jfrog-cli-tests:v1.0.0",
+				Nodes: []*xrayUtils.GraphNode{
+					{Id: "npm://xml:1.0.1"},
+					{Id: "npm://json:9.0.6"},
+				},
+			},
+		},
+		{
+			name:     "Prod",
+			depScope: "prodOnly",
+			expectedUniqueDeps: []string{
+				"npm://jfrog-cli-tests:v1.0.0",
+				"npm://xml:1.0.1",
+			},
+			expectedTree: &xrayUtils.GraphNode{
+				Id:    "npm://jfrog-cli-tests:v1.0.0",
+				Nodes: []*xrayUtils.GraphNode{{Id: "npm://xml:1.0.1"}},
+			},
+		},
+		{
+			name:     "Dev",
+			depScope: "devOnly",
+			expectedUniqueDeps: []string{
+				"npm://jfrog-cli-tests:v1.0.0",
+				"npm://json:9.0.6",
+			},
+			expectedTree: &xrayUtils.GraphNode{
+				Id:    "npm://jfrog-cli-tests:v1.0.0",
+				Nodes: []*xrayUtils.GraphNode{{Id: "npm://json:9.0.6"}},
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			// IsCurationCmd is false (default) — exercises the pnpm ls audit path.
+			params := technologies.BuildInfoBomGeneratorParams{}
+			rootNode, uniqueDeps, err := BuildDependencyTree(*params.SetNpmScope(testCase.depScope))
+			require.NoError(t, err)
+			assert.ElementsMatch(t, uniqueDeps, testCase.expectedUniqueDeps, "First is actual, Second is Expected")
+			if assert.Len(t, rootNode, 1) {
+				assert.Equal(t, rootNode[0].Id, testCase.expectedTree.Id)
+				if !tests.CompareTree(testCase.expectedTree, rootNode[0]) {
+					t.Error("expected:", testCase.expectedTree.Nodes, "got:", rootNode[0].Nodes)
+				}
+			}
+		})
+	}
+}
+
+// TestInstallProjectIfNeeded verifies that installProjectIfNeeded creates a temp dir
+// with node_modules installed without touching the original project directory.
+func TestInstallProjectIfNeeded(t *testing.T) {
+	_, cleanUp := technologies.CreateTestWorkspace(t, filepath.Join("projects", "package-managers", "npm", "npm-no-lock"))
+	defer cleanUp()
+
+	currentDir, err := coreutils.GetWorkingDirectory()
+	assert.NoError(t, err)
+
+	pnpmExecPath, _, err := getPnpmExecPath()
+	assert.NoError(t, err)
+
+	dirForDependenciesCalculation, err := installProjectIfNeeded(pnpmExecPath, currentDir)
+	assert.NoError(t, err)
+	assert.NotEmpty(t, dirForDependenciesCalculation)
+
+	nodeModulesExist, err := fileutils.IsDirExists(filepath.Join(dirForDependenciesCalculation, "node_modules"), false)
+	assert.NoError(t, err)
+	assert.True(t, nodeModulesExist)
+
+	// Original directory must NOT have node_modules created.
+	nodeModulesExist, err = fileutils.IsDirExists(filepath.Join(currentDir, "node_modules"), false)
+	assert.NoError(t, err)
+	assert.False(t, nodeModulesExist)
+}
+
+// TestParsePnpmLSContentNestsWorkspaceMembers verifies that a multi-importer
+// workspace is rendered as a single tree rooted at the workspace root, with each
+// member nested as a direct child carrying its own dependencies — matching npm.
+func TestParsePnpmLSContentNestsWorkspaceMembers(t *testing.T) {
+	projects, err := parsePnpmLockFile(viteFixtureDir(t), ".")
+	require.NoError(t, err)
+	require.Len(t, projects, 1)
+
+	trees, uniqueDeps := parsePnpmLSContent(projects)
+	require.Len(t, trees, 1, "workspace must collapse into a single root tree")
+	root := trees[0]
+
+	viteMember := findNodeByID(root, getDependencyId("packages/vite", "0.0.0"))
+	require.NotNil(t, viteMember, "packages/vite must be a node under the root")
+	assert.NotNil(t, findNodeByID(viteMember, getDependencyId("rolldown", "1.0.3")),
+		"member's dependency must be nested under the member node")
+
+	createMember := findNodeByID(root, getDependencyId("packages/create-vite", "0.0.0"))
+	require.NotNil(t, createMember, "packages/create-vite must be a node under the root")
+	assert.NotNil(t, findNodeByID(createMember, getDependencyId("cross-spawn", "7.0.6")),
+		"member's dev dependency must be nested under the member node")
+
+	// Local member nodes are local packages, not published artifacts — they must be
+	// excluded from the HEAD-check set, while their real dependencies stay in it.
+	assert.NotContains(t, uniqueDeps, getDependencyId("packages/vite", "0.0.0"))
+	assert.NotContains(t, uniqueDeps, getDependencyId("packages/create-vite", "0.0.0"))
+	assert.Contains(t, uniqueDeps, getDependencyId("rolldown", "1.0.3"))
+	assert.Contains(t, uniqueDeps, getDependencyId("cross-spawn", "7.0.6"))
+}
+
+// TestResolveWorkspaceRoot covers the three cases: a standalone project (no marker),
+// the workspace root itself, and a member dir that must resolve up to the root.
+func TestResolveWorkspaceRoot(t *testing.T) {
+	root := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(root, "pnpm-workspace.yaml"), []byte("packages:\n  - '.'\n  - 'packages/*'\n"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(root, "pnpm-lock.yaml"), []byte("lockfileVersion: '9.0'\n"), 0o644))
+	member := filepath.Join(root, "packages", "ui")
+	require.NoError(t, os.MkdirAll(member, 0o755))
+
+	t.Run("workspace root resolves to itself with '.'", func(t *testing.T) {
+		gotRoot, importer := resolveWorkspaceRoot(root)
+		assert.Equal(t, root, gotRoot)
+		assert.Equal(t, ".", importer)
+	})
+
+	t.Run("member resolves up to the root with its relative importer", func(t *testing.T) {
+		gotRoot, importer := resolveWorkspaceRoot(member)
+		assert.Equal(t, root, gotRoot)
+		assert.Equal(t, "packages/ui", importer)
+	})
+
+	t.Run("standalone dir with no marker resolves to itself", func(t *testing.T) {
+		standalone := t.TempDir()
+		gotRoot, importer := resolveWorkspaceRoot(standalone)
+		assert.Equal(t, standalone, gotRoot)
+		assert.Equal(t, ".", importer)
+	})
+}
+
+func findNodeByID(node *xrayUtils.GraphNode, id string) *xrayUtils.GraphNode {
+	if node == nil {
+		return nil
+	}
+	for _, child := range node.Nodes {
+		if child.Id == id {
+			return child
+		}
+	}
+	return nil
+}
+
+func TestValidateSupportedPnpmVersion(t *testing.T) {
 	testCases := []struct {
 		name        string
 		version     string
@@ -170,7 +346,7 @@ func TestValidatePnpmMinVersion(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			err := validatePnpmMinVersion(tc.version)
+			err := validateSupportedPnpmVersion(tc.version)
 			if tc.expectError {
 				assert.Error(t, err)
 			} else {
@@ -178,4 +354,109 @@ func TestValidatePnpmMinVersion(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestParsePnpmCvsFailedPackages(t *testing.T) {
+	cases := []struct {
+		name   string
+		output string
+		want   []string
+	}{
+		{
+			name: "single package",
+			output: " ERR_PNPM_NO_MATCHING_VERSION  No matching version found for lodash@4.99.0\n" +
+				"This error happened while installing a direct dependency of /tmp/proj",
+			want: []string{"lodash@4.99.0"},
+		},
+		{
+			name: "multiple packages",
+			output: "ERR_PNPM_NO_MATCHING_VERSION  No matching version found for lodash@4.99.0\n" +
+				"ERR_PNPM_NO_MATCHING_VERSION  No matching version found for express@99.0.0\n",
+			want: []string{"lodash@4.99.0", "express@99.0.0"},
+		},
+		{
+			name:   "no matching version lines",
+			output: "some unrelated pnpm error output",
+			want:   nil,
+		},
+		{
+			name: "deduplication",
+			output: "No matching version found for lodash@4.99.0\n" +
+				"No matching version found for lodash@4.99.0\n",
+			want: []string{"lodash@4.99.0"},
+		},
+		{
+			name:   "scoped package",
+			output: "ERR_PNPM_NO_MATCHING_VERSION  No matching version found for @angular/core@18.99.0\n",
+			want:   []string{"@angular/core@18.99.0"},
+		},
+		{
+			name: "scoped and unscoped mixed",
+			output: "No matching version found for @scope/pkg@1.2.3\n" +
+				"No matching version found for express@99.0.0\n",
+			want: []string{"@scope/pkg@1.2.3", "express@99.0.0"},
+		},
+		{
+			name:   "trailing text after reference is ignored",
+			output: "ERR_PNPM_NO_MATCHING_VERSION  No matching version found for lodash@4.99.99 while fetching it from https://artifactory/api/npm/repo/lodash",
+			want:   []string{"lodash@4.99.99"},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := parsePnpmCvsFailedPackages(tc.output)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}
+
+func TestWrapLockfileRegenError(t *testing.T) {
+	const curationPrefix = "Curation audit failed: one or more pinned package versions were unavailable during dependency resolution"
+	runErr := errors.New("exit status 1")
+
+	t.Run("ERR_PNPM_NO_MATCHING_VERSION becomes curation message", func(t *testing.T) {
+		out := []byte("ERR_PNPM_NO_MATCHING_VERSION  No matching version found for react@18.99.0\n")
+		err := wrapLockfileRegenError(out, runErr)
+		require.Error(t, err)
+		assert.True(t, strings.HasPrefix(err.Error(), curationPrefix),
+			"expected curation prefix, got: %s", err.Error())
+		assert.Contains(t, err.Error(), "react@18.99.0")
+		assert.Contains(t, err.Error(), "Affected package(s):")
+	})
+
+	t.Run("multiple blocked packages all listed", func(t *testing.T) {
+		out := []byte("ERR_PNPM_NO_MATCHING_VERSION  No matching version found for lodash@4.99.0\n" +
+			"ERR_PNPM_NO_MATCHING_VERSION  No matching version found for express@99.0.0\n")
+		err := wrapLockfileRegenError(out, runErr)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "lodash@4.99.0")
+		assert.Contains(t, err.Error(), "express@99.0.0")
+	})
+
+	t.Run("scoped blocked package is listed", func(t *testing.T) {
+		out := []byte("ERR_PNPM_NO_MATCHING_VERSION  No matching version found for @angular/core@18.99.0\n")
+		err := wrapLockfileRegenError(out, runErr)
+		require.Error(t, err)
+		assert.True(t, strings.HasPrefix(err.Error(), curationPrefix),
+			"expected curation prefix, got: %s", err.Error())
+		assert.Contains(t, err.Error(), "@angular/core@18.99.0")
+		assert.Contains(t, err.Error(), "Affected package(s):")
+	})
+
+	t.Run("unrelated failure returns raw output", func(t *testing.T) {
+		out := []byte("some unrelated pnpm failure")
+		err := wrapLockfileRegenError(out, runErr)
+		require.Error(t, err)
+		assert.False(t, strings.HasPrefix(err.Error(), curationPrefix),
+			"unexpected curation prefix for unrelated error")
+		assert.Contains(t, err.Error(), "some unrelated pnpm failure")
+	})
+
+	t.Run("ERR_PNPM_NO_MATCHING_VERSION without package line still shows curation header", func(t *testing.T) {
+		out := []byte("ERR_PNPM_NO_MATCHING_VERSION  something unusual without the standard line")
+		err := wrapLockfileRegenError(out, runErr)
+		require.Error(t, err)
+		assert.True(t, strings.HasPrefix(err.Error(), curationPrefix),
+			"expected curation prefix even without extracted package name")
+	})
 }

--- a/sca/bom/buildinfo/technologies/pnpm/pnpm_test.go
+++ b/sca/bom/buildinfo/technologies/pnpm/pnpm_test.go
@@ -5,9 +5,6 @@ import (
 	"sort"
 	"testing"
 
-	"github.com/jfrog/jfrog-cli-core/v2/utils/coreutils"
-	"github.com/jfrog/jfrog-client-go/utils/io/fileutils"
-
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -18,7 +15,6 @@ import (
 )
 
 func TestBuildDependencyTreeLimitedDepth(t *testing.T) {
-	// Create and change directory to test workspace
 	_, cleanUp := technologies.CreateTestWorkspace(t, filepath.Join("projects", "package-managers", "npm", "npm-big-tree"))
 	defer cleanUp()
 	testCases := []struct {
@@ -62,14 +58,12 @@ func TestBuildDependencyTreeLimitedDepth(t *testing.T) {
 
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
-			// Build dependency tree
 			params := technologies.BuildInfoBomGeneratorParams{MaxTreeDepth: testCase.treeDepth}
 			rootNode, uniqueDeps, err := BuildDependencyTree(params)
 			require.NoError(t, err)
 			sort.Slice(uniqueDeps, func(i, j int) bool {
 				return uniqueDeps[i] < uniqueDeps[j]
 			})
-			// Validations
 			assert.ElementsMatch(t, uniqueDeps, testCase.expectedUniqueDeps, "First is actual, Second is Expected")
 			if assert.Len(t, rootNode, 1) {
 				assert.Equal(t, rootNode[0].Id, testCase.expectedTree.Id)
@@ -81,27 +75,26 @@ func TestBuildDependencyTreeLimitedDepth(t *testing.T) {
 	}
 }
 
-func TestBuildDependencyTree(t *testing.T) {
-	// Create and change directory to test workspace
-	_, cleanUp := technologies.CreateTestWorkspace(t, filepath.Join("projects", "package-managers", "npm", "npm-no-lock"))
+func TestBuildDependencyTreePnpmLockfile(t *testing.T) {
+	_, cleanUp := technologies.CreateTestWorkspace(t, filepath.Join("projects", "package-managers", "pnpm", "pnpm-project"))
 	defer cleanUp()
 
 	testCases := []struct {
 		name               string
-		depType            string
+		depScope           string
 		expectedUniqueDeps []string
 		expectedTree       *xrayUtils.GraphNode
 	}{
 		{
-			name:    "All",
-			depType: "all",
+			name:     "All dependencies",
+			depScope: "all",
 			expectedUniqueDeps: []string{
-				"npm://jfrog-cli-tests:v1.0.0",
+				"npm://pnpm-example:1.0.0",
 				"npm://xml:1.0.1",
 				"npm://json:9.0.6",
 			},
 			expectedTree: &xrayUtils.GraphNode{
-				Id: "npm://jfrog-cli-tests:v1.0.0",
+				Id: "npm://pnpm-example:1.0.0",
 				Nodes: []*xrayUtils.GraphNode{
 					{Id: "npm://xml:1.0.1"},
 					{Id: "npm://json:9.0.6"},
@@ -109,26 +102,26 @@ func TestBuildDependencyTree(t *testing.T) {
 			},
 		},
 		{
-			name:    "Prod",
-			depType: "prodOnly",
+			name:     "Prod only",
+			depScope: "prodOnly",
 			expectedUniqueDeps: []string{
-				"npm://jfrog-cli-tests:v1.0.0",
+				"npm://pnpm-example:1.0.0",
 				"npm://xml:1.0.1",
 			},
 			expectedTree: &xrayUtils.GraphNode{
-				Id:    "npm://jfrog-cli-tests:v1.0.0",
+				Id:    "npm://pnpm-example:1.0.0",
 				Nodes: []*xrayUtils.GraphNode{{Id: "npm://xml:1.0.1"}},
 			},
 		},
 		{
-			name:    "Dev",
-			depType: "devOnly",
+			name:     "Dev only",
+			depScope: "devOnly",
 			expectedUniqueDeps: []string{
-				"npm://jfrog-cli-tests:v1.0.0",
+				"npm://pnpm-example:1.0.0",
 				"npm://json:9.0.6",
 			},
 			expectedTree: &xrayUtils.GraphNode{
-				Id:    "npm://jfrog-cli-tests:v1.0.0",
+				Id:    "npm://pnpm-example:1.0.0",
 				Nodes: []*xrayUtils.GraphNode{{Id: "npm://json:9.0.6"}},
 			},
 		},
@@ -136,14 +129,13 @@ func TestBuildDependencyTree(t *testing.T) {
 
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
-			// Build dependency tree
 			params := technologies.BuildInfoBomGeneratorParams{}
-			rootNode, uniqueDeps, err := BuildDependencyTree(*params.SetNpmScope(testCase.depType))
+			rootNode, uniqueDeps, err := BuildDependencyTree(*params.SetNpmScope(testCase.depScope))
 			require.NoError(t, err)
-			// Validations
-			assert.ElementsMatch(t, uniqueDeps, testCase.expectedUniqueDeps, "First is actual, Second is Expected")
+			sort.Slice(uniqueDeps, func(i, j int) bool { return uniqueDeps[i] < uniqueDeps[j] })
+			assert.ElementsMatch(t, uniqueDeps, testCase.expectedUniqueDeps)
 			if assert.Len(t, rootNode, 1) {
-				assert.Equal(t, rootNode[0].Id, testCase.expectedTree.Id)
+				assert.Equal(t, testCase.expectedTree.Id, rootNode[0].Id)
 				if !tests.CompareTree(testCase.expectedTree, rootNode[0]) {
 					t.Error("expected:", testCase.expectedTree.Nodes, "got:", rootNode[0].Nodes)
 				}
@@ -152,25 +144,14 @@ func TestBuildDependencyTree(t *testing.T) {
 	}
 }
 
-func TestInstallProjectIfNeeded(t *testing.T) {
-	_, cleanUp := technologies.CreateTestWorkspace(t, filepath.Join("projects", "package-managers", "npm", "npm-no-lock"))
+func TestEnsureLockfileExisting(t *testing.T) {
+	_, cleanUp := technologies.CreateTestWorkspace(t, filepath.Join("projects", "package-managers", "pnpm", "pnpm-project"))
 	defer cleanUp()
 
-	currentDir, err := coreutils.GetWorkingDirectory()
-	assert.NoError(t, err)
-
 	pnpmExecPath, err := getPnpmExecPath()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
-	dirForDependenciesCalculation, err := installProjectIfNeeded(pnpmExecPath, currentDir)
+	// Workspace already contains pnpm-lock.yaml — ensureLockfile should be a no-op.
+	err = ensureLockfile(pnpmExecPath, ".")
 	assert.NoError(t, err)
-	assert.NotEmpty(t, dirForDependenciesCalculation)
-
-	nodeModulesExist, err := fileutils.IsDirExists(filepath.Join(dirForDependenciesCalculation, "node_modules"), false)
-	assert.NoError(t, err)
-	assert.True(t, nodeModulesExist)
-
-	nodeModulesExist, err = fileutils.IsDirExists(filepath.Join(currentDir, "node_modules"), false)
-	assert.NoError(t, err)
-	assert.False(t, nodeModulesExist)
 }

--- a/sca/bom/buildinfo/technologies/pnpm/pnpm_test.go
+++ b/sca/bom/buildinfo/technologies/pnpm/pnpm_test.go
@@ -155,3 +155,27 @@ func TestEnsureLockfileExisting(t *testing.T) {
 	err = ensureLockfile(pnpmExecPath, ".")
 	assert.NoError(t, err)
 }
+
+func TestValidatePnpmMinVersion(t *testing.T) {
+	testCases := []struct {
+		name        string
+		version     string
+		expectError bool
+	}{
+		{name: "v10 accepted", version: "10.0.0", expectError: false},
+		{name: "v10 minor accepted", version: "10.27.0", expectError: false},
+		{name: "v9 rejected", version: "9.15.0", expectError: true},
+		{name: "v8 rejected", version: "8.15.9", expectError: true},
+		{name: "v11 accepted", version: "11.0.0", expectError: false},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validatePnpmMinVersion(tc.version)
+			if tc.expectError {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}

--- a/sca/bom/buildinfo/technologies/pnpm/pnpmlock.go
+++ b/sca/bom/buildinfo/technologies/pnpm/pnpmlock.go
@@ -1,0 +1,213 @@
+package pnpm
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+// Minimum supported pnpm lockfile version. Versions below this use a different
+// format (flat packages map with no snapshots block) that we do not support.
+const minSupportedLockfileVersion = "6.0"
+
+// pnpmLockFile is the top-level structure of pnpm-lock.yaml.
+type pnpmLockFile struct {
+	LockfileVersion string                         `yaml:"lockfileVersion"`
+	Importers       map[string]pnpmLockImporter    `yaml:"importers"`
+	Snapshots       map[string]pnpmLockSnapshot    `yaml:"snapshots"`
+}
+
+// pnpmLockImporter represents a workspace member (or the root project at ".").
+type pnpmLockImporter struct {
+	Dependencies    map[string]pnpmLockDep `yaml:"dependencies"`
+	DevDependencies map[string]pnpmLockDep `yaml:"devDependencies"`
+}
+
+// pnpmLockDep holds the resolved version for a direct dependency.
+type pnpmLockDep struct {
+	Version string `yaml:"version"`
+}
+
+// pnpmLockSnapshot is one entry in the snapshots block.
+// The key format is "<name>@<version>(<peer1>@<v>)(<peer2>@<v>)..." but we
+// strip the peer suffix when building Xray dependency IDs.
+type pnpmLockSnapshot struct {
+	// Dependencies are keyed by bare package name; values are either a plain
+	// version string or a version+peer-suffix string (e.g. "3.0.5(@foo/bar@1.2)").
+	Dependencies map[string]string `yaml:"dependencies"`
+}
+
+// parsePnpmLockFile reads workingDir/pnpm-lock.yaml and converts it into the
+// same []pnpmLsProject shape that the old `pnpm ls --json` path produced.
+// The name and version for each importer entry are taken from
+// workingDir/<importerPath>/package.json when available; importer paths other
+// than "." are treated as workspace members.
+func parsePnpmLockFile(workingDir string) ([]pnpmLsProject, error) {
+	lockPath := workingDir + "/pnpm-lock.yaml"
+	data, err := os.ReadFile(lockPath)
+	if err != nil {
+		return nil, fmt.Errorf("reading pnpm-lock.yaml: %w", err)
+	}
+
+	var lf pnpmLockFile
+	if err = yaml.Unmarshal(data, &lf); err != nil {
+		return nil, fmt.Errorf("parsing pnpm-lock.yaml: %w", err)
+	}
+
+	if err = validateLockfileVersion(lf.LockfileVersion); err != nil {
+		return nil, err
+	}
+
+	// Root-only project (no importers block) — treat the whole file as a single importer.
+	if len(lf.Importers) == 0 {
+		return nil, fmt.Errorf("pnpm-lock.yaml has no importers block; run 'pnpm install --lockfile-only' first")
+	}
+
+	var projects []pnpmLsProject
+	for importerPath, importer := range lf.Importers {
+		name, version := readPackageNameVersion(workingDir, importerPath)
+		project := pnpmLsProject{
+			Name:    name,
+			Version: version,
+		}
+
+		visited := map[string]bool{}
+		project.Dependencies = buildDepsMap(importer.Dependencies, lf.Snapshots, visited)
+		project.DevDependencies = buildDepsMap(importer.DevDependencies, lf.Snapshots, visited)
+		projects = append(projects, project)
+	}
+	return projects, nil
+}
+
+// buildDepsMap converts a direct-dependency map from the importers block into
+// the nested pnpmLsDependency tree, walking the snapshots block for transitive deps.
+func buildDepsMap(deps map[string]pnpmLockDep, snapshots map[string]pnpmLockSnapshot, visited map[string]bool) map[string]pnpmLsDependency {
+	if len(deps) == 0 {
+		return nil
+	}
+	result := make(map[string]pnpmLsDependency)
+	for name, dep := range deps {
+		// dep.Version may contain a peer-dep suffix: "2.0.0(@peer/dep@1.0.0)"
+		// Strip it for the Xray ID; keep the raw form for snapshot lookup.
+		rawRef := dep.Version
+		_, cleanVersion := splitPnpmRef(rawRef)
+		depKey := buildSnapshotKey(name, rawRef)
+
+		entry := pnpmLsDependency{
+			From:    name,
+			Version: cleanVersion,
+		}
+		if !visited[depKey] {
+			visited[depKey] = true
+			entry.Dependencies = walkSnapshot(depKey, snapshots, visited)
+			visited[depKey] = false // allow same package at different depths
+		}
+		result[name] = entry
+	}
+	return result
+}
+
+// walkSnapshot recursively resolves transitive dependencies from the snapshots block.
+func walkSnapshot(snapshotKey string, snapshots map[string]pnpmLockSnapshot, visited map[string]bool) map[string]pnpmLsDependency {
+	snap, ok := snapshots[snapshotKey]
+	if !ok || len(snap.Dependencies) == 0 {
+		return nil
+	}
+	result := make(map[string]pnpmLsDependency)
+	for name, rawRef := range snap.Dependencies {
+		_, cleanVersion := splitPnpmRef(rawRef)
+		childKey := buildSnapshotKey(name, rawRef)
+		entry := pnpmLsDependency{
+			From:    name,
+			Version: cleanVersion,
+		}
+		if !visited[childKey] {
+			visited[childKey] = true
+			entry.Dependencies = walkSnapshot(childKey, snapshots, visited)
+			visited[childKey] = false
+		}
+		result[name] = entry
+	}
+	return result
+}
+
+// splitPnpmRef splits a pnpm lockfile reference into (name, version).
+// The reference may be either a snapshot key like "@scope/pkg@2.0.0(@peer@1.0)"
+// or a plain version string like "2.0.0(@peer@1.0)".
+// In both cases the peer-dep suffix (everything from the first '(' onward) is stripped.
+// The split is always on the LAST '@' so scoped names like "@scope/pkg" are handled correctly.
+func splitPnpmRef(ref string) (name, version string) {
+	// Strip peer-dep suffix.
+	if i := strings.IndexByte(ref, '('); i >= 0 {
+		ref = ref[:i]
+	}
+	i := strings.LastIndexByte(ref, '@')
+	if i <= 0 {
+		// No '@' or starts with '@' but has no version — treat the whole thing as a version.
+		return "", ref
+	}
+	return ref[:i], ref[i+1:]
+}
+
+// buildSnapshotKey constructs the key used to look up an entry in the snapshots map.
+// pnpm stores snapshots under the full "<name>@<version>(<peers>)" key, so we need
+// to combine the package name with its raw (possibly peer-suffixed) version ref.
+// For plain version strings (no name in the ref) the name is prepended.
+func buildSnapshotKey(name, rawRef string) string {
+	// If rawRef already contains an '@' after the first character (i.e. it's a full
+	// "<name>@<version>..." key rather than a bare version), use it as-is.
+	if strings.Count(rawRef, "@") >= 1 && !strings.HasPrefix(rawRef, "@") {
+		return name + "@" + rawRef
+	}
+	// Scoped packages (@scope/pkg) always start with '@'; their version refs look like
+	// "2.0.0" or "2.0.0(@peer@1.0)" — never "<name>@<version>".
+	if strings.HasPrefix(rawRef, "@") {
+		// rawRef is itself a full scoped key e.g. "@scope/pkg@2.0.0(@peer@1.0)"
+		return rawRef
+	}
+	return name + "@" + rawRef
+}
+
+// readPackageNameVersion reads name and version from the package.json at
+// workingDir/<importerPath>/package.json. Falls back to the importer path as
+// the name and "0.0.0" as the version if the file is absent or unreadable.
+func readPackageNameVersion(workingDir, importerPath string) (name, version string) {
+	dir := workingDir
+	if importerPath != "." {
+		dir = workingDir + "/" + importerPath
+	}
+	data, err := os.ReadFile(dir + "/package.json")
+	if err != nil {
+		return importerPath, "0.0.0"
+	}
+	// Minimal JSON extraction — avoid a full unmarshal dependency just for two fields.
+	var pkg struct {
+		Name    string `json:"name"`
+		Version string `json:"version"`
+	}
+	// Use yaml decoder as a light JSON superset parser (json is valid yaml).
+	if err = yaml.Unmarshal(data, &pkg); err != nil || pkg.Name == "" {
+		return importerPath, "0.0.0"
+	}
+	if pkg.Version == "" {
+		pkg.Version = "0.0.0"
+	}
+	return pkg.Name, pkg.Version
+}
+
+// validateLockfileVersion rejects lockfile versions older than minSupportedLockfileVersion.
+// pnpm v5 used "5.x" and had a different flat format; v6+ uses the current structure.
+func validateLockfileVersion(v string) error {
+	// Strip surrounding quotes if present (pnpm 9 writes lockfileVersion: '9.0').
+	v = strings.Trim(v, "'\"")
+	if v == "" {
+		return fmt.Errorf("pnpm-lock.yaml is missing lockfileVersion; run 'pnpm install --lockfile-only' to regenerate")
+	}
+	// Only reject clearly old formats (5.x). Anything >= 6.0 shares the same structure.
+	if strings.HasPrefix(v, "5.") {
+		return fmt.Errorf("pnpm-lock.yaml lockfileVersion %q requires pnpm v6 or later to parse; please upgrade pnpm and re-run 'pnpm install --lockfile-only'", v)
+	}
+	return nil
+}

--- a/sca/bom/buildinfo/technologies/pnpm/pnpmlock.go
+++ b/sca/bom/buildinfo/technologies/pnpm/pnpmlock.go
@@ -1,33 +1,34 @@
 package pnpm
 
 import (
+	"encoding/json"
 	"fmt"
 	"os"
+	"path/filepath"
+	"strconv"
 	"strings"
 
 	"gopkg.in/yaml.v3"
 )
 
-// Minimum supported pnpm lockfile version. Versions below this use a different
-// format (flat packages map with no snapshots block) that we do not support.
-const minSupportedLockfileVersion = "6.0"
-
 // pnpmLockFile is the top-level structure of pnpm-lock.yaml.
 type pnpmLockFile struct {
-	LockfileVersion string                         `yaml:"lockfileVersion"`
-	Importers       map[string]pnpmLockImporter    `yaml:"importers"`
-	Snapshots       map[string]pnpmLockSnapshot    `yaml:"snapshots"`
+	LockfileVersion string                      `yaml:"lockfileVersion"`
+	Importers       map[string]pnpmLockImporter `yaml:"importers"`
+	Snapshots       map[string]pnpmLockSnapshot `yaml:"snapshots"`
 }
 
 // pnpmLockImporter represents a workspace member (or the root project at ".").
 type pnpmLockImporter struct {
-	Dependencies    map[string]pnpmLockDep `yaml:"dependencies"`
-	DevDependencies map[string]pnpmLockDep `yaml:"devDependencies"`
+	Dependencies         map[string]pnpmLockDep `yaml:"dependencies"`
+	DevDependencies      map[string]pnpmLockDep `yaml:"devDependencies"`
+	OptionalDependencies map[string]pnpmLockDep `yaml:"optionalDependencies"`
 }
 
-// pnpmLockDep holds the resolved version for a direct dependency.
+// pnpmLockDep holds the resolved version and original specifier for a direct dependency.
 type pnpmLockDep struct {
-	Version string `yaml:"version"`
+	Specifier string `yaml:"specifier"`
+	Version   string `yaml:"version"`
 }
 
 // pnpmLockSnapshot is one entry in the snapshots block.
@@ -39,13 +40,17 @@ type pnpmLockSnapshot struct {
 	Dependencies map[string]string `yaml:"dependencies"`
 }
 
-// parsePnpmLockFile reads workingDir/pnpm-lock.yaml and converts it into the
-// same []pnpmLsProject shape that the old `pnpm ls --json` path produced.
-// The name and version for each importer entry are taken from
-// workingDir/<importerPath>/package.json when available; importer paths other
-// than "." are treated as workspace members.
-func parsePnpmLockFile(workingDir string) ([]pnpmLsProject, error) {
-	lockPath := workingDir + "/pnpm-lock.yaml"
+// parsePnpmLockFile reads workingDir/pnpm-lock.yaml and converts it into []pnpmLsProject,
+// scoped by importer:
+//   - importer "." (or "") collapses the whole workspace into a single project rooted at
+//     the "." importer, with each member attached as a direct dependency — mirroring how
+//     npm records root→workspace edges, so a root-level `jf ca` audits the whole workspace.
+//   - a member importer (e.g. "packages/app") returns only that member as its own project,
+//     used when `jf ca --working-dirs=<member>` targets a single workspace package.
+//
+// Names/versions come from each importer's package.json when available.
+func parsePnpmLockFile(workingDir, importer string) ([]pnpmLsProject, error) {
+	lockPath := filepath.Join(workingDir, "pnpm-lock.yaml")
 	data, err := os.ReadFile(lockPath)
 	if err != nil {
 		return nil, fmt.Errorf("reading pnpm-lock.yaml: %w", err)
@@ -60,25 +65,79 @@ func parsePnpmLockFile(workingDir string) ([]pnpmLsProject, error) {
 		return nil, err
 	}
 
-	// Root-only project (no importers block) — treat the whole file as a single importer.
 	if len(lf.Importers) == 0 {
 		return nil, fmt.Errorf("pnpm-lock.yaml has no importers block; run 'pnpm install --lockfile-only' first")
 	}
 
-	var projects []pnpmLsProject
-	for importerPath, importer := range lf.Importers {
-		name, version := readPackageNameVersion(workingDir, importerPath)
-		project := pnpmLsProject{
-			Name:    name,
-			Version: version,
-		}
-
-		visited := map[string]bool{}
-		project.Dependencies = buildDepsMap(importer.Dependencies, lf.Snapshots, visited)
-		project.DevDependencies = buildDepsMap(importer.DevDependencies, lf.Snapshots, visited)
-		projects = append(projects, project)
+	if importer != "" && importer != "." {
+		return parseSingleImporter(workingDir, importer, lf)
 	}
-	return projects, nil
+
+	rootName, rootVersion := readPackageNameVersion(workingDir, ".")
+	root := pnpmLsProject{Name: rootName, Version: rootVersion}
+	if rootImporter, ok := lf.Importers["."]; ok {
+		visited := map[string]bool{}
+		root.Dependencies = buildProdDepsMap(rootImporter, lf.Snapshots, visited)
+		root.DevDependencies = buildDepsMap(rootImporter.DevDependencies, lf.Snapshots, visited)
+	}
+
+	// Nest every workspace member (any importer other than ".") as a direct dependency
+	// of the root so the whole workspace is audited under a single npm-like tree.
+	for importerPath, importer := range lf.Importers {
+		if importerPath == "." {
+			continue
+		}
+		memberName, memberVersion := readPackageNameVersion(workingDir, importerPath)
+		visited := map[string]bool{}
+		memberDeps := buildProdDepsMap(importer, lf.Snapshots, visited)
+		for depName, dep := range buildDepsMap(importer.DevDependencies, lf.Snapshots, visited) {
+			if memberDeps == nil {
+				memberDeps = map[string]pnpmLsDependency{}
+			}
+			memberDeps[depName] = dep
+		}
+		if root.Dependencies == nil {
+			root.Dependencies = map[string]pnpmLsDependency{}
+		}
+		root.Dependencies[memberName] = pnpmLsDependency{
+			From:         memberName,
+			Version:      memberVersion,
+			Dependencies: memberDeps,
+			Local:        true,
+		}
+	}
+	return []pnpmLsProject{root}, nil
+}
+
+// buildProdDepsMap merges an importer's regular and optional dependencies into one
+// production dependency map. pnpm installs optionalDependencies by default (when the
+// platform matches), so curation must evaluate them alongside regular dependencies.
+func buildProdDepsMap(imp pnpmLockImporter, snapshots map[string]pnpmLockSnapshot, visited map[string]bool) map[string]pnpmLsDependency {
+	prod := buildDepsMap(imp.Dependencies, snapshots, visited)
+	for name, dep := range buildDepsMap(imp.OptionalDependencies, snapshots, visited) {
+		if prod == nil {
+			prod = map[string]pnpmLsDependency{}
+		}
+		prod[name] = dep
+	}
+	return prod
+}
+
+// parseSingleImporter returns only the given workspace member as its own project (its
+// own deps and devDeps, with transitives), used when a run is scoped to one member via
+// --working-dirs. The member is the tree root here, so it is skipped from the curation
+// HEAD-check the same way any project root is.
+func parseSingleImporter(workingDir, importerPath string, lf pnpmLockFile) ([]pnpmLsProject, error) {
+	imp, ok := lf.Importers[importerPath]
+	if !ok {
+		return nil, fmt.Errorf("pnpm workspace member %q is not recorded in pnpm-lock.yaml; run 'pnpm install --lockfile-only' to refresh it", importerPath)
+	}
+	name, version := readPackageNameVersion(workingDir, importerPath)
+	project := pnpmLsProject{Name: name, Version: version}
+	visited := map[string]bool{}
+	project.Dependencies = buildProdDepsMap(imp, lf.Snapshots, visited)
+	project.DevDependencies = buildDepsMap(imp.DevDependencies, lf.Snapshots, visited)
+	return []pnpmLsProject{project}, nil
 }
 
 // buildDepsMap converts a direct-dependency map from the importers block into
@@ -133,38 +192,29 @@ func walkSnapshot(snapshotKey string, snapshots map[string]pnpmLockSnapshot, vis
 	return result
 }
 
-// splitPnpmRef splits a pnpm lockfile reference into (name, version).
-// The reference may be either a snapshot key like "@scope/pkg@2.0.0(@peer@1.0)"
-// or a plain version string like "2.0.0(@peer@1.0)".
-// In both cases the peer-dep suffix (everything from the first '(' onward) is stripped.
-// The split is always on the LAST '@' so scoped names like "@scope/pkg" are handled correctly.
+// splitPnpmRef splits a pnpm ref into (name, version), stripping any peer-dep suffix.
+// Splits on the last '@' so scoped names like "@scope/pkg" are handled correctly.
 func splitPnpmRef(ref string) (name, version string) {
-	// Strip peer-dep suffix.
 	if i := strings.IndexByte(ref, '('); i >= 0 {
 		ref = ref[:i]
 	}
 	i := strings.LastIndexByte(ref, '@')
 	if i <= 0 {
-		// No '@' or starts with '@' but has no version — treat the whole thing as a version.
 		return "", ref
 	}
 	return ref[:i], ref[i+1:]
 }
 
-// buildSnapshotKey constructs the key used to look up an entry in the snapshots map.
-// pnpm stores snapshots under the full "<name>@<version>(<peers>)" key, so we need
-// to combine the package name with its raw (possibly peer-suffixed) version ref.
-// For plain version strings (no name in the ref) the name is prepended.
+// buildSnapshotKey returns the snapshots-map key for a dependency. rawRef is usually a
+// bare version, giving "<name>@<rawRef>". For an aliased dep ("npm:<target>@<range>"),
+// rawRef is the target ref (e.g. "@babel/code-frame@7.29.7") which is itself the key, so
+// it is returned as-is — detected by '@' in the version part (ignoring the peer suffix).
 func buildSnapshotKey(name, rawRef string) string {
-	// If rawRef already contains an '@' after the first character (i.e. it's a full
-	// "<name>@<version>..." key rather than a bare version), use it as-is.
-	if strings.Count(rawRef, "@") >= 1 && !strings.HasPrefix(rawRef, "@") {
-		return name + "@" + rawRef
+	base := rawRef
+	if i := strings.IndexByte(base, '('); i >= 0 {
+		base = base[:i]
 	}
-	// Scoped packages (@scope/pkg) always start with '@'; their version refs look like
-	// "2.0.0" or "2.0.0(@peer@1.0)" — never "<name>@<version>".
-	if strings.HasPrefix(rawRef, "@") {
-		// rawRef is itself a full scoped key e.g. "@scope/pkg@2.0.0(@peer@1.0)"
+	if strings.Contains(base, "@") {
 		return rawRef
 	}
 	return name + "@" + rawRef
@@ -176,19 +226,17 @@ func buildSnapshotKey(name, rawRef string) string {
 func readPackageNameVersion(workingDir, importerPath string) (name, version string) {
 	dir := workingDir
 	if importerPath != "." {
-		dir = workingDir + "/" + importerPath
+		dir = filepath.Join(workingDir, importerPath)
 	}
-	data, err := os.ReadFile(dir + "/package.json")
+	data, err := os.ReadFile(filepath.Join(dir, "package.json"))
 	if err != nil {
 		return importerPath, "0.0.0"
 	}
-	// Minimal JSON extraction — avoid a full unmarshal dependency just for two fields.
 	var pkg struct {
 		Name    string `json:"name"`
 		Version string `json:"version"`
 	}
-	// Use yaml decoder as a light JSON superset parser (json is valid yaml).
-	if err = yaml.Unmarshal(data, &pkg); err != nil || pkg.Name == "" {
+	if err = json.Unmarshal(data, &pkg); err != nil || pkg.Name == "" {
 		return importerPath, "0.0.0"
 	}
 	if pkg.Version == "" {
@@ -197,17 +245,76 @@ func readPackageNameVersion(workingDir, importerPath string) (name, version stri
 	return pkg.Name, pkg.Version
 }
 
-// validateLockfileVersion rejects lockfile versions older than minSupportedLockfileVersion.
-// pnpm v5 used "5.x" and had a different flat format; v6+ uses the current structure.
+// lockfileSpecifiersDrift reports whether workingDir's package.json declares a
+// different set of direct-dependency specifiers than its pnpm-lock.yaml records —
+// covering added, removed, and changed specifiers. jf ca operates on the given
+// directory, whose lockfile records that project under the "." importer, so the
+// comparison is against "." only. Returns false on any read/parse error so the
+// caller falls back to mtime-only.
+func lockfileSpecifiersDrift(workingDir, lockPath string) bool {
+	pkgData, err := os.ReadFile(filepath.Join(workingDir, "package.json"))
+	if err != nil {
+		return false
+	}
+	var pkg struct {
+		Dependencies         map[string]string `json:"dependencies"`
+		DevDependencies      map[string]string `json:"devDependencies"`
+		OptionalDependencies map[string]string `json:"optionalDependencies"`
+	}
+	if err = json.Unmarshal(pkgData, &pkg); err != nil {
+		return false
+	}
+
+	lockData, err := os.ReadFile(lockPath)
+	if err != nil {
+		return false
+	}
+	var lf pnpmLockFile
+	if err = yaml.Unmarshal(lockData, &lf); err != nil {
+		return false
+	}
+
+	rootImporter, ok := lf.Importers["."]
+	if !ok {
+		return false
+	}
+	return specifiersDiffer(pkg.Dependencies, rootImporter.Dependencies) ||
+		specifiersDiffer(pkg.DevDependencies, rootImporter.DevDependencies) ||
+		specifiersDiffer(pkg.OptionalDependencies, rootImporter.OptionalDependencies)
+}
+
+// specifiersDiffer reports whether the package.json dependency specifiers differ
+// from the lockfile importer entry in EITHER direction — a differing count catches
+// added or removed deps, and the per-name check catches changed or missing specifiers.
+func specifiersDiffer(pkgDeps map[string]string, lockDeps map[string]pnpmLockDep) bool {
+	if len(pkgDeps) != len(lockDeps) {
+		return true
+	}
+	for name, specifier := range pkgDeps {
+		lockDep, ok := lockDeps[name]
+		if !ok || lockDep.Specifier != specifier {
+			return true
+		}
+	}
+	return false
+}
+
+// validateLockfileVersion accepts only lockfileVersion 9.0+, which introduced the
+// 'snapshots' block this parser reads. Older formats (5.x–8.x) use a differently-shaped
+// 'packages' block and would yield an empty snapshots map, silently dropping transitives.
 func validateLockfileVersion(v string) error {
 	// Strip surrounding quotes if present (pnpm 9 writes lockfileVersion: '9.0').
 	v = strings.Trim(v, "'\"")
 	if v == "" {
 		return fmt.Errorf("pnpm-lock.yaml is missing lockfileVersion; run 'pnpm install --lockfile-only' to regenerate")
 	}
-	// Only reject clearly old formats (5.x). Anything >= 6.0 shares the same structure.
-	if strings.HasPrefix(v, "5.") {
-		return fmt.Errorf("pnpm-lock.yaml lockfileVersion %q requires pnpm v6 or later to parse; please upgrade pnpm and re-run 'pnpm install --lockfile-only'", v)
+	major, _, _ := strings.Cut(v, ".")
+	majorNum, err := strconv.Atoi(major)
+	if err != nil {
+		return fmt.Errorf("pnpm-lock.yaml has an unrecognized lockfileVersion %q; run 'pnpm install --lockfile-only' to regenerate", v)
+	}
+	if majorNum < 9 {
+		return fmt.Errorf("pnpm-lock.yaml lockfileVersion %q is not supported (only 9.0 and later, written by pnpm 9/10, are parseable); run 'pnpm install --lockfile-only' with pnpm %d to regenerate", v, supportedPnpmMajorVersion)
 	}
 	return nil
 }

--- a/sca/bom/buildinfo/technologies/pnpm/pnpmlock_test.go
+++ b/sca/bom/buildinfo/technologies/pnpm/pnpmlock_test.go
@@ -24,7 +24,7 @@ func testdataDir(t *testing.T) string {
 // TestParsePnpmLockFileSimple exercises the simple fixture (two top-level deps, no transitives).
 func TestParsePnpmLockFileSimple(t *testing.T) {
 	dir := testdataDir(t)
-	projects, err := parsePnpmLockFile(dir)
+	projects, err := parsePnpmLockFile(dir, ".")
 	require.NoError(t, err)
 	require.Len(t, projects, 1)
 
@@ -50,10 +50,10 @@ func TestParsePnpmLockFileComplex(t *testing.T) {
 	complexContent, readErr := os.ReadFile(complexLock)
 	require.NoError(t, readErr)
 
-	require.NoError(t, os.WriteFile(simpleLock, complexContent, 0644))
-	t.Cleanup(func() { _ = os.WriteFile(simpleLock, origContent, 0644) })
+	require.NoError(t, os.WriteFile(filepath.Clean(simpleLock), complexContent, 0644))    // #nosec G703 -- simpleLock is constructed from a test-controlled directory, not user input
+	t.Cleanup(func() { _ = os.WriteFile(filepath.Clean(simpleLock), origContent, 0644) }) // #nosec G703 -- simpleLock is constructed from a test-controlled directory, not user input
 
-	projects, err := parsePnpmLockFile(dir)
+	projects, err := parsePnpmLockFile(dir, ".")
 	require.NoError(t, err)
 	require.Len(t, projects, 1)
 
@@ -82,6 +82,89 @@ func TestParsePnpmLockFileComplex(t *testing.T) {
 	assert.Equal(t, "9.0.6", p.DevDependencies["json"].Version)
 }
 
+// TestParsePnpmLockFileOptionalDependencies ensures optionalDependencies (e.g. sharp,
+// fsevents) are curated as production dependencies, not silently dropped.
+func TestParsePnpmLockFileOptionalDependencies(t *testing.T) {
+	dir := t.TempDir()
+	lock := "lockfileVersion: '9.0'\n" +
+		"importers:\n" +
+		"  .:\n" +
+		"    dependencies:\n" +
+		"      xml:\n" +
+		"        specifier: 1.0.1\n" +
+		"        version: 1.0.1\n" +
+		"    optionalDependencies:\n" +
+		"      fsevents:\n" +
+		"        specifier: ^2.3.3\n" +
+		"        version: 2.3.3\n" +
+		"snapshots:\n" +
+		"  xml@1.0.1: {}\n" +
+		"  fsevents@2.3.3: {}\n"
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "pnpm-lock.yaml"), []byte(lock), 0o644))
+
+	projects, err := parsePnpmLockFile(dir, ".")
+	require.NoError(t, err)
+	require.Len(t, projects, 1)
+
+	deps := projects[0].Dependencies
+	require.Contains(t, deps, "xml")
+	require.Contains(t, deps, "fsevents", "optionalDependencies must be curated as prod deps")
+	assert.Equal(t, "2.3.3", deps["fsevents"].Version)
+}
+
+func viteFixtureDir(t *testing.T) string {
+	t.Helper()
+	dir, err := filepath.Abs("../../../../..")
+	require.NoError(t, err)
+	return filepath.Join(dir, "tests", "testdata", "projects", "package-managers", "pnpm", "vite")
+}
+
+// TestParsePnpmLockFileVite is a smoke test using a trimmed copy of vitejs/vite's
+// pnpm-lock.yaml. The fixture carries top-level blocks absent from the hand-crafted
+// fixtures (patchedDependencies, overrides, packageExtensionsChecksum), so it would
+// catch a regression such as switching to strict YAML decoding (KnownFields(true)).
+// The fixture has 3 importers (root ".", packages/vite, packages/create-vite); they
+// are collapsed into a single root project with the two members nested as direct
+// dependencies, mirroring npm's whole-workspace-at-root behaviour.
+func TestParsePnpmLockFileVite(t *testing.T) {
+	projects, err := parsePnpmLockFile(viteFixtureDir(t), ".")
+	require.NoError(t, err)
+	require.Len(t, projects, 1)
+
+	root := projects[0]
+	// Root's own devDependencies are preserved.
+	assert.Contains(t, root.DevDependencies, "@types/node")
+	assert.Contains(t, root.DevDependencies, "eslint")
+
+	// Each workspace member is nested under the root as a direct dependency, with its
+	// own deps (prod + dev merged) carried in the member node.
+	require.Contains(t, root.Dependencies, "packages/vite")
+	assert.Contains(t, root.Dependencies["packages/vite"].Dependencies, "rolldown")
+	require.Contains(t, root.Dependencies, "packages/create-vite")
+	assert.Contains(t, root.Dependencies["packages/create-vite"].Dependencies, "cross-spawn")
+}
+
+// TestParsePnpmLockFileMemberScope verifies that scoping to a single member importer
+// returns only that member's dependencies (not the root's or other members'), used when
+// `jf ca --working-dirs=<member>` targets one workspace package.
+func TestParsePnpmLockFileMemberScope(t *testing.T) {
+	projects, err := parsePnpmLockFile(viteFixtureDir(t), "packages/vite")
+	require.NoError(t, err)
+	require.Len(t, projects, 1)
+
+	member := projects[0]
+	// Only the member's own dependency is present.
+	require.Contains(t, member.Dependencies, "rolldown")
+	// The root's and sibling member's deps must NOT leak into the scoped result.
+	assert.NotContains(t, member.Dependencies, "eslint")
+	assert.NotContains(t, member.DevDependencies, "eslint")
+	assert.NotContains(t, member.Dependencies, "cross-spawn")
+
+	// An unknown importer is reported clearly rather than silently returning everything.
+	_, err = parsePnpmLockFile(viteFixtureDir(t), "packages/does-not-exist")
+	assert.Error(t, err)
+}
+
 // TestSplitPnpmRef checks peer-suffix stripping and scoped name handling.
 func TestSplitPnpmRef(t *testing.T) {
 	tests := []struct {
@@ -101,25 +184,99 @@ func TestSplitPnpmRef(t *testing.T) {
 	}
 }
 
-// TestValidateLockfileVersion ensures old lockfile versions are rejected and modern ones accepted.
+// TestValidateLockfileVersion ensures only lockfileVersion 9.0+ (the 'snapshots'
+// format this parser understands) is accepted, and older formats are rejected
+// rather than silently yielding an incomplete dependency tree.
 func TestValidateLockfileVersion(t *testing.T) {
-	assert.NoError(t, validateLockfileVersion("6.0"))
-	assert.NoError(t, validateLockfileVersion("'6.0'"))
+	// Accepted: 9.0 and later (pnpm 9/10 'snapshots' format).
 	assert.NoError(t, validateLockfileVersion("9.0"))
 	assert.NoError(t, validateLockfileVersion("'9.0'"))
+	assert.NoError(t, validateLockfileVersion("10.0"))
+	// Rejected: 5.x–8.x use a differently-shaped 'packages' block.
 	assert.Error(t, validateLockfileVersion("5.4"))
+	assert.Error(t, validateLockfileVersion("6.0"))
+	assert.Error(t, validateLockfileVersion("'6.0'"))
+	assert.Error(t, validateLockfileVersion("8.0"))
+	// Rejected: missing or unparsable.
 	assert.Error(t, validateLockfileVersion(""))
+	assert.Error(t, validateLockfileVersion("abc"))
 }
 
-// TestBuildSnapshotKey checks that scoped and non-scoped package references
-// produce the correct snapshot lookup key.
+// TestBuildSnapshotKey covers plain, scoped, and aliased refs. Aliased cases mirror
+// real pnpm 10 output: the alias target ref is itself the key and must be used as-is.
 func TestBuildSnapshotKey(t *testing.T) {
-	// Plain version (most common in importers block).
 	assert.Equal(t, "xml@1.0.1", buildSnapshotKey("xml", "1.0.1"))
-	// Scoped package with plain version.
 	assert.Equal(t, "@scope/pkg@2.0.0", buildSnapshotKey("@scope/pkg", "2.0.0"))
-	// Scoped package with peer-dep suffix (common for peer-requiring packages).
 	assert.Equal(t, "@scope/pkg@2.0.0(@peer/dep@1.0.0)", buildSnapshotKey("@scope/pkg", "2.0.0(@peer/dep@1.0.0)"))
-	// Non-scoped package with peer-dep suffix from a snapshot's dependencies map.
 	assert.Equal(t, "transitive-a@1.2.3", buildSnapshotKey("transitive-a", "1.2.3"))
+	// Aliased scoped target: "my-babel": "npm:@babel/code-frame@^7".
+	assert.Equal(t, "@babel/code-frame@7.29.7", buildSnapshotKey("my-babel", "@babel/code-frame@7.29.7"))
+	// Aliased unscoped target: "my-lodash": "npm:lodash.merge@^4".
+	assert.Equal(t, "lodash.merge@4.6.2", buildSnapshotKey("my-lodash", "lodash.merge@4.6.2"))
+	assert.Equal(t, "@babel/code-frame@7.29.7(react@18.0.0)", buildSnapshotKey("my-babel", "@babel/code-frame@7.29.7(react@18.0.0)"))
+}
+
+// TestSpecifiersDiffer verifies bidirectional specifier comparison: added, removed,
+// and changed deps all count as drift, while a matching set does not.
+func TestSpecifiersDiffer(t *testing.T) {
+	lock := map[string]pnpmLockDep{"xml": {Specifier: "1.0.1"}, "json": {Specifier: "9.0.6"}}
+
+	assert.False(t, specifiersDiffer(map[string]string{"xml": "1.0.1", "json": "9.0.6"}, lock), "identical sets must not drift")
+	assert.True(t, specifiersDiffer(map[string]string{"xml": "2.0.0", "json": "9.0.6"}, lock), "changed specifier must drift")
+	assert.True(t, specifiersDiffer(map[string]string{"xml": "1.0.1"}, lock), "removed dep (lock has extra) must drift")
+	assert.True(t, specifiersDiffer(map[string]string{"xml": "1.0.1", "json": "9.0.6", "extra": "1.0.0"}, lock), "added dep must drift")
+	assert.True(t, specifiersDiffer(map[string]string{"xml": "1.0.1", "other": "9.0.6"}, lock), "same count, renamed dep must drift")
+	assert.False(t, specifiersDiffer(nil, nil), "both empty must not drift")
+}
+
+// TestLockfileSpecifiersDrift exercises the file-level drift check on the directory's
+// own lockfile ("." importer), including the removed-dependency case.
+func TestLockfileSpecifiersDrift(t *testing.T) {
+	writeProject := func(t *testing.T, pkgJSON, lock string) (dir, lockPath string) {
+		t.Helper()
+		dir = t.TempDir()
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "package.json"), []byte(pkgJSON), 0o644))
+		lockPath = filepath.Join(dir, "pnpm-lock.yaml")
+		require.NoError(t, os.WriteFile(lockPath, []byte(lock), 0o644))
+		return dir, lockPath
+	}
+
+	t.Run("in sync — no drift", func(t *testing.T) {
+		dir, lockPath := writeProject(t,
+			`{"dependencies":{"xml":"1.0.1"}}`,
+			"lockfileVersion: '9.0'\nimporters:\n  .:\n    dependencies:\n      xml:\n        specifier: 1.0.1\n        version: 1.0.1\nsnapshots: {}\n")
+		assert.False(t, lockfileSpecifiersDrift(dir, lockPath))
+	})
+
+	t.Run("removed dep still in lockfile — drift", func(t *testing.T) {
+		dir, lockPath := writeProject(t,
+			`{"dependencies":{"xml":"1.0.1"}}`,
+			"lockfileVersion: '9.0'\nimporters:\n  .:\n    dependencies:\n      xml:\n        specifier: 1.0.1\n        version: 1.0.1\n      json:\n        specifier: 9.0.6\n        version: 9.0.6\nsnapshots: {}\n")
+		assert.True(t, lockfileSpecifiersDrift(dir, lockPath))
+	})
+
+	t.Run("added dep not yet in lockfile — drift", func(t *testing.T) {
+		dir, lockPath := writeProject(t,
+			`{"dependencies":{"xml":"1.0.1","json":"9.0.6"}}`,
+			"lockfileVersion: '9.0'\nimporters:\n  .:\n    dependencies:\n      xml:\n        specifier: 1.0.1\n        version: 1.0.1\nsnapshots: {}\n")
+		assert.True(t, lockfileSpecifiersDrift(dir, lockPath))
+	})
+
+	t.Run("changed specifier — drift", func(t *testing.T) {
+		dir, lockPath := writeProject(t,
+			`{"dependencies":{"xml":"2.0.0"}}`,
+			"lockfileVersion: '9.0'\nimporters:\n  .:\n    dependencies:\n      xml:\n        specifier: 1.0.1\n        version: 1.0.1\nsnapshots: {}\n")
+		assert.True(t, lockfileSpecifiersDrift(dir, lockPath))
+	})
+
+	t.Run("added optional dep not yet in lockfile — drift", func(t *testing.T) {
+		dir, lockPath := writeProject(t,
+			`{"dependencies":{"xml":"1.0.1"},"optionalDependencies":{"fsevents":"^2.3.3"}}`,
+			"lockfileVersion: '9.0'\nimporters:\n  .:\n    dependencies:\n      xml:\n        specifier: 1.0.1\n        version: 1.0.1\nsnapshots: {}\n")
+		assert.True(t, lockfileSpecifiersDrift(dir, lockPath))
+	})
+
+	t.Run("read error returns false", func(t *testing.T) {
+		assert.False(t, lockfileSpecifiersDrift(t.TempDir(), filepath.Join(t.TempDir(), "missing.yaml")))
+	})
 }

--- a/sca/bom/buildinfo/technologies/pnpm/pnpmlock_test.go
+++ b/sca/bom/buildinfo/technologies/pnpm/pnpmlock_test.go
@@ -1,0 +1,125 @@
+package pnpm
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// fixtureDir is relative to the repository root; in tests we use
+// technologies.CreateTestWorkspace to cd into the fixture, but for pure parser
+// tests we want to read files without changing the working directory.
+func testdataDir(t *testing.T) string {
+	t.Helper()
+	// Walk up until we find the go.mod root, then descend into testdata.
+	// Assumes tests run from within the module tree.
+	dir, err := filepath.Abs("../../../../..")
+	require.NoError(t, err)
+	return filepath.Join(dir, "tests", "testdata", "projects", "package-managers", "pnpm", "pnpm-project")
+}
+
+// TestParsePnpmLockFileSimple exercises the simple fixture (two top-level deps, no transitives).
+func TestParsePnpmLockFileSimple(t *testing.T) {
+	dir := testdataDir(t)
+	projects, err := parsePnpmLockFile(dir)
+	require.NoError(t, err)
+	require.Len(t, projects, 1)
+
+	p := projects[0]
+	assert.Equal(t, "pnpm-example", p.Name)
+	assert.Equal(t, "1.0.0", p.Version)
+
+	require.Contains(t, p.Dependencies, "xml")
+	assert.Equal(t, "1.0.1", p.Dependencies["xml"].Version)
+
+	require.Contains(t, p.DevDependencies, "json")
+	assert.Equal(t, "9.0.6", p.DevDependencies["json"].Version)
+}
+
+// TestParsePnpmLockFileComplex tests scoped packages, peer-dep suffixes, and transitives.
+func TestParsePnpmLockFileComplex(t *testing.T) {
+	dir := testdataDir(t)
+	// Swap the simple lockfile for the complex one temporarily.
+	simpleLock := filepath.Join(dir, "pnpm-lock.yaml")
+	complexLock := filepath.Join(dir, "pnpm-lock-complex.yaml")
+	origContent, readErr := os.ReadFile(simpleLock)
+	require.NoError(t, readErr)
+	complexContent, readErr := os.ReadFile(complexLock)
+	require.NoError(t, readErr)
+
+	require.NoError(t, os.WriteFile(simpleLock, complexContent, 0644))
+	t.Cleanup(func() { _ = os.WriteFile(simpleLock, origContent, 0644) })
+
+	projects, err := parsePnpmLockFile(dir)
+	require.NoError(t, err)
+	require.Len(t, projects, 1)
+
+	p := projects[0]
+	assert.Equal(t, "pnpm-example", p.Name)
+	assert.Equal(t, "1.0.0", p.Version)
+
+	// prod: xml (no transitives)
+	require.Contains(t, p.Dependencies, "xml")
+	assert.Equal(t, "1.0.1", p.Dependencies["xml"].Version)
+	assert.Empty(t, p.Dependencies["xml"].Dependencies)
+
+	// prod: @scope/pkg — peer suffix stripped from version
+	require.Contains(t, p.Dependencies, "@scope/pkg")
+	scopedPkg := p.Dependencies["@scope/pkg"]
+	assert.Equal(t, "2.0.0", scopedPkg.Version, "peer-dep suffix must be stripped from version")
+
+	// @scope/pkg has two transitive deps: @peer/dep and transitive-a
+	require.Contains(t, scopedPkg.Dependencies, "@peer/dep")
+	assert.Equal(t, "1.0.0", scopedPkg.Dependencies["@peer/dep"].Version)
+	require.Contains(t, scopedPkg.Dependencies, "transitive-a")
+	assert.Equal(t, "1.2.3", scopedPkg.Dependencies["transitive-a"].Version)
+
+	// dev: json
+	require.Contains(t, p.DevDependencies, "json")
+	assert.Equal(t, "9.0.6", p.DevDependencies["json"].Version)
+}
+
+// TestSplitPnpmRef checks peer-suffix stripping and scoped name handling.
+func TestSplitPnpmRef(t *testing.T) {
+	tests := []struct {
+		input       string
+		wantName    string
+		wantVersion string
+	}{
+		{"1.0.1", "", "1.0.1"},
+		{"2.0.0(@peer/dep@1.0.0)", "", "2.0.0"},
+		{"@scope/pkg@2.0.0(@peer@1.0)", "@scope/pkg", "2.0.0"},
+		{"xml@1.0.1", "xml", "1.0.1"},
+	}
+	for _, tc := range tests {
+		name, version := splitPnpmRef(tc.input)
+		assert.Equal(t, tc.wantName, name, "name for %q", tc.input)
+		assert.Equal(t, tc.wantVersion, version, "version for %q", tc.input)
+	}
+}
+
+// TestValidateLockfileVersion ensures old lockfile versions are rejected and modern ones accepted.
+func TestValidateLockfileVersion(t *testing.T) {
+	assert.NoError(t, validateLockfileVersion("6.0"))
+	assert.NoError(t, validateLockfileVersion("'6.0'"))
+	assert.NoError(t, validateLockfileVersion("9.0"))
+	assert.NoError(t, validateLockfileVersion("'9.0'"))
+	assert.Error(t, validateLockfileVersion("5.4"))
+	assert.Error(t, validateLockfileVersion(""))
+}
+
+// TestBuildSnapshotKey checks that scoped and non-scoped package references
+// produce the correct snapshot lookup key.
+func TestBuildSnapshotKey(t *testing.T) {
+	// Plain version (most common in importers block).
+	assert.Equal(t, "xml@1.0.1", buildSnapshotKey("xml", "1.0.1"))
+	// Scoped package with plain version.
+	assert.Equal(t, "@scope/pkg@2.0.0", buildSnapshotKey("@scope/pkg", "2.0.0"))
+	// Scoped package with peer-dep suffix (common for peer-requiring packages).
+	assert.Equal(t, "@scope/pkg@2.0.0(@peer/dep@1.0.0)", buildSnapshotKey("@scope/pkg", "2.0.0(@peer/dep@1.0.0)"))
+	// Non-scoped package with peer-dep suffix from a snapshot's dependencies map.
+	assert.Equal(t, "transitive-a@1.2.3", buildSnapshotKey("transitive-a", "1.2.3"))
+}

--- a/tests/testdata/projects/package-managers/pnpm/pnpm-project/package.json
+++ b/tests/testdata/projects/package-managers/pnpm/pnpm-project/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "pnpm-example",
+  "version": "1.0.0",
+  "description": "pnpm test project for jf ca / jf audit",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "xml": "1.0.1"
+  },
+  "devDependencies": {
+    "json": "9.0.6"
+  }
+}

--- a/tests/testdata/projects/package-managers/pnpm/pnpm-project/pnpm-lock-complex.yaml
+++ b/tests/testdata/projects/package-managers/pnpm/pnpm-project/pnpm-lock-complex.yaml
@@ -1,0 +1,56 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    dependencies:
+      xml:
+        specifier: 1.0.1
+        version: 1.0.1
+      '@scope/pkg':
+        specifier: 2.0.0
+        version: 2.0.0(@peer/dep@1.0.0)
+    devDependencies:
+      json:
+        specifier: 9.0.6
+        version: 9.0.6
+
+packages:
+
+  '@peer/dep@1.0.0':
+    resolution: {integrity: sha512-aaa==}
+
+  '@scope/pkg@2.0.0':
+    resolution: {integrity: sha512-bbb==}
+    peerDependencies:
+      '@peer/dep': '>=1.0.0'
+
+  json@9.0.6:
+    resolution: {integrity: sha512-Nx+4WwMM1xadgqjjteOVEyjoIVq7fGH1hAlRDoxoq2tFzYsBYZDIKwYbyxolkTYwxsSOgAZD2ACLkeGjhFW2Jw==}
+    engines: {node: '>=0.10.0'}
+    hasBin: true
+
+  transitive-a@1.2.3:
+    resolution: {integrity: sha512-ccc==}
+
+  xml@1.0.1:
+    resolution: {integrity: sha512-huCv9IH9Tcf95zuYCsQraZtWnJvBtLVE0QHMOs8bWyZAFZNDcYjsPq1nEx8jKA9y+Beo9v+7OBPRisQTjinQMw==}
+
+snapshots:
+
+  '@peer/dep@1.0.0': {}
+
+  '@scope/pkg@2.0.0(@peer/dep@1.0.0)':
+    dependencies:
+      '@peer/dep': 1.0.0
+      transitive-a: 1.2.3
+
+  json@9.0.6: {}
+
+  transitive-a@1.2.3: {}
+
+  xml@1.0.1: {}

--- a/tests/testdata/projects/package-managers/pnpm/pnpm-project/pnpm-lock.yaml
+++ b/tests/testdata/projects/package-managers/pnpm/pnpm-project/pnpm-lock.yaml
@@ -1,0 +1,33 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    dependencies:
+      xml:
+        specifier: 1.0.1
+        version: 1.0.1
+    devDependencies:
+      json:
+        specifier: 9.0.6
+        version: 9.0.6
+
+packages:
+
+  json@9.0.6:
+    resolution: {integrity: sha512-Nx+4WwMM1xadgqjjteOVEyjoIVq7fGH1hAlRDoxoq2tFzYsBYZDIKwYbyxolkTYwxsSOgAZD2ACLkeGjhFW2Jw==}
+    engines: {node: '>=0.10.0'}
+    hasBin: true
+
+  xml@1.0.1:
+    resolution: {integrity: sha512-huCv9IH9Tcf95zuYCsQraZtWnJvBtLVE0QHMOs8bWyZAFZNDcYjsPq1nEx8jKA9y+Beo9v+7OBPRisQTjinQMw==}
+
+snapshots:
+
+  json@9.0.6: {}
+
+  xml@1.0.1: {}

--- a/tests/testdata/projects/package-managers/pnpm/vite/package.json
+++ b/tests/testdata/projects/package-managers/pnpm/vite/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "@vitejs/vite-monorepo",
+  "version": "0.0.0",
+  "private": true
+}

--- a/tests/testdata/projects/package-managers/pnpm/vite/pnpm-lock.yaml
+++ b/tests/testdata/projects/package-managers/pnpm/vite/pnpm-lock.yaml
@@ -1,0 +1,48 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: false
+  dedupePeers: true
+  excludeLinksFromLockfile: false
+
+overrides:
+  rolldown: 1.0.3
+
+packageExtensionsChecksum: sha256-Tldxs3DhJEw/FFBonUidqhCBqApA0zxQnop3Y+BTO3U=
+
+patchedDependencies:
+  chokidar@3.6.0:
+    hash: 8a4f9e2b397e6034b91a0508faae3cecb97f222313faa129d7cb0eb71e9d0e84
+    path: patches/chokidar@3.6.0.patch
+  dotenv-expand@13.0.0:
+    hash: 49330a663821151418e003e822a82a6a61d2f0f8a6e3cab00c1c94815a112889
+    path: patches/dotenv-expand@13.0.0.patch
+  sirv@3.0.2:
+    hash: c07c56eb72faea34341d465cde2314e89db472106ed378181e3447893af6bf95
+    path: patches/sirv@3.0.2.patch
+
+importers:
+  .:
+    devDependencies:
+      '@types/node':
+        specifier: ^24.12.4
+        version: 24.12.4
+      eslint:
+        specifier: ^9.39.4
+        version: 9.39.4(jiti@2.6.1)(ms@2.1.3)
+  packages/vite:
+    dependencies:
+      rolldown:
+        specifier: 1.0.3
+        version: 1.0.3
+  packages/create-vite:
+    devDependencies:
+      cross-spawn:
+        specifier: ^7.0.6
+        version: 7.0.6
+
+snapshots:
+  cross-spawn@7.0.6: {}
+  rolldown@1.0.3: {}
+  '@types/node@24.12.4': {}
+  eslint@9.39.4(jiti@2.6.1)(ms@2.1.3): {}

--- a/utils/techutils/techutils.go
+++ b/utils/techutils/techutils.go
@@ -574,7 +574,7 @@ func getDirChildren(dir string, dirsList []string) (children []string) {
 //     wd/wd2: [tech1]
 func mapFilesToRelevantWorkingDirectories(files []string, requestedDescriptors map[Technology][]string) (workingDirectoryToIndicators map[string][]string, excludedTechAtWorkingDir map[string][]Technology, err error) {
 	workingDirectoryToIndicatorsSet := make(map[string]*datastructures.Set[string])
-	excludedTechAtWorkingDir = make(map[string][]Technology)
+	excludedTechAtWorkingDirSet := make(map[string]*datastructures.Set[Technology])
 	for _, path := range files {
 		directory := filepath.Dir(path)
 
@@ -594,13 +594,20 @@ func mapFilesToRelevantWorkingDirectories(files []string, requestedDescriptors m
 			}
 			// Check if the working directory contains a file/directory with a name that ends with an excluded suffix
 			if isExclude(path, techData) {
-				excludedTechAtWorkingDir[directory] = append(excludedTechAtWorkingDir[directory], tech)
+				if _, exist := excludedTechAtWorkingDirSet[directory]; !exist {
+					excludedTechAtWorkingDirSet[directory] = datastructures.MakeSet[Technology]()
+				}
+				excludedTechAtWorkingDirSet[directory].Add(tech)
 			}
 		}
 	}
 	workingDirectoryToIndicators = make(map[string][]string)
 	for wd, indicators := range workingDirectoryToIndicatorsSet {
 		workingDirectoryToIndicators[wd] = indicators.ToSlice()
+	}
+	excludedTechAtWorkingDir = make(map[string][]Technology)
+	for wd, excluded := range excludedTechAtWorkingDirSet {
+		excludedTechAtWorkingDir[wd] = excluded.ToSlice()
 	}
 	return
 }

--- a/utils/techutils/techutils.go
+++ b/utils/techutils/techutils.go
@@ -174,7 +174,7 @@ var technologiesData = map[Technology]TechData{
 	},
 	Npm: {
 		indicators:                 []string{"package.json", "package-lock.json", "npm-shrinkwrap.json"},
-		exclude:                    []string{"pnpm-lock.yaml", ".yarnrc.yml", "yarn.lock", ".yarn"},
+		exclude:                    []string{"pnpm-lock.yaml", "pnpm-workspace.yaml", ".pnpmfile.cjs", ".yarnrc.yml", "yarn.lock", ".yarn"},
 		packageDescriptors:         []string{"package.json"},
 		formal:                     string(Npm),
 		packageVersionOperator:     "@",
@@ -185,7 +185,7 @@ var technologiesData = map[Technology]TechData{
 	Pnpm: {
 		packageType:                "npm",
 		xrayPackageType:            "npm",
-		indicators:                 []string{"pnpm-lock.yaml"},
+		indicators:                 []string{"pnpm-lock.yaml", "pnpm-workspace.yaml", ".pnpmfile.cjs"},
 		exclude:                    []string{".yarnrc.yml", "yarn.lock", ".yarn"},
 		packageDescriptors:         []string{"package.json"},
 		packageVersionOperator:     "@",
@@ -195,7 +195,7 @@ var technologiesData = map[Technology]TechData{
 	},
 	Yarn: {
 		indicators:             []string{".yarnrc.yml", "yarn.lock", ".yarn", ".yarnrc"},
-		exclude:                []string{"pnpm-lock.yaml"},
+		exclude:                []string{"pnpm-lock.yaml", "pnpm-workspace.yaml", ".pnpmfile.cjs"},
 		packageDescriptors:     []string{"package.json"},
 		packageVersionOperator: "@",
 		projectType:            project.Yarn,

--- a/utils/techutils/techutils_test.go
+++ b/utils/techutils/techutils_test.go
@@ -59,6 +59,35 @@ func TestMapFilesToRelevantWorkingDirectories(t *testing.T) {
 			expectedExcluded:     map[string][]Technology{"dir": {Npm, Yarn}},
 		},
 		{
+			name:                 "pnpmWorkspaceTest",
+			paths:                []string{filepath.Join("dir", "package.json"), filepath.Join("dir", "pnpm-workspace.yaml")},
+			requestedDescriptors: noRequest,
+			expectedWorkingDir:   map[string][]string{"dir": {filepath.Join("dir", "package.json"), filepath.Join("dir", "pnpm-workspace.yaml")}},
+			expectedExcluded:     map[string][]Technology{"dir": {Npm, Yarn}},
+		},
+		{
+			name:                 "pnpmfileTest",
+			paths:                []string{filepath.Join("dir", "package.json"), filepath.Join("dir", ".pnpmfile.cjs")},
+			requestedDescriptors: noRequest,
+			expectedWorkingDir:   map[string][]string{"dir": {filepath.Join("dir", "package.json"), filepath.Join("dir", ".pnpmfile.cjs")}},
+			expectedExcluded:     map[string][]Technology{"dir": {Npm, Yarn}},
+		},
+		{
+			// pnpm-workspace.yaml + pnpm-lock.yaml both present: only pnpm should be detected,
+			// npm and yarn excluded.
+			name: "pnpmWorkspaceAndLockfileTest",
+			paths: []string{
+				filepath.Join("dir", "package.json"),
+				filepath.Join("dir", "pnpm-workspace.yaml"),
+				filepath.Join("dir", "pnpm-lock.yaml"),
+			},
+			requestedDescriptors: noRequest,
+			expectedWorkingDir: map[string][]string{
+				"dir": {filepath.Join("dir", "package.json"), filepath.Join("dir", "pnpm-workspace.yaml"), filepath.Join("dir", "pnpm-lock.yaml")},
+			},
+			expectedExcluded: map[string][]Technology{"dir": {Npm, Yarn}},
+		},
+		{
 			name:                 "yarnTest",
 			paths:                []string{filepath.Join("dir", "package.json"), filepath.Join("dir", ".yarn")},
 			requestedDescriptors: noRequest,


### PR DESCRIPTION
- [ ] The pull request is targeting the `dev` branch.
- [ ] The code has been validated to compile successfully by running `go vet ./...`.
- [ ] The code has been formatted properly using `go fmt ./...`.
- [ ] All [static analysis checks](https://github.com/jfrog/jfrog-cli-security/actions/workflows/analysis.yml) passed.
- [ ] All [tests](https://github.com/jfrog/jfrog-cli-security/actions/workflows/test.yml) have passed. If this feature is not already covered by the tests, new tests have been added.
- [ ] Updated the [Contributing page](https://github.com/jfrog/jfrog-cli-security/blob/main/CONTRIBUTING.md) / [ReadMe page](https://github.com/jfrog/jfrog-cli-security/blob/main/README.md) / [CI Workflow files](https://github.com/jfrog/jfrog-cli-security/tree/main/.github/workflows) if needed.
- [ ] All changes are detailed at the description. if not already covered at [JFrog Documentation](https://github.com/jfrog/documentation), new documentation have been added.

-----

What: Added pnpm support to jf ca (curation audit) using lockfile-based dependency resolution
Why: jf ca can't run pnpm ls (requires node_modules) — lockfile parsing avoids any tarball downloads
How: pnpm install --lockfile-only generates/refreshes the lockfile, then pnpm-lock.yaml is parsed directly. jf audit/jf scan pnpm workflow is unchanged.
Scope: Only pnpm v10.x supported. jf audit path untouched.
Test plan: new unit tests in pnpm_test.go, pnpmlock_test.go, curationaudit_test.go

<img width="1508" height="819" alt="Screenshot 2026-06-02 at 12 39 43 PM" src="https://github.com/user-attachments/assets/2c52fad1-ee94-47c6-a2c8-7ef11b84a2a7" />

Detailed Test execution plan is here https://jfrog-int.atlassian.net/browse/XRAY-144540