### PR TITLE
XRAY-145623 - pip jf ca failure due to CVS

### DIFF
--- a/commands/curation/curationaudit.go
+++ b/commands/curation/curationaudit.go
@@ -96,6 +96,7 @@ const (
 )
 
 var CurationOutputFormats = []string{string(outFormat.Table), string(outFormat.Json)}
+var osGetwd = os.Getwd
 
 var supportedTech = map[techutils.Technology]func(ca *CurationAuditCommand) (bool, error){
 	techutils.Npm:  func(ca *CurationAuditCommand) (bool, error) { return true, nil },
@@ -377,6 +378,7 @@ func convertResultsToSummary(results map[string]*CurationReport) formats.Results
 			CuratedPackages: &formats.CuratedPackages{
 				PackageCount: packagesStatus.totalNumberOfPackages,
 				Blocked:      getBlocked(packagesStatus.packagesStatus),
+				IsPartial:    packagesStatus.isPartial,
 			},
 		})
 	}
@@ -1240,9 +1242,10 @@ func (ca *CurationAuditCommand) runCvsFallback(cvsErr *python.CvsBlockedError, t
 		// Fallback produced nothing — surface the original error (current behaviour).
 		return cvsErr
 	}
-	workPath, wdErr := os.Getwd()
+	workPath, wdErr := osGetwd()
 	if wdErr != nil {
-		return cvsErr
+		log.Warn(fmt.Sprintf("curation-blocked resolution fallback: could not determine working directory (%v) — reporting under fallback key", wdErr))
+		workPath = "unknown-project"
 	}
 	results[filepath.Base(workPath)] = &CurationReport{
 		packagesStatus:        packagesStatus,
@@ -1395,6 +1398,12 @@ func (nc *treeAnalyzer) fetchCvsBlockedStatus(pins []python.PinnedRequirement) [
 				pin.Name, resolvedVersion, headErr))
 			continue
 		}
+		// Package is accessible — CVS cache may be stale; not currently blocked.
+		if headErr == nil && headResp != nil && headResp.StatusCode != http.StatusForbidden {
+			log.Debug(fmt.Sprintf("curation-blocked resolution fallback: HEAD probe returned %d for %s==%s — not CVS-blocked, skipping",
+				headResp.StatusCode, pin.Name, resolvedVersion))
+			continue
+		}
 
 		// ── Step 3b: 403 from HEAD → recover policy details via GET with waiver
 		var pkStatus *PackageStatus
@@ -1409,12 +1418,15 @@ func (nc *treeAnalyzer) fetchCvsBlockedStatus(pins []python.PinnedRequirement) [
 		depRelation := directRelation
 		if effectiveParent(pin) != pin.Name {
 			depRelation = indirectRelation
+		} else if pin.Version == "" && pin.VersionRange == "" {
+			// Name-only entry from ResolutionImpossible — parent attribution is
+			// unknown but these are always transitive deps by definition.
+			depRelation = indirectRelation
 		}
 		if pkStatus == nil {
-			// HEAD returned non-403 or GET probe errored — CVS stripped the
-			// version from the index but policy details aren't available via
-			// this path; record with unknown reason so the package is never
-			// silently dropped.
+			// HEAD returned 403 but GET probe errored — CVS stripped the version
+			// from the index but policy details aren't available via this path;
+			// record with unknown reason so the package is never silently dropped.
 			statuses = append(statuses, &PackageStatus{
 				PackageName:       pin.Name,
 				PackageVersion:    resolvedVersion,

--- a/commands/curation/curationaudit.go
+++ b/commands/curation/curationaudit.go
@@ -1220,11 +1220,11 @@ func (nc *treeAnalyzer) fetchNodeStatus(node xrayUtils.GraphNode, p *sync.Map) e
 func (ca *CurationAuditCommand) runCvsFallback(cvsErr *python.CvsBlockedError, tech techutils.Technology, results map[string]*CurationReport) error {
 	rtManager, serverDetails, err := ca.getRtManagerAndAuth(tech)
 	if err != nil {
-		return fmt.Errorf("CVS fallback: failed to get Artifactory manager (%w); pip error: %w", err, cvsErr)
+		return fmt.Errorf("curation-blocked resolution fallback: failed to get Artifactory manager (%w); pip error: %w", err, cvsErr)
 	}
 	rtAuth, err := serverDetails.CreateArtAuthConfig()
 	if err != nil {
-		return fmt.Errorf("CVS fallback: failed to create auth config (%w); pip error: %w", err, cvsErr)
+		return fmt.Errorf("curation-blocked resolution fallback: failed to create auth config (%w); pip error: %w", err, cvsErr)
 	}
 	analyzer := treeAnalyzer{
 		rtManager:            rtManager,
@@ -1355,7 +1355,7 @@ func (nc *treeAnalyzer) fetchCvsBlockedStatus(pins []python.PinnedRequirement) [
 			// Use the unfiltered all-versions metadata API to find the newest match.
 			allVersions, err := nc.lookupPypiAllVersions(pin.Name)
 			if err != nil {
-				log.Debug(fmt.Sprintf("CVS fallback: all-versions lookup failed for %s%s: %v",
+				log.Debug(fmt.Sprintf("curation-blocked resolution fallback: all-versions lookup failed for %s%s: %v",
 					pin.Name, pin.VersionRange, err))
 				continue
 			}
@@ -1366,11 +1366,11 @@ func (nc *treeAnalyzer) fetchCvsBlockedStatus(pins []python.PinnedRequirement) [
 				resolvedVersion = python.ResolveVersionRange(">=0", allVersions)
 			}
 			if resolvedVersion == "" {
-				log.Debug(fmt.Sprintf("CVS fallback: no version found for %s%s",
+				log.Debug(fmt.Sprintf("curation-blocked resolution fallback: no version found for %s%s",
 					pin.Name, pin.VersionRange))
 				continue
 			}
-			log.Debug(fmt.Sprintf("CVS fallback: resolved %s%s → %s",
+			log.Debug(fmt.Sprintf("curation-blocked resolution fallback: resolved %s%s → %s",
 				pin.Name, pin.VersionRange, resolvedVersion))
 		}
 
@@ -1382,7 +1382,7 @@ func (nc *treeAnalyzer) fetchCvsBlockedStatus(pins []python.PinnedRequirement) [
 			// so skip it: with no recoverable blockers the command falls back to
 			// the graceful "Affected package(s)" message (PR #761 behaviour),
 			// rather than rendering a misleading empty table row.
-			log.Debug(fmt.Sprintf("CVS fallback: metadata lookup failed for %s==%s: %v — treating as unresolved",
+			log.Debug(fmt.Sprintf("curation-blocked resolution fallback: metadata lookup failed for %s==%s: %v — treating as unresolved",
 				pin.Name, resolvedVersion, err))
 			continue
 		}
@@ -1391,7 +1391,7 @@ func (nc *treeAnalyzer) fetchCvsBlockedStatus(pins []python.PinnedRequirement) [
 		headDetails := nc.httpClientDetails.Clone()
 		headResp, _, headErr := nc.rtManager.Client().SendHead(dlURL, headDetails)
 		if headErr != nil && (headResp == nil || headResp.StatusCode != http.StatusForbidden) {
-			log.Debug(fmt.Sprintf("CVS fallback: HEAD probe failed for %s==%s: %v",
+			log.Debug(fmt.Sprintf("curation-blocked resolution fallback: HEAD probe failed for %s==%s: %v",
 				pin.Name, resolvedVersion, headErr))
 			continue
 		}
@@ -1402,7 +1402,7 @@ func (nc *treeAnalyzer) fetchCvsBlockedStatus(pins []python.PinnedRequirement) [
 			var getErr error
 			pkStatus, getErr = nc.getBlockedPackageDetails(dlURL, pin.Name, resolvedVersion)
 			if getErr != nil {
-				log.Debug(fmt.Sprintf("CVS fallback: GET probe failed for %s==%s: %v",
+				log.Debug(fmt.Sprintf("curation-blocked resolution fallback: GET probe failed for %s==%s: %v",
 					pin.Name, resolvedVersion, getErr))
 			}
 		}

--- a/commands/curation/curationaudit.go
+++ b/commands/curation/curationaudit.go
@@ -349,10 +349,9 @@ func (ca *CurationAuditCommand) Run() (err error) {
 	if scanErr != nil {
 		log.Error("Curation audit encountered errors while checking some packages; the report below may be incomplete:")
 	}
-	for _, report := range results {
+	for projectPath, report := range results {
 		if report.isPartial {
-			log.Warn(cvsPartialReportWarning)
-			break
+			log.Warn(fmt.Sprintf("[%s] %s", projectPath, cvsPartialReportWarning))
 		}
 	}
 
@@ -1221,11 +1220,11 @@ func (nc *treeAnalyzer) fetchNodeStatus(node xrayUtils.GraphNode, p *sync.Map) e
 func (ca *CurationAuditCommand) runCvsFallback(cvsErr *python.CvsBlockedError, tech techutils.Technology, results map[string]*CurationReport) error {
 	rtManager, serverDetails, err := ca.getRtManagerAndAuth(tech)
 	if err != nil {
-		return cvsErr
+		return fmt.Errorf("CVS fallback: failed to get Artifactory manager (%w); pip error: %w", err, cvsErr)
 	}
 	rtAuth, err := serverDetails.CreateArtAuthConfig()
 	if err != nil {
-		return cvsErr
+		return fmt.Errorf("CVS fallback: failed to create auth config (%w); pip error: %w", err, cvsErr)
 	}
 	analyzer := treeAnalyzer{
 		rtManager:            rtManager,
@@ -1343,6 +1342,9 @@ func (nc *treeAnalyzer) lookupPypiNormalDownloadURL(name, ver string) (string, e
 // version) is NOT rendered as a row; with no recoverable blockers the command
 // falls back to the graceful PR #761 message listing affected package(s), so a
 // version that is not in the metadata API is never shown as a fake "blocked" row.
+//
+// HTTP calls are sequential per pin. This path is an error-recovery path that
+// typically processes 1-3 packages, so parallelism is not worth the complexity.
 func (nc *treeAnalyzer) fetchCvsBlockedStatus(pins []python.PinnedRequirement) []*PackageStatus {
 	var statuses []*PackageStatus
 	for _, pin := range pins {
@@ -1391,6 +1393,7 @@ func (nc *treeAnalyzer) fetchCvsBlockedStatus(pins []python.PinnedRequirement) [
 		if headErr != nil && (headResp == nil || headResp.StatusCode != http.StatusForbidden) {
 			log.Debug(fmt.Sprintf("CVS fallback: HEAD probe failed for %s==%s: %v",
 				pin.Name, resolvedVersion, headErr))
+			continue
 		}
 
 		// ── Step 3b: 403 from HEAD → recover policy details via GET with waiver
@@ -1403,6 +1406,10 @@ func (nc *treeAnalyzer) fetchCvsBlockedStatus(pins []python.PinnedRequirement) [
 					pin.Name, resolvedVersion, getErr))
 			}
 		}
+		depRelation := directRelation
+		if effectiveParent(pin) != pin.Name {
+			depRelation = indirectRelation
+		}
 		if pkStatus == nil {
 			// HEAD returned non-403 or GET probe errored — CVS stripped the
 			// version from the index but policy details aren't available via
@@ -1413,6 +1420,7 @@ func (nc *treeAnalyzer) fetchCvsBlockedStatus(pins []python.PinnedRequirement) [
 				PackageVersion:    resolvedVersion,
 				ParentName:        effectiveParent(pin),
 				ParentVersion:     effectiveParentVersion(pin),
+				DepRelation:       depRelation,
 				BlockedPackageUrl: dlURL,
 				Action:            blocked,
 				BlockingReason:    BlockingReasonUnknown,
@@ -1426,6 +1434,7 @@ func (nc *treeAnalyzer) fetchCvsBlockedStatus(pins []python.PinnedRequirement) [
 		pkStatus.PackageVersion = resolvedVersion
 		pkStatus.ParentName = effectiveParent(pin)
 		pkStatus.ParentVersion = effectiveParentVersion(pin)
+		pkStatus.DepRelation = depRelation
 		statuses = append(statuses, pkStatus)
 	}
 	return statuses

--- a/commands/curation/curationaudit.go
+++ b/commands/curation/curationaudit.go
@@ -85,6 +85,14 @@ const (
 	MinArtiNuGetSupport       = "7.93.0"
 	MinXrayPassThroughSupport = "3.92.0"
 	MinArtiGradleGemSupport   = "7.63.5"
+
+	// cvsPartialReportWarning is shown when pip resolution failed because CVS
+	// stripped a required version from the simple index, but the metadata-API
+	// fallback succeeded in recovering at least one policy violation.
+	cvsPartialReportWarning = "The curation audit was unable to fully resolve the dependency tree because one or more pinned package versions " +
+		"are blocked by the curation policy. Details of the policy violations are shown in the table below.\n" +
+		"Dependency analysis cannot proceed until these issues are addressed.\n" +
+		"Once you apply a waiver or switch to an approved version and re-run the audit, additional results will be available."
 )
 
 var CurationOutputFormats = []string{string(outFormat.Table), string(outFormat.Json)}
@@ -244,6 +252,11 @@ type CurationAuditCommand struct {
 type CurationReport struct {
 	packagesStatus        []*PackageStatus
 	totalNumberOfPackages int
+	// isPartial is set when the dependency tree could not be fully resolved
+	// (e.g. CVS blocked a pip version from the simple index) and the report
+	// was produced via the metadata-API fallback. The partial-report warning
+	// is printed after the spinner stops so it is not swallowed by the spinner.
+	isPartial bool
 }
 
 type WaiverResponse struct {
@@ -330,9 +343,17 @@ func (ca *CurationAuditCommand) Run() (err error) {
 	if ca.Progress() != nil {
 		err = errors.Join(err, ca.Progress().Quit())
 	}
-	// Print after the spinner has stopped so the message appears on the terminal.
+	// Print after the spinner has stopped so the messages appear on the terminal.
+	// Don't include scanErr.Error() here — it is in the returned err and the CLI framework
+	// prints it once; printing it here too would duplicate the full error message.
 	if scanErr != nil {
-		log.Error("Curation audit encountered errors while checking some packages; the report below may be incomplete: " + scanErr.Error())
+		log.Error("Curation audit encountered errors while checking some packages; the report below may be incomplete:")
+	}
+	for _, report := range results {
+		if report.isPartial {
+			log.Warn(cvsPartialReportWarning)
+			break
+		}
 	}
 
 	for projectPath, packagesStatus := range results {
@@ -602,6 +623,14 @@ func (ca *CurationAuditCommand) auditTree(tech techutils.Technology, results map
 	}
 	depTreeResult, err := buildinfo.GetTechDependencyTree(params, serverDetails, tech)
 	if err != nil {
+		// When CVS strips a pinned version from the simple index, pip can't
+		// resolve the project and GetTechDependencyTree returns a CvsBlockedError.
+		// Instead of aborting with no output, run the metadata-API fallback to
+		// recover the curation policy and render a partial table.
+		var cvsErr *python.CvsBlockedError
+		if tech == techutils.Pip && errors.As(err, &cvsErr) {
+			return ca.runCvsFallback(cvsErr, tech, results)
+		}
 		return err
 	}
 	// Validate the graph isn't empty.
@@ -1183,6 +1212,252 @@ func (nc *treeAnalyzer) fetchNodeStatus(node xrayUtils.GraphNode, p *sync.Map) e
 		}
 	}
 	return nil
+}
+
+// runCvsFallback is called when pip resolution failed because CVS stripped a
+// pinned version from the simple index (CvsBlockedError). It uses the PyPI
+// metadata API to recover each blocker's real download URL, probes the normal
+// (non-audit) download path, and renders the policy in a partial curation table.
+func (ca *CurationAuditCommand) runCvsFallback(cvsErr *python.CvsBlockedError, tech techutils.Technology, results map[string]*CurationReport) error {
+	rtManager, serverDetails, err := ca.getRtManagerAndAuth(tech)
+	if err != nil {
+		return cvsErr
+	}
+	rtAuth, err := serverDetails.CreateArtAuthConfig()
+	if err != nil {
+		return cvsErr
+	}
+	analyzer := treeAnalyzer{
+		rtManager:            rtManager,
+		extractPoliciesRegex: ca.extractPoliciesRegex,
+		rtAuth:               rtAuth,
+		httpClientDetails:    rtAuth.CreateHttpClientDetails(),
+		url:                  rtAuth.GetUrl(),
+		repo:                 ca.PackageManagerConfig.TargetRepo(),
+		tech:                 tech,
+	}
+	packagesStatus := analyzer.fetchCvsBlockedStatus(cvsErr.Packages)
+	if len(packagesStatus) == 0 {
+		// Fallback produced nothing — surface the original error (current behaviour).
+		return cvsErr
+	}
+	workPath, wdErr := os.Getwd()
+	if wdErr != nil {
+		return cvsErr
+	}
+	results[filepath.Base(workPath)] = &CurationReport{
+		packagesStatus:        packagesStatus,
+		totalNumberOfPackages: len(packagesStatus),
+		isPartial:             true,
+	}
+	return nil
+}
+
+// lookupPypiAllVersions calls the Artifactory PyPI metadata API for a package
+// name (no version — returns all releases) and returns all available version
+// strings. This endpoint is NOT filtered by CVS, so it includes versions that
+// have been stripped from the simple index.
+func (nc *treeAnalyzer) lookupPypiAllVersions(name string) ([]string, error) {
+	metadataURL := fmt.Sprintf("%s/api/pypi/%s/pypi/%s/json",
+		strings.TrimSuffix(nc.url, "/"), nc.repo, name)
+
+	requestDetails := nc.httpClientDetails.Clone()
+	resp, body, _, err := nc.rtManager.Client().SendGet(metadataURL, true, requestDetails)
+	if err != nil {
+		return nil, fmt.Errorf("all-versions metadata API request failed for %s: %w", name, err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("all-versions metadata API returned HTTP %d for %s", resp.StatusCode, name)
+	}
+
+	var meta struct {
+		Releases map[string]json.RawMessage `json:"releases"`
+	}
+	if err := json.Unmarshal(body, &meta); err != nil {
+		return nil, fmt.Errorf("failed to parse all-versions metadata for %s: %w", name, err)
+	}
+
+	versions := make([]string, 0, len(meta.Releases))
+	for v := range meta.Releases {
+		versions = append(versions, v)
+	}
+	return versions, nil
+}
+
+// lookupPypiNormalDownloadURL calls the Artifactory PyPI metadata API for
+// name@version (which CVS does NOT filter) and returns the first available
+// download URL as a normal Artifactory path (no api/curation/audit/ prefix).
+// The url field in the metadata JSON is a relative path such as
+// "../../packages/packages/<hash>/<file>" — the stable anchor is "packages/"
+// so we slice from there and prepend the Artifactory base + repo.
+func (nc *treeAnalyzer) lookupPypiNormalDownloadURL(name, ver string) (string, error) {
+	metadataURL := fmt.Sprintf("%s/api/pypi/%s/pypi/%s/%s/json",
+		strings.TrimSuffix(nc.url, "/"), nc.repo, name, ver)
+
+	requestDetails := nc.httpClientDetails.Clone()
+	resp, body, _, err := nc.rtManager.Client().SendGet(metadataURL, true, requestDetails)
+	if err != nil {
+		return "", fmt.Errorf("metadata API request failed for %s==%s: %w", name, ver, err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("metadata API returned HTTP %d for %s==%s", resp.StatusCode, name, ver)
+	}
+
+	var meta struct {
+		Urls []struct {
+			PackageType string `json:"packagetype"`
+			URL         string `json:"url"`
+		} `json:"urls"`
+	}
+	if err := json.Unmarshal(body, &meta); err != nil {
+		return "", fmt.Errorf("failed to parse metadata for %s==%s: %w", name, ver, err)
+	}
+
+	// Prefer wheel over source dist — probe whichever we find first.
+	for _, preferred := range []string{"bdist_wheel", "sdist"} {
+		for _, u := range meta.Urls {
+			if u.PackageType != preferred {
+				continue
+			}
+			// Strip the leading relative components; the stable part is "packages/...".
+			idx := strings.Index(u.URL, "packages/")
+			if idx < 0 {
+				continue
+			}
+			return fmt.Sprintf("%s/api/pypi/%s/%s",
+				strings.TrimSuffix(nc.url, "/"), nc.repo, u.URL[idx:]), nil
+		}
+	}
+	return "", fmt.Errorf("no download URL found in metadata for %s==%s", name, ver)
+}
+
+// fetchCvsBlockedStatus recovers the curation policy for each CVS-blocked package:
+//
+//  1. For range-based blockers (PinnedRequirement.VersionRange set): resolve the
+//     newest version satisfying the range via the unfiltered all-versions metadata API.
+//  2. Call the version-specific metadata API to get the normal download URL.
+//  3. Probe the normal (non-audit) download URL via getBlockedPackageDetails.
+//
+// A blocker that cannot be confirmed as curation-blocked (its version is absent
+// from the metadata API — e.g. removed from the index, or a typo/nonexistent
+// version) is NOT rendered as a row; with no recoverable blockers the command
+// falls back to the graceful PR #761 message listing affected package(s), so a
+// version that is not in the metadata API is never shown as a fake "blocked" row.
+func (nc *treeAnalyzer) fetchCvsBlockedStatus(pins []python.PinnedRequirement) []*PackageStatus {
+	var statuses []*PackageStatus
+	for _, pin := range pins {
+		// ── Step 1: resolve range / no-version → exact version ───────────────
+		resolvedVersion := pin.Version
+		if pin.VersionRange != "" || resolvedVersion == "" {
+			// Either a range spec or a ResolutionImpossible entry with no version.
+			// Use the unfiltered all-versions metadata API to find the newest match.
+			allVersions, err := nc.lookupPypiAllVersions(pin.Name)
+			if err != nil {
+				log.Debug(fmt.Sprintf("CVS fallback: all-versions lookup failed for %s%s: %v",
+					pin.Name, pin.VersionRange, err))
+				continue
+			}
+			if pin.VersionRange != "" {
+				resolvedVersion = python.ResolveVersionRange(pin.VersionRange, allVersions)
+			} else {
+				// No range — pick the newest available version.
+				resolvedVersion = python.ResolveVersionRange(">=0", allVersions)
+			}
+			if resolvedVersion == "" {
+				log.Debug(fmt.Sprintf("CVS fallback: no version found for %s%s",
+					pin.Name, pin.VersionRange))
+				continue
+			}
+			log.Debug(fmt.Sprintf("CVS fallback: resolved %s%s → %s",
+				pin.Name, pin.VersionRange, resolvedVersion))
+		}
+
+		// ── Step 2: metadata API → normal download URL ────────────────────────
+		dlURL, err := nc.lookupPypiNormalDownloadURL(pin.Name, resolvedVersion)
+		if err != nil {
+			// Version is absent from the metadata API (removed from the index, or
+			// a typo/nonexistent version). There is no recoverable policy to show,
+			// so skip it: with no recoverable blockers the command falls back to
+			// the graceful "Affected package(s)" message (PR #761 behaviour),
+			// rather than rendering a misleading empty table row.
+			log.Debug(fmt.Sprintf("CVS fallback: metadata lookup failed for %s==%s: %v — treating as unresolved",
+				pin.Name, resolvedVersion, err))
+			continue
+		}
+
+		// ── Step 3a: HEAD probe — detect whether the version is download-blocked
+		headDetails := nc.httpClientDetails.Clone()
+		headResp, _, headErr := nc.rtManager.Client().SendHead(dlURL, headDetails)
+		if headErr != nil && (headResp == nil || headResp.StatusCode != http.StatusForbidden) {
+			log.Debug(fmt.Sprintf("CVS fallback: HEAD probe failed for %s==%s: %v",
+				pin.Name, resolvedVersion, headErr))
+		}
+
+		// ── Step 3b: 403 from HEAD → recover policy details via GET with waiver
+		var pkStatus *PackageStatus
+		if headResp != nil && headResp.StatusCode == http.StatusForbidden {
+			var getErr error
+			pkStatus, getErr = nc.getBlockedPackageDetails(dlURL, pin.Name, resolvedVersion)
+			if getErr != nil {
+				log.Debug(fmt.Sprintf("CVS fallback: GET probe failed for %s==%s: %v",
+					pin.Name, resolvedVersion, getErr))
+			}
+		}
+		if pkStatus == nil {
+			// HEAD returned non-403 or GET probe errored — CVS stripped the
+			// version from the index but policy details aren't available via
+			// this path; record with unknown reason so the package is never
+			// silently dropped.
+			statuses = append(statuses, &PackageStatus{
+				PackageName:       pin.Name,
+				PackageVersion:    resolvedVersion,
+				ParentName:        effectiveParent(pin),
+				ParentVersion:     effectiveParentVersion(pin),
+				BlockedPackageUrl: dlURL,
+				Action:            blocked,
+				BlockingReason:    BlockingReasonUnknown,
+				PkgType:           string(nc.tech),
+			})
+			continue
+		}
+
+		// Policy recovered — set parent attribution from the parsed blocker.
+		pkStatus.PackageName = pin.Name
+		pkStatus.PackageVersion = resolvedVersion
+		pkStatus.ParentName = effectiveParent(pin)
+		pkStatus.ParentVersion = effectiveParentVersion(pin)
+		statuses = append(statuses, pkStatus)
+	}
+	return statuses
+}
+
+// effectiveParent returns the parent name to populate in the curation table row.
+// For direct exact pins, ParentName equals Name (set by parseCvsFailedPackages);
+// for transitive range blockers it is the requiring package. When not yet set,
+// fall back to the package itself.
+func effectiveParent(pin python.PinnedRequirement) string {
+	if pin.ParentName != "" && pin.ParentName != pin.Name {
+		return pin.ParentName
+	}
+	return pin.Name
+}
+
+// effectiveParentVersion returns the version to show in the "Direct Dependency
+// Version" column. For exact pins it is the pinned version.
+//
+// For a ranged DIRECT dependency (parent == package, e.g. requirements.txt has
+// "langchain-core>=1.4.0") the range spec itself is shown so the column is not
+// blank. For a TRANSITIVE blocker (parent differs from the package) the range
+// describes the blocked package, not the parent — so it must not be shown in
+// the parent column; we leave it blank when the parent version is unknown.
+func effectiveParentVersion(pin python.PinnedRequirement) string {
+	if pin.ParentVersion != "" {
+		return pin.ParentVersion
+	}
+	if pin.VersionRange != "" && (pin.ParentName == "" || pin.ParentName == pin.Name) {
+		return pin.VersionRange
+	}
+	return pin.Version
 }
 
 // We try to collect curation details from GET response after HEAD request got forbidden status code.

--- a/commands/curation/curationaudit_test.go
+++ b/commands/curation/curationaudit_test.go
@@ -1943,6 +1943,121 @@ func TestFetchCvsBlockedStatusNotInMetadataNotRendered(t *testing.T) {
 	assert.Empty(t, statuses, "a version absent from the metadata API must not be rendered as a blocked row")
 }
 
+// TestFetchCvsBlockedStatusSetsDepRelation verifies DepRelation is populated for both direct and transitive CVS-fallback rows.
+func TestFetchCvsBlockedStatusSetsDepRelation(t *testing.T) {
+	const (
+		repo            = "test-pip-repo"
+		blockedPkg      = "langchain-core"
+		blockedVer      = "1.4.7"
+		parentPkg       = "deepagents"
+		parentVer       = "0.6.1"
+		whlRelativePath = "packages/ab/cd/langchain_core-1.4.7-py3-none-any.whl"
+	)
+
+	serverMock, _, rtManager := coreCommonTests.CreateRtRestsMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/pypi/"+blockedPkg+"/json"):
+			w.WriteHeader(http.StatusOK)
+			_, _ = fmt.Fprintf(w, `{"releases":{%q:[]}}`, blockedVer)
+		case r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/pypi/"+blockedPkg+"/"+blockedVer+"/json"):
+			w.WriteHeader(http.StatusOK)
+			_, _ = fmt.Fprintf(w, `{"urls":[{"packagetype":"bdist_wheel","url":"../../%s"}]}`, whlRelativePath)
+		case r.Method == http.MethodHead:
+			w.WriteHeader(http.StatusForbidden)
+		default:
+			w.WriteHeader(http.StatusForbidden)
+			_, _ = w.Write([]byte(`{"errors":[{"status":403,"message":"Package langchain-core:1.4.7 download was blocked by Curation service due to policy 'strict-policy'","policy":"strict-policy","condition":"immature","explanation":"too new","recommendation":"use older"}]}`))
+		}
+	})
+	defer serverMock.Close()
+
+	rtAuth := rtManager.GetConfig().GetServiceDetails()
+	analyzer := treeAnalyzer{
+		rtManager:            rtManager,
+		extractPoliciesRegex: regexp.MustCompile(extractPoliciesRegexTemplate),
+		rtAuth:               rtAuth,
+		httpClientDetails:    rtAuth.CreateHttpClientDetails(),
+		url:                  rtAuth.GetUrl(),
+		repo:                 repo,
+		tech:                 techutils.Pip,
+	}
+
+	// Transitive pin: parent differs from package → indirect.
+	pins := []python.PinnedRequirement{
+		{Name: blockedPkg, VersionRange: ">=1.4.0", ParentName: parentPkg, ParentVersion: parentVer},
+	}
+	statuses := analyzer.fetchCvsBlockedStatus(pins)
+	require.Len(t, statuses, 1)
+	assert.Equal(t, indirectRelation, statuses[0].DepRelation, "transitive CVS-fallback row must be indirect")
+
+	// Direct pin: parent equals package → direct.
+	pins = []python.PinnedRequirement{
+		{Name: blockedPkg, Version: blockedVer, ParentName: blockedPkg, ParentVersion: blockedVer},
+	}
+	statuses = analyzer.fetchCvsBlockedStatus(pins)
+	require.Len(t, statuses, 1)
+	assert.Equal(t, directRelation, statuses[0].DepRelation, "direct CVS-fallback row must be direct")
+}
+
+// TestFetchCvsBlockedStatusHeadErrorNoFalsePositive verifies that a HEAD transport error does not
+// produce a spurious blocked row.
+func TestFetchCvsBlockedStatusHeadErrorNoFalsePositive(t *testing.T) {
+	const (
+		repo            = "test-pip-repo"
+		pkg             = "foo"
+		ver             = "1.0"
+		whlRelativePath = "packages/ab/cd/foo-1.0-py3-none-any.whl"
+	)
+
+	serverMock, _, rtManager := coreCommonTests.CreateRtRestsMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodHead:
+			w.WriteHeader(http.StatusInternalServerError)
+		case r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/pypi/"+pkg+"/"+ver+"/json"):
+			w.WriteHeader(http.StatusOK)
+			_, _ = fmt.Fprintf(w, `{"urls":[{"packagetype":"bdist_wheel","url":"../../%s"}]}`, whlRelativePath)
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	})
+	defer serverMock.Close()
+
+	rtAuth := rtManager.GetConfig().GetServiceDetails()
+	analyzer := treeAnalyzer{
+		rtManager:            rtManager,
+		extractPoliciesRegex: regexp.MustCompile(extractPoliciesRegexTemplate),
+		rtAuth:               rtAuth,
+		httpClientDetails:    rtAuth.CreateHttpClientDetails(),
+		url:                  rtAuth.GetUrl(),
+		repo:                 repo,
+		tech:                 techutils.Pip,
+	}
+
+	pins := []python.PinnedRequirement{{Name: pkg, Version: ver, ParentName: pkg, ParentVersion: ver}}
+	statuses := analyzer.fetchCvsBlockedStatus(pins)
+	assert.Empty(t, statuses, "HEAD transport error must not produce a false-positive blocked row")
+}
+
+// TestEffectiveParentVersion covers all branches of the effectiveParentVersion helper.
+func TestEffectiveParentVersion(t *testing.T) {
+	cases := []struct {
+		name string
+		pin  python.PinnedRequirement
+		want string
+	}{
+		{"exact direct", python.PinnedRequirement{Name: "foo", Version: "1.0", ParentName: "foo", ParentVersion: "1.0"}, "1.0"},
+		{"direct range — shows range spec", python.PinnedRequirement{Name: "foo", VersionRange: ">=1.4", ParentName: "foo"}, ">=1.4"},
+		{"transitive range — parent ver unknown", python.PinnedRequirement{Name: "foo", VersionRange: ">=1.4", ParentName: "bar"}, ""},
+		{"transitive with known parent ver", python.PinnedRequirement{Name: "foo", VersionRange: ">=1.4", ParentName: "bar", ParentVersion: "2.3"}, "2.3"},
+		{"ResolutionImpossible — all empty", python.PinnedRequirement{Name: "foo", ParentName: "foo"}, ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, effectiveParentVersion(tc.pin))
+		})
+	}
+}
+
 func TestValidateRunNativeForTech(t *testing.T) {
 	// Sanity: npm and pnpm are the allow-listed techs. Both flag states pass.
 	assert.NoError(t, validateRunNativeForTech(techutils.Npm, true))

--- a/commands/curation/curationaudit_test.go
+++ b/commands/curation/curationaudit_test.go
@@ -3,6 +3,7 @@ package curation
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -22,6 +23,7 @@ import (
 	biutils "github.com/jfrog/build-info-go/utils"
 	"github.com/jfrog/gofrog/datastructures"
 	coreCommonTests "github.com/jfrog/jfrog-cli-core/v2/common/tests"
+	"github.com/jfrog/jfrog-cli-core/v2/common/project"
 	"github.com/jfrog/jfrog-cli-core/v2/utils/config"
 	"github.com/jfrog/jfrog-cli-core/v2/utils/coreutils"
 	"github.com/jfrog/jfrog-client-go/utils/io/fileutils"
@@ -1475,6 +1477,41 @@ func Test_convertResultsToSummary(t *testing.T) {
 			},
 		},
 		{
+			name: "partial CVS fallback report — IsPartial propagates to summary",
+			input: map[string]*CurationReport{
+				"project1": {
+					packagesStatus: []*PackageStatus{
+						{
+							PackageName:    "langchain-core",
+							PackageVersion: "1.4.7",
+							ParentVersion:  "1.4.7",
+							ParentName:     "langchain-core",
+							Action:         "blocked",
+							Policy:         []Policy{{Policy: "p", Condition: "immature"}},
+						},
+					},
+					totalNumberOfPackages: 1,
+					isPartial:             true,
+				},
+			},
+			expected: formats.ResultsSummary{
+				Scans: []formats.ScanSummary{
+					{
+						Target: "project1",
+						CuratedPackages: &formats.CuratedPackages{
+							PackageCount: 1,
+							IsPartial:    true,
+							Blocked: []formats.BlockedPackages{{
+								Policy:    "p",
+								Condition: "immature",
+								Packages:  map[string]int{"langchain-core:1.4.7": 1},
+							}},
+						},
+					},
+				},
+			},
+		},
+		{
 			name: "results for three result - aggregate one, same component in two policies",
 			input: map[string]*CurationReport{
 				"project1": {
@@ -1997,6 +2034,15 @@ func TestFetchCvsBlockedStatusSetsDepRelation(t *testing.T) {
 	statuses = analyzer.fetchCvsBlockedStatus(pins)
 	require.Len(t, statuses, 1)
 	assert.Equal(t, directRelation, statuses[0].DepRelation, "direct CVS-fallback row must be direct")
+
+	// ResolutionImpossible: name-only, self-attributed → must be indirect.
+	pins = []python.PinnedRequirement{
+		{Name: blockedPkg, ParentName: blockedPkg}, // no Version, no VersionRange
+	}
+	statuses = analyzer.fetchCvsBlockedStatus(pins)
+	require.Len(t, statuses, 1)
+	assert.Equal(t, indirectRelation, statuses[0].DepRelation,
+		"ResolutionImpossible CVS-fallback row must be indirect (parent unknown)")
 }
 
 // TestFetchCvsBlockedStatusHeadErrorNoFalsePositive verifies that a HEAD transport error does not
@@ -2036,6 +2082,99 @@ func TestFetchCvsBlockedStatusHeadErrorNoFalsePositive(t *testing.T) {
 	pins := []python.PinnedRequirement{{Name: pkg, Version: ver, ParentName: pkg, ParentVersion: ver}}
 	statuses := analyzer.fetchCvsBlockedStatus(pins)
 	assert.Empty(t, statuses, "HEAD transport error must not produce a false-positive blocked row")
+}
+
+// TestFetchCvsBlockedStatusHeadOKNoFalsePositive verifies that a HEAD 200 (stale CVS cache scenario)
+// does not produce a spurious blocked row. When pip's CVS-filtered simple-index hid a version but
+// the artifact is now accessible (policy changed, waiver granted), HEAD returns 200 and the package
+// must be skipped entirely.
+func TestFetchCvsBlockedStatusHeadOKNoFalsePositive(t *testing.T) {
+	const (
+		repo            = "test-pip-repo"
+		pkg             = "foo"
+		ver             = "1.0"
+		whlRelativePath = "packages/ab/cd/foo-1.0-py3-none-any.whl"
+	)
+
+	serverMock, _, rtManager := coreCommonTests.CreateRtRestsMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodHead:
+			// Stale CVS cache cleared; package is now accessible.
+			w.WriteHeader(http.StatusOK)
+		case r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/pypi/"+pkg+"/"+ver+"/json"):
+			w.WriteHeader(http.StatusOK)
+			_, _ = fmt.Fprintf(w, `{"urls":[{"packagetype":"bdist_wheel","url":"../../%s"}]}`, whlRelativePath)
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	})
+	defer serverMock.Close()
+
+	rtAuth := rtManager.GetConfig().GetServiceDetails()
+	analyzer := treeAnalyzer{
+		rtManager:            rtManager,
+		extractPoliciesRegex: regexp.MustCompile(extractPoliciesRegexTemplate),
+		rtAuth:               rtAuth,
+		httpClientDetails:    rtAuth.CreateHttpClientDetails(),
+		url:                  rtAuth.GetUrl(),
+		repo:                 repo,
+		tech:                 techutils.Pip,
+	}
+
+	pins := []python.PinnedRequirement{{Name: pkg, Version: ver, ParentName: pkg, ParentVersion: ver}}
+	statuses := analyzer.fetchCvsBlockedStatus(pins)
+	assert.Empty(t, statuses, "HEAD 200 (stale CVS cache) must not produce a false-positive blocked row")
+}
+
+// TestRunCvsFallbackGetWdFailurePreservesResults verifies that a failed os.Getwd() does not cause
+// runCvsFallback to discard the already-recovered packagesStatus. The results map must be populated
+// under the "unknown-project" fallback key instead of silently returning cvsErr.
+func TestRunCvsFallbackGetWdFailurePreservesResults(t *testing.T) {
+	const (
+		repo            = "test-pip-repo"
+		blockedPkg      = "langchain-core"
+		blockedVer      = "1.4.7"
+		whlRelativePath = "packages/ab/cd/langchain_core-1.4.7-py3-none-any.whl"
+	)
+	blockJSON := `{"errors":[{"status":403,"message":"Package langchain-core:1.4.7 download was blocked by Curation service due to policy 'p'","policy":"p","condition":"immature","explanation":"too new","recommendation":"use older"}]}`
+	serverMock, serverDetails, _ := coreCommonTests.CreateRtRestsMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/pypi/"+blockedPkg+"/"+blockedVer+"/json"):
+			w.WriteHeader(http.StatusOK)
+			_, _ = fmt.Fprintf(w, `{"urls":[{"packagetype":"bdist_wheel","url":"../../%s"}]}`, whlRelativePath)
+		case r.Method == http.MethodHead:
+			w.WriteHeader(http.StatusForbidden)
+		default:
+			w.WriteHeader(http.StatusForbidden)
+			_, _ = w.Write([]byte(blockJSON))
+		}
+	})
+	defer serverMock.Close()
+
+	repoConfig := (&project.RepositoryConfig{}).
+		SetTargetRepo(repo).
+		SetServerDetails(serverDetails)
+	ca := &CurationAuditCommand{
+		PackageManagerConfig: repoConfig,
+		extractPoliciesRegex: regexp.MustCompile(extractPoliciesRegexTemplate),
+	}
+
+	// Simulate os.Getwd() failure via the injectable function variable.
+	orig := osGetwd
+	osGetwd = func() (string, error) { return "", errors.New("simulated: no such file or directory") }
+	t.Cleanup(func() { osGetwd = orig })
+
+	cvsErr := &python.CvsBlockedError{
+		Packages: []python.PinnedRequirement{
+			{Name: blockedPkg, Version: blockedVer, ParentName: blockedPkg, ParentVersion: blockedVer},
+		},
+	}
+	results := map[string]*CurationReport{}
+	err := ca.runCvsFallback(cvsErr, techutils.Pip, results)
+
+	assert.NoError(t, err, "os.Getwd failure must not surface as an error")
+	assert.Len(t, results, 1, "recovered packagesStatus must be stored even when Getwd fails")
+	assert.Contains(t, results, "unknown-project", "results key must be the fallback key when Getwd fails")
 }
 
 // TestEffectiveParentVersion covers all branches of the effectiveParentVersion helper.

--- a/commands/curation/curationaudit_test.go
+++ b/commands/curation/curationaudit_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/jfrog/jfrog-cli-security/sca/bom/buildinfo/technologies/python"
 	testUtils "github.com/jfrog/jfrog-cli-security/tests/utils"
 	"github.com/jfrog/jfrog-cli-security/utils"
 	"github.com/jfrog/jfrog-cli-security/utils/techutils"
@@ -1801,9 +1802,147 @@ func TestFetchNodesStatusConcurrentMapWrite(t *testing.T) {
 	assert.Equal(t, numNodes, count, "expected all %d packages to be recorded as blocked", numNodes)
 }
 
-// TestValidateRunNativeForTech checks that --run-native is accepted for npm and
-// pnpm (both .npmrc-based) and rejected for all other techs with an error that
-// names the offending tech.
+// TestFetchCvsBlockedStatusTransitive verifies the CVS fallback for a transitive range blocker:
+// the range is resolved to the newest satisfying version and the policy is recovered from the 403 probe.
+func TestFetchCvsBlockedStatusTransitive(t *testing.T) {
+	const (
+		repo            = "test-pip-repo"
+		blockedPkg      = "langchain-core"
+		blockedVer      = "1.4.7"
+		parentPkg       = "deepagents"
+		parentVer       = "0.6.1"
+		rangeSpec       = ">=1.4.0"
+		expectedPolicy  = "strict-immature-policy"
+		expectedCond    = "Package version is immature (strict)"
+		expectedExpl    = "Package version is 3 days old"
+		expectedRec     = "Use an older version or wait until this version is no longer immature"
+		whlRelativePath = "packages/ab/cd/langchain_core-1.4.7-py3-none-any.whl"
+	)
+
+	// Curation 403 body returned when the normal download URL is probed.
+	blockMsg := fmt.Sprintf(
+		"Package %s:%s download was blocked by JFrog Packages Curation service due to the following policies violated {%s, %s, %s, %s}.",
+		blockedPkg, blockedVer, expectedPolicy, expectedCond, expectedExpl, expectedRec,
+	)
+	blockResponse := fmt.Sprintf(`{"errors":[{"status":403,"message":%q}]}`, blockMsg)
+
+	// All-versions metadata JSON (the simple-index-unfiltered endpoint).
+	allVersionsJSON := `{"releases":{"1.4.0":[],"1.4.1":[],"1.4.5":[],"1.4.7":[]}}`
+
+	// Version-specific metadata JSON (returns the whl download URL).
+	versionMetaJSON := fmt.Sprintf(`{"urls":[{"packagetype":"bdist_wheel","url":"../../%s"}]}`, whlRelativePath)
+
+	serverMock, _, rtManager := coreCommonTests.CreateRtRestsMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		// All-versions metadata: /api/pypi/<repo>/pypi/<name>/json
+		case r.Method == http.MethodGet && strings.HasSuffix(r.URL.Path, "/pypi/"+blockedPkg+"/json"):
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(allVersionsJSON))
+
+		// Version-specific metadata: /api/pypi/<repo>/pypi/<name>/<ver>/json
+		case r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/pypi/"+blockedPkg+"/"+blockedVer+"/json"):
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(versionMetaJSON))
+
+		// Normal download URL probe: HEAD first → 403 (detection step)
+		case r.Method == http.MethodHead && strings.Contains(r.URL.Path, whlRelativePath):
+			w.WriteHeader(http.StatusForbidden)
+
+		// Normal download URL probe: GET with waiver → 403 with policy body
+		case r.Method == http.MethodGet && strings.Contains(r.URL.Path, whlRelativePath):
+			w.WriteHeader(http.StatusForbidden)
+			_, _ = w.Write([]byte(blockResponse))
+
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	})
+	defer serverMock.Close()
+
+	rtAuth := rtManager.GetConfig().GetServiceDetails()
+	httpClientDetails := rtAuth.CreateHttpClientDetails()
+
+	analyzer := treeAnalyzer{
+		rtManager:            rtManager,
+		extractPoliciesRegex: regexp.MustCompile(extractPoliciesRegexTemplate),
+		rtAuth:               rtAuth,
+		httpClientDetails:    httpClientDetails,
+		url:                  rtAuth.GetUrl(),
+		repo:                 repo,
+		tech:                 techutils.Pip,
+		parallelRequests:     1,
+	}
+
+	// Transitive PinnedRequirement: langchain-core with deepagents as parent.
+	pins := []python.PinnedRequirement{
+		{
+			Name:          blockedPkg,
+			VersionRange:  rangeSpec,
+			ParentName:    parentPkg,
+			ParentVersion: parentVer,
+		},
+	}
+
+	statuses := analyzer.fetchCvsBlockedStatus(pins)
+	require.Len(t, statuses, 1)
+
+	s := statuses[0]
+
+	// Blocked package attribution
+	assert.Equal(t, blockedPkg, s.PackageName, "blocked package name")
+	assert.Equal(t, blockedVer, s.PackageVersion, "blocked package version — newest satisfying range")
+
+	// Parent (direct dep) attribution
+	assert.Equal(t, parentPkg, s.ParentName, "direct dependency name")
+	assert.Equal(t, parentVer, s.ParentVersion, "direct dependency version")
+
+	// Policy details recovered from the 403 probe
+	require.Len(t, s.Policy, 1)
+	assert.Equal(t, expectedPolicy, s.Policy[0].Policy, "violated policy name")
+	assert.Equal(t, expectedCond, s.Policy[0].Condition, "violated condition name")
+	assert.Equal(t, expectedExpl, s.Policy[0].Explanation, "explanation")
+	assert.Equal(t, expectedRec, s.Policy[0].Recommendation, "recommendation")
+	assert.Equal(t, blocked, s.Action)
+}
+
+// TestFetchCvsBlockedStatusNotInMetadataNotRendered verifies that a version absent from the metadata API is not rendered as a blocked row.
+func TestFetchCvsBlockedStatusNotInMetadataNotRendered(t *testing.T) {
+	const (
+		repo = "test-pip-repo"
+		pkg  = "telnyx"
+		ver  = "4.87.1000" // not in the metadata API
+	)
+
+	serverMock, _, rtManager := coreCommonTests.CreateRtRestsMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/pypi/"+pkg+"/"+ver+"/json"):
+			w.WriteHeader(http.StatusNotFound)
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	})
+	defer serverMock.Close()
+
+	rtAuth := rtManager.GetConfig().GetServiceDetails()
+	analyzer := treeAnalyzer{
+		rtManager:            rtManager,
+		extractPoliciesRegex: regexp.MustCompile(extractPoliciesRegexTemplate),
+		rtAuth:               rtAuth,
+		httpClientDetails:    rtAuth.CreateHttpClientDetails(),
+		url:                  rtAuth.GetUrl(),
+		repo:                 repo,
+		tech:                 techutils.Pip,
+		parallelRequests:     1,
+	}
+
+	pins := []python.PinnedRequirement{
+		{Name: pkg, Version: ver, ParentName: pkg, ParentVersion: ver},
+	}
+
+	statuses := analyzer.fetchCvsBlockedStatus(pins)
+	assert.Empty(t, statuses, "a version absent from the metadata API must not be rendered as a blocked row")
+}
+
 func TestValidateRunNativeForTech(t *testing.T) {
 	// Sanity: npm and pnpm are the allow-listed techs. Both flag states pass.
 	assert.NoError(t, validateRunNativeForTech(techutils.Npm, true))

--- a/sca/bom/buildinfo/technologies/pnpm/pnpm_test.go
+++ b/sca/bom/buildinfo/technologies/pnpm/pnpm_test.go
@@ -44,7 +44,7 @@ func TestBuildDependencyTreeLimitedDepth(t *testing.T) {
 			name:      "With transitive dependencies",
 			treeDepth: "1",
 			expectedUniqueDeps: []string{
-				"npm://axios:1.17.0",
+				"npm://axios:1.18.0",
 				"npm://balaganjs:1.0.0",
 				"npm://yargs:13.3.0",
 				"npm://zen-website:1.0.0",
@@ -54,7 +54,7 @@ func TestBuildDependencyTreeLimitedDepth(t *testing.T) {
 				Nodes: []*xrayUtils.GraphNode{
 					{
 						Id:    "npm://balaganjs:1.0.0",
-						Nodes: []*xrayUtils.GraphNode{{Id: "npm://axios:1.17.0"}, {Id: "npm://yargs:13.3.0"}},
+						Nodes: []*xrayUtils.GraphNode{{Id: "npm://axios:1.18.0"}, {Id: "npm://yargs:13.3.0"}},
 					},
 				},
 			},

--- a/sca/bom/buildinfo/technologies/python/python.go
+++ b/sca/bom/buildinfo/technologies/python/python.go
@@ -295,14 +295,15 @@ func installPipDeps(params technologies.BuildInfoBomGeneratorParams) (setupFileU
 		}
 		setupFileUsed = false
 	}
-	// When CVS hides the pinned version from the simple-index, pip fails
-	// with "No matching distribution found" instead of hitting a 403, so
-	// IsForbiddenOutput never fires. Replace the misleading pip error with
-	// a structured one.
-	if err != nil && params.IsCurationCmd && remoteUrl != "" &&
-		isCvsVersionFilteredOutput(errors.Join(err, reqErr).Error()) {
-		pins := parseCvsFailedPackages(errors.Join(err, reqErr).Error())
-		err = errors.Join(err, errors.New(formatCvsBlockedRequirementsMessage(pins)))
+	// When CVS hides the pinned version from the simple-index, pip fails with
+	// "No matching distribution found" instead of hitting a 403. Return a
+	// structured CvsBlockedError so the curation-audit command can recover
+	// policy details via the PyPI metadata-API fallback and still produce a
+	// (partial) curation table instead of failing with no report at all.
+	if err != nil && params.IsCurationCmd && remoteUrl != "" {
+		if combinedOutput := errors.Join(err, reqErr).Error(); isCvsVersionFilteredOutput(combinedOutput) {
+			err = &CvsBlockedError{Packages: parseCvsFailedPackages(combinedOutput), Cause: err}
+		}
 	}
 	if err != nil || reqErr != nil {
 		if msgToUser := technologies.GetMsgToUserForCurationBlock(params.IsCurationCmd, techutils.Pip, errors.Join(err, reqErr).Error()); msgToUser != "" {

--- a/sca/bom/buildinfo/technologies/python/python_cvs_fallback.go
+++ b/sca/bom/buildinfo/technologies/python/python_cvs_fallback.go
@@ -1,40 +1,145 @@
 package python
 
 import (
+	"errors"
 	"fmt"
 	"regexp"
+	"slices"
 	"strings"
+
+	"github.com/jfrog/gofrog/version"
 )
 
-type pinnedRequirement struct {
-	Name    string
-	Version string
+// PinnedRequirement is a blocker extracted from pip's failure output.
+type PinnedRequirement struct {
+	Name          string
+	Version       string
+	VersionRange  string
+	ParentName    string
+	ParentVersion string
 }
 
-// pipFailedPinnedReqRegex extracts a pinned name==version from pip's "No
-// matching distribution found for X==Y" and "satisfies the requirement X==Y"
-// error lines. Only exact == pins are captured; range specifiers are skipped
-// because they represent transitive constraints, not the user's direct pin.
+// CvsBlockedError is returned when CVS hides a pinned version from the simple index.
+// Packages lists the blockers so the curation-audit command can recover policy details via the metadata-API fallback.
+type CvsBlockedError struct {
+	Packages []PinnedRequirement
+	Cause    error
+}
+
+func (e *CvsBlockedError) Error() string {
+	return errors.Join(e.Cause, errors.New(formatCvsBlockedRequirementsMessage(e.Packages))).Error()
+}
+
+func (e *CvsBlockedError) Unwrap() error { return e.Cause }
+
+// pipFailedPinnedReqRegex matches exact == pins in pip's error output.
+// Groups: (1) name, (2) version.
 var pipFailedPinnedReqRegex = regexp.MustCompile(
 	`(?:No matching distribution found for|satisfies the requirement)\s+` +
 		`([A-Za-z0-9][A-Za-z0-9._-]*)(?:\[[^\]]*\])?==([^\s(,;]+)`)
 
-// parseCvsFailedPackages extracts the pinned packages that pip explicitly
-// reported as unresolvable from pip's error output. This ensures only the
-// packages that actually caused the failure are listed, not every pin in the
-// requirements file.
-func parseCvsFailedPackages(pipOutput string) []pinnedRequirement {
-	var failed []pinnedRequirement
+// pipFailedRangeReqRegex matches range-based failures in pip's error output.
+// Groups: (1) name, (2) range-spec, (3) parent-name (optional), (4) parent-version (optional).
+var pipFailedRangeReqRegex = regexp.MustCompile(
+	`(?:No matching distribution found for|satisfies the requirement)\s+` +
+		`([A-Za-z0-9][A-Za-z0-9._-]*)(?:\[[^\]]*\])?((?:(?:~=|!=|>=|<=|>|<)[^\s,(]+(?:,(?:~=|!=|>=|<=|>|<)[^\s,(]+)*))` +
+		`(?:\s+\(from\s+([A-Za-z0-9][A-Za-z0-9._-]*)(?:==([^\s)]+))?\))?`)
+
+// pipCollectingRegex matches packages pip collected before failing; used to recover parent version omitted in "(from <parent>)".
+// Groups: (1) name, (2) version.
+var pipCollectingRegex = regexp.MustCompile(
+	`Collecting\s+([A-Za-z0-9][A-Za-z0-9._-]*)(?:\[[^\]]*\])?==([^\s(,;]+)`)
+
+// pipResolutionImpossibleRegex matches the indented package list in a ResolutionImpossible error; stops at the first blank line.
+// Group: (1) block of indented package lines.
+var pipResolutionImpossibleRegex = regexp.MustCompile(
+	`no matching distributions available for your environment:\r?\n((?:[ \t]+[A-Za-z0-9][A-Za-z0-9._-]*[ \t]*\r?\n)+)`)
+
+// pipDirectFromRequirementsRegex matches a top-level dep from requirements.txt; used to attribute a ResolutionImpossible blocker to the direct dep.
+// Groups: (1) name, (2) version.
+var pipDirectFromRequirementsRegex = regexp.MustCompile(
+	`Collecting\s+([A-Za-z0-9][A-Za-z0-9._-]*)(?:\[[^\]]*\])?==([^\s(,;]+)\s+\(from\s+-r\s`)
+
+// parseCvsFailedPackages extracts blockers from pip's failure output.
+// Only packages that caused the failure are returned, not every requirements entry.
+func parseCvsFailedPackages(pipOutput string) []PinnedRequirement {
 	seen := map[string]bool{}
+	var failed []PinnedRequirement
+
+	// collected versions: recover parent version when pip omits it in "(from X)".
+	collected := map[string]string{}
+	for _, m := range pipCollectingRegex.FindAllStringSubmatch(pipOutput, -1) {
+		collected[normalizePyPIName(m[1])] = strings.TrimRight(m[2], ")")
+	}
+
+	// Exact pins first.
 	for _, m := range pipFailedPinnedReqRegex.FindAllStringSubmatch(pipOutput, -1) {
 		name := normalizePyPIName(m[1])
-		version := strings.TrimRight(m[2], ")")
-		key := name + "==" + version
+		ver := strings.TrimRight(m[2], ")")
+		key := name + "==" + ver
 		if !seen[key] {
 			seen[key] = true
-			failed = append(failed, pinnedRequirement{Name: name, Version: version})
+			failed = append(failed, PinnedRequirement{
+				Name:          name,
+				Version:       ver,
+				ParentName:    name,
+				ParentVersion: ver,
+			})
 		}
 	}
+
+	// Range specs (transitive or ranged direct deps).
+	for _, m := range pipFailedRangeReqRegex.FindAllStringSubmatch(pipOutput, -1) {
+		name := normalizePyPIName(m[1])
+		rangeSpec := m[2]
+		key := name + rangeSpec
+		if seen[key] {
+			continue
+		}
+		seen[key] = true
+		pr := PinnedRequirement{
+			Name:         name,
+			VersionRange: rangeSpec,
+		}
+		if m[3] != "" {
+			pr.ParentName = normalizePyPIName(m[3])
+			pr.ParentVersion = m[4]
+			// pip omitted parent version in "(from X)" — recover from its Collecting line.
+			if pr.ParentVersion == "" {
+				pr.ParentVersion = collected[pr.ParentName]
+			}
+		} else {
+			// No "(from X)" captured — treat as direct dep; parent resolved later.
+			pr.ParentName = name
+		}
+		failed = append(failed, pr)
+	}
+
+	// ResolutionImpossible: deep transitive deps stripped by CVS never appear in a
+	// "No matching distribution found" line, so add them as name-only entries.
+	if m := pipResolutionImpossibleRegex.FindStringSubmatch(pipOutput); len(m) > 1 {
+		// Attribute to the single direct dep from requirements.txt when unambiguous;
+		// with multiple direct deps the attribution is unclear so leave self-attributed.
+		var directName, directVer string
+		if dm := pipDirectFromRequirementsRegex.FindAllStringSubmatch(pipOutput, -1); len(dm) == 1 {
+			directName = normalizePyPIName(dm[0][1])
+			directVer = strings.TrimRight(dm[0][2], ")")
+		}
+		for _, raw := range strings.Fields(m[1]) {
+			name := normalizePyPIName(strings.TrimSpace(raw))
+			if name == "" || seen[name] {
+				continue
+			}
+			seen[name] = true
+			pr := PinnedRequirement{Name: name, ParentName: name}
+			if directName != "" && directName != name {
+				pr.ParentName = directName
+				pr.ParentVersion = directVer
+			}
+			failed = append(failed, pr)
+		}
+	}
+
 	return failed
 }
 
@@ -44,13 +149,17 @@ func normalizePyPIName(name string) string {
 	return strings.ToLower(pypiNameNormalizeRegex.ReplaceAllString(name, "-"))
 }
 
-func formatCvsBlockedRequirementsMessage(pins []pinnedRequirement) string {
+func formatCvsBlockedRequirementsMessage(pins []PinnedRequirement) string {
 	var b strings.Builder
 	b.WriteString("Curation audit failed: one or more pinned package versions were unavailable during dependency resolution, so the corresponding curation policy violations could not be evaluated.")
 	if len(pins) > 0 {
 		b.WriteString("\n\nAffected package(s):\n")
 		for _, p := range pins {
-			fmt.Fprintf(&b, " - %s==%s\n", p.Name, p.Version)
+			if p.VersionRange != "" {
+				fmt.Fprintf(&b, " - %s%s\n", p.Name, p.VersionRange)
+			} else {
+				fmt.Fprintf(&b, " - %s==%s\n", p.Name, p.Version)
+			}
 		}
 	}
 	return b.String()
@@ -58,5 +167,72 @@ func formatCvsBlockedRequirementsMessage(pins []pinnedRequirement) string {
 
 func isCvsVersionFilteredOutput(output string) bool {
 	return strings.Contains(output, "No matching distribution found") ||
-		strings.Contains(output, "Could not find a version that satisfies the requirement")
+		strings.Contains(output, "Could not find a version that satisfies the requirement") ||
+		// ResolutionImpossible: direct dep resolved but a transitive dep was stripped by CVS.
+		(strings.Contains(output, "ResolutionImpossible") &&
+			strings.Contains(output, "no matching distributions available for your environment"))
+}
+
+// ResolveVersionRange returns the newest version from candidates satisfying rangeSpec.
+// Returns "" if no candidate matches.
+func ResolveVersionRange(rangeSpec string, candidates []string) string {
+	var matching []string
+	for _, v := range candidates {
+		if versionMatchesRange(v, rangeSpec) {
+			matching = append(matching, v)
+		}
+	}
+	if len(matching) == 0 {
+		return ""
+	}
+	slices.SortFunc(matching, func(a, b string) int {
+		va := version.NewVersion(a)
+		switch {
+		case va.Compare(b) < 0:
+			return -1
+		case va.Compare(b) > 0:
+			return 1
+		default:
+			return 0
+		}
+	})
+	return matching[0]
+}
+
+// versionMatchesRange reports whether v satisfies all constraints in rangeSpec.
+func versionMatchesRange(v, rangeSpec string) bool {
+	ver := version.NewVersion(v)
+	for _, part := range strings.Split(rangeSpec, ",") {
+		if !versionMatchesConstraint(ver, strings.TrimSpace(part)) {
+			return false
+		}
+	}
+	return true
+}
+
+// versionMatchesConstraint reports whether v satisfies a single PEP 440 specifier.
+func versionMatchesConstraint(ver *version.Version, constraint string) bool {
+	for _, op := range []string{"~=", "!=", ">=", "<=", ">", "<", "=="} {
+		if !strings.HasPrefix(constraint, op) {
+			continue
+		}
+		c := constraint[len(op):]
+		switch op {
+		case ">=":
+			return ver.Compare(c) <= 0
+		case ">":
+			return ver.Compare(c) < 0
+		case "<=":
+			return ver.Compare(c) >= 0
+		case "<":
+			return ver.Compare(c) > 0
+		case "==":
+			return ver.Compare(c) == 0
+		case "!=":
+			return ver.Compare(c) != 0
+		case "~=":
+			return ver.AtLeast(c)
+		}
+	}
+	return true
 }

--- a/sca/bom/buildinfo/technologies/python/python_cvs_fallback.go
+++ b/sca/bom/buildinfo/technologies/python/python_cvs_fallback.go
@@ -251,5 +251,5 @@ func versionMatchesConstraint(ver *version.Version, constraint string) bool {
 			return !ver.AtLeast(upper)
 		}
 	}
-	return true
+	return false
 }

--- a/sca/bom/buildinfo/technologies/python/python_cvs_fallback.go
+++ b/sca/bom/buildinfo/technologies/python/python_cvs_fallback.go
@@ -156,11 +156,12 @@ func formatCvsBlockedRequirementsMessage(pins []PinnedRequirement) string {
 	if len(pins) > 0 {
 		b.WriteString("\n\nAffected package(s):\n")
 		for _, p := range pins {
-			if p.VersionRange != "" {
+			switch {
+			case p.VersionRange != "":
 				fmt.Fprintf(&b, " - %s%s\n", p.Name, p.VersionRange)
-			} else if p.Version != "" {
+			case p.Version != "":
 				fmt.Fprintf(&b, " - %s==%s\n", p.Name, p.Version)
-			} else {
+			default:
 				fmt.Fprintf(&b, " - %s (version unknown)\n", p.Name)
 			}
 		}

--- a/sca/bom/buildinfo/technologies/python/python_cvs_fallback.go
+++ b/sca/bom/buildinfo/technologies/python/python_cvs_fallback.go
@@ -158,8 +158,10 @@ func formatCvsBlockedRequirementsMessage(pins []PinnedRequirement) string {
 		for _, p := range pins {
 			if p.VersionRange != "" {
 				fmt.Fprintf(&b, " - %s%s\n", p.Name, p.VersionRange)
-			} else {
+			} else if p.Version != "" {
 				fmt.Fprintf(&b, " - %s==%s\n", p.Name, p.Version)
+			} else {
+				fmt.Fprintf(&b, " - %s (version unknown)\n", p.Name)
 			}
 		}
 	}

--- a/sca/bom/buildinfo/technologies/python/python_cvs_fallback.go
+++ b/sca/bom/buildinfo/technologies/python/python_cvs_fallback.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"regexp"
 	"slices"
+	"strconv"
 	"strings"
 
 	"github.com/jfrog/gofrog/version"
@@ -231,7 +232,23 @@ func versionMatchesConstraint(ver *version.Version, constraint string) bool {
 		case "!=":
 			return ver.Compare(c) != 0
 		case "~=":
-			return ver.AtLeast(c)
+			// PEP 440: ~= X.Y means >= X.Y AND < (X+1).0; ~= X.Y.Z means >= X.Y.Z AND < X.(Y+1).0
+			if !ver.AtLeast(c) {
+				return false
+			}
+			parts := strings.Split(c, ".")
+			if len(parts) < 2 {
+				return false
+			}
+			upperParts := make([]string, len(parts)-1)
+			copy(upperParts, parts[:len(parts)-1])
+			last, err := strconv.Atoi(upperParts[len(upperParts)-1])
+			if err != nil {
+				return false
+			}
+			upperParts[len(upperParts)-1] = strconv.Itoa(last + 1)
+			upper := strings.Join(upperParts, ".") + ".0"
+			return !ver.AtLeast(upper)
 		}
 	}
 	return true

--- a/sca/bom/buildinfo/technologies/python/python_cvs_fallback_test.go
+++ b/sca/bom/buildinfo/technologies/python/python_cvs_fallback_test.go
@@ -230,6 +230,9 @@ func TestVersionMatchesConstraintCompatibleRelease(t *testing.T) {
 		{"1.4.9", "~=1.4.2", true},
 		{"1.5.0", "~=1.4.2", false},
 		{"1.4.1", "~=1.4.2", false},
+		// unrecognized operator should not match
+		{"1.0.0", "1.0.0", false},
+		{"1.0.0", "===1.0.0", false},
 	}
 	for _, tc := range cases {
 		t.Run(tc.v+"_"+tc.constraint, func(t *testing.T) {

--- a/sca/bom/buildinfo/technologies/python/python_cvs_fallback_test.go
+++ b/sca/bom/buildinfo/technologies/python/python_cvs_fallback_test.go
@@ -3,6 +3,7 @@ package python
 import (
 	"testing"
 
+	"github.com/jfrog/gofrog/version"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -211,3 +212,29 @@ func TestVersionMatchesRange(t *testing.T) {
 		})
 	}
 }
+
+func TestVersionMatchesConstraintCompatibleRelease(t *testing.T) {
+	cases := []struct {
+		v          string
+		constraint string
+		want       bool
+	}{
+		// ~= 1.4 means >= 1.4 AND < 2.0
+		{"1.4.0", "~=1.4", true},
+		{"1.9.9", "~=1.4", true},
+		{"2.0.0", "~=1.4", false},
+		{"3.0.0", "~=1.4", false},
+		{"1.3.9", "~=1.4", false},
+		// ~= 1.4.2 means >= 1.4.2 AND < 1.5.0
+		{"1.4.2", "~=1.4.2", true},
+		{"1.4.9", "~=1.4.2", true},
+		{"1.5.0", "~=1.4.2", false},
+		{"1.4.1", "~=1.4.2", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.v+"_"+tc.constraint, func(t *testing.T) {
+			assert.Equal(t, tc.want, versionMatchesConstraint(version.NewVersion(tc.v), tc.constraint))
+		})
+	}
+}
+

--- a/sca/bom/buildinfo/technologies/python/python_cvs_fallback_test.go
+++ b/sca/bom/buildinfo/technologies/python/python_cvs_fallback_test.go
@@ -138,6 +138,15 @@ func TestFormatCvsBlockedRequirementsMessageRange(t *testing.T) {
 	assert.Contains(t, msg, " - langchain-core>=1.4.0,<2.0.0")
 }
 
+func TestFormatCvsBlockedRequirementsMessageResolutionImpossible(t *testing.T) {
+	// ResolutionImpossible entries have no Version and no VersionRange — must not emit a trailing "==".
+	msg := formatCvsBlockedRequirementsMessage(
+		[]PinnedRequirement{{Name: "langgraph-sdk", ParentName: "langgraph-sdk"}})
+
+	assert.Contains(t, msg, " - langgraph-sdk (version unknown)")
+	assert.NotContains(t, msg, "langgraph-sdk==")
+}
+
 func TestCvsBlockedError(t *testing.T) {
 	pins := []PinnedRequirement{{Name: "deepagents", Version: "0.6.8", ParentName: "deepagents", ParentVersion: "0.6.8"}}
 	cause := assert.AnError

--- a/sca/bom/buildinfo/technologies/python/python_cvs_fallback_test.go
+++ b/sca/bom/buildinfo/technologies/python/python_cvs_fallback_test.go
@@ -10,32 +10,84 @@ func TestParseCvsFailedPackages(t *testing.T) {
 	cases := []struct {
 		name   string
 		output string
-		want   []pinnedRequirement
+		want   []PinnedRequirement
 	}{
 		{
 			name:   "no matching distribution",
 			output: "ERROR: No matching distribution found for deepagents==0.5.5",
-			want:   []pinnedRequirement{{Name: "deepagents", Version: "0.5.5"}},
+			want:   []PinnedRequirement{{Name: "deepagents", Version: "0.5.5", ParentName: "deepagents", ParentVersion: "0.5.5"}},
 		},
 		{
 			name:   "could not find a version",
 			output: "ERROR: Could not find a version that satisfies the requirement langchain-core==1.4.0 (from versions: 1.0.0)",
-			want:   []pinnedRequirement{{Name: "langchain-core", Version: "1.4.0"}},
+			want:   []PinnedRequirement{{Name: "langchain-core", Version: "1.4.0", ParentName: "langchain-core", ParentVersion: "1.4.0"}},
 		},
 		{
 			name:   "name is normalized",
 			output: "ERROR: No matching distribution found for Langchain_Core==1.4.0",
-			want:   []pinnedRequirement{{Name: "langchain-core", Version: "1.4.0"}},
-		},
-		{
-			name:   "range specifiers are not captured",
-			output: "ERROR: Could not find a version that satisfies the requirement langchain-core<2.0.0,>=1.3.2 (from deepagents)",
-			want:   nil,
+			want:   []PinnedRequirement{{Name: "langchain-core", Version: "1.4.0", ParentName: "langchain-core", ParentVersion: "1.4.0"}},
 		},
 		{
 			name:   "deduplicates repeated lines",
 			output: "ERROR: No matching distribution found for deepagents==0.5.5\nERROR: No matching distribution found for deepagents==0.5.5",
-			want:   []pinnedRequirement{{Name: "deepagents", Version: "0.5.5"}},
+			want: []PinnedRequirement{
+				{Name: "deepagents", Version: "0.5.5", ParentName: "deepagents", ParentVersion: "0.5.5"},
+			},
+		},
+		{
+			name:   "range spec without parent",
+			output: "ERROR: No matching distribution found for langchain-core>=1.4.0,<2.0.0",
+			want: []PinnedRequirement{
+				{Name: "langchain-core", VersionRange: ">=1.4.0,<2.0.0", ParentName: "langchain-core"},
+			},
+		},
+		{
+			name:   "range spec with parent",
+			output: "ERROR: Could not find a version that satisfies the requirement langchain-core>=1.4.0 (from deepagents==0.6.8)",
+			want: []PinnedRequirement{
+				{Name: "langchain-core", VersionRange: ">=1.4.0", ParentName: "deepagents", ParentVersion: "0.6.8"},
+			},
+		},
+		{
+			// pip omits the version in "(from deepagents)"; recovered from the "Collecting" line.
+			name: "transitive range, parent version recovered from Collecting line",
+			output: "Collecting deepagents==0.6.8 (from -r requirements.txt (line 1))\n" +
+				"ERROR: Could not find a version that satisfies the requirement langchain-core<2.0.0,>=1.4.0 (from deepagents) (from versions: 1.3.3, 1.4.0a1)\n" +
+				"ERROR: No matching distribution found for langchain-core<2.0.0,>=1.4.0",
+			want: []PinnedRequirement{
+				{Name: "langchain-core", VersionRange: "<2.0.0,>=1.4.0", ParentName: "deepagents", ParentVersion: "0.6.8"},
+			},
+		},
+		{
+			// Package list must not spill past the blank line into the "To fix this" instruction text.
+			name: "ResolutionImpossible attributes blocker to direct dep",
+			output: "Collecting deepagents==0.6.9 (from -r requirements.txt (line 1))\n" +
+				"  Downloading deepagents-0.6.9-py3-none-any.whl (221 kB)\n" +
+				"ERROR: Cannot install langchain because these package versions have conflicting dependencies.\n" +
+				"The conflict is caused by:\n" +
+				"    langgraph 1.2.5 depends on langgraph-sdk<0.5.0 and >=0.4.2\n" +
+				"Additionally, some packages in these conflicts have no matching distributions available for your environment:\n" +
+				"    langgraph-sdk\n" +
+				"\n" +
+				"To fix this you could try to:\n" +
+				"1. loosen the range of package versions you've specified\n" +
+				"ERROR: ResolutionImpossible: for help visit ...\n",
+			want: []PinnedRequirement{
+				{Name: "langgraph-sdk", ParentName: "deepagents", ParentVersion: "0.6.9"},
+			},
+		},
+		{
+			// Multiple direct deps → ambiguous attribution, blocker stays self-attributed.
+			name: "ResolutionImpossible with multiple stripped deps",
+			output: "no matching distributions available for your environment:\n" +
+				"    langgraph-sdk\n" +
+				"    another-pkg\n" +
+				"\n" +
+				"To fix this you could try to:\n",
+			want: []PinnedRequirement{
+				{Name: "langgraph-sdk", ParentName: "langgraph-sdk"},
+				{Name: "another-pkg", ParentName: "another-pkg"},
+			},
 		},
 		{
 			name:   "unrelated pip error yields nothing",
@@ -51,10 +103,15 @@ func TestParseCvsFailedPackages(t *testing.T) {
 }
 
 func TestIsCvsVersionFilteredOutput(t *testing.T) {
+	resolutionImpossible := "ERROR: ResolutionImpossible\n" +
+		"Additionally, some packages in these conflicts have no matching distributions available for your environment:\n" +
+		"    langgraph-sdk"
 	cases := map[string]bool{
 		"ERROR: No matching distribution found for deepagents==0.5.5":                                 true,
 		"ERROR: Could not find a version that satisfies the requirement langchain-core<2.0.0,>=1.3.2": true,
-		"ERROR: 403 Forbidden": false,
+		resolutionImpossible:                               true,
+		"ERROR: 403 Forbidden":                             false,
+		"ERROR: ResolutionImpossible: some other conflict": false, // no "no matching distributions" line
 	}
 	for output, want := range cases {
 		t.Run(output, func(t *testing.T) {
@@ -65,10 +122,92 @@ func TestIsCvsVersionFilteredOutput(t *testing.T) {
 
 func TestFormatCvsBlockedRequirementsMessage(t *testing.T) {
 	msg := formatCvsBlockedRequirementsMessage(
-		[]pinnedRequirement{{Name: "deepagents", Version: "0.5.5"}})
+		[]PinnedRequirement{{Name: "deepagents", Version: "0.5.5", ParentName: "deepagents", ParentVersion: "0.5.5"}})
 
 	assert.Contains(t, msg, "Curation audit failed")
 	assert.Contains(t, msg, "could not be evaluated")
 	assert.Contains(t, msg, "Affected package(s):")
 	assert.Contains(t, msg, " - deepagents==0.5.5")
+}
+
+func TestFormatCvsBlockedRequirementsMessageRange(t *testing.T) {
+	msg := formatCvsBlockedRequirementsMessage(
+		[]PinnedRequirement{{Name: "langchain-core", VersionRange: ">=1.4.0,<2.0.0", ParentName: "deepagents"}})
+
+	assert.Contains(t, msg, " - langchain-core>=1.4.0,<2.0.0")
+}
+
+func TestCvsBlockedError(t *testing.T) {
+	pins := []PinnedRequirement{{Name: "deepagents", Version: "0.6.8", ParentName: "deepagents", ParentVersion: "0.6.8"}}
+	cause := assert.AnError
+	err := &CvsBlockedError{Packages: pins, Cause: cause}
+
+	assert.ErrorIs(t, err, cause)
+	assert.Contains(t, err.Error(), "deepagents==0.6.8")
+	assert.Contains(t, err.Error(), "Curation audit failed")
+}
+
+func TestResolveVersionRange(t *testing.T) {
+	cases := []struct {
+		name       string
+		rangeSpec  string
+		candidates []string
+		want       string
+	}{
+		{
+			name:       "picks newest in range",
+			rangeSpec:  ">=1.4.0,<2.0.0",
+			candidates: []string{"1.0.0", "1.4.0", "1.5.0", "1.9.9", "2.0.0", "2.1.0"},
+			want:       "1.9.9",
+		},
+		{
+			name:       "no candidate satisfies range",
+			rangeSpec:  ">=3.0.0",
+			candidates: []string{"1.0.0", "2.0.0"},
+			want:       "",
+		},
+		{
+			name:       "exact pin via == in range",
+			rangeSpec:  "==1.4.0",
+			candidates: []string{"1.3.0", "1.4.0", "1.5.0"},
+			want:       "1.4.0",
+		},
+		{
+			name:       "greater than strictly",
+			rangeSpec:  ">1.4.0",
+			candidates: []string{"1.4.0", "1.4.1", "1.5.0"},
+			want:       "1.5.0",
+		},
+		{
+			name:       "not equal excludes version",
+			rangeSpec:  "!=1.5.0,>=1.4.0",
+			candidates: []string{"1.4.0", "1.5.0", "1.6.0"},
+			want:       "1.6.0",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, ResolveVersionRange(tc.rangeSpec, tc.candidates))
+		})
+	}
+}
+
+func TestVersionMatchesRange(t *testing.T) {
+	cases := []struct {
+		v         string
+		rangeSpec string
+		want      bool
+	}{
+		{"1.5.0", ">=1.4.0,<2.0.0", true},
+		{"1.4.0", ">=1.4.0,<2.0.0", true},
+		{"2.0.0", ">=1.4.0,<2.0.0", false},
+		{"1.3.9", ">=1.4.0", false},
+		{"1.4.0", "!=1.4.0", false},
+		{"1.4.1", "!=1.4.0", true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.v+"_"+tc.rangeSpec, func(t *testing.T) {
+			assert.Equal(t, tc.want, versionMatchesRange(tc.v, tc.rangeSpec))
+		})
+	}
 }

--- a/utils/formats/summary.go
+++ b/utils/formats/summary.go
@@ -60,6 +60,9 @@ type ScaScanResultSummary struct {
 type CuratedPackages struct {
 	Blocked      []BlockedPackages `json:"blocked,omitempty"`
 	PackageCount int               `json:"num_packages,omitempty"`
+	// IsPartial is true when the dependency tree could not be fully resolved (e.g. CVS pip fallback).
+	// PackageCount reflects only recovered blocked packages, not the full tree size.
+	IsPartial bool `json:"partial,omitempty"`
 }
 
 type BlockedPackages struct {


### PR DESCRIPTION
- [ ] The pull request is targeting the `dev` branch.
- [ ] The code has been validated to compile successfully by running `go vet ./...`.
- [ ] The code has been formatted properly using `go fmt ./...`.
- [ ] All [static analysis checks](https://github.com/jfrog/jfrog-cli-security/actions/workflows/analysis.yml) passed.
- [ ] All [tests](https://github.com/jfrog/jfrog-cli-security/actions/workflows/test.yml) have passed. If this feature is not already covered by the tests, new tests have been added.
- [ ] Updated the [Contributing page](https://github.com/jfrog/jfrog-cli-security/blob/main/CONTRIBUTING.md) / [ReadMe page](https://github.com/jfrog/jfrog-cli-security/blob/main/README.md) / [CI Workflow files](https://github.com/jfrog/jfrog-cli-security/tree/main/.github/workflows) if needed.
- [ ] All changes are detailed at the description. if not already covered at [JFrog Documentation](https://github.com/jfrog/documentation), new documentation have been added.

-----

**Problem**
When CVS is active, Artifactory removes blocked package versions from the pip simple index. This causes pip install to fail during jf ca dependency resolution — and the command aborts with no output instead of reporting which packages are blocked.

**Solution**
Detect CVS-induced pip failures and run a metadata-API fallback to recover curation policy details and render a partial report.
