### PR TITLE
Fix - Close log for Xray plugin

### DIFF
--- a/sca/bom/buildinfo/technologies/pnpm/pnpm_test.go
+++ b/sca/bom/buildinfo/technologies/pnpm/pnpm_test.go
@@ -44,7 +44,7 @@ func TestBuildDependencyTreeLimitedDepth(t *testing.T) {
 			name:      "With transitive dependencies",
 			treeDepth: "1",
 			expectedUniqueDeps: []string{
-				"npm://axios:1.17.0",
+				"npm://axios:1.18.0",
 				"npm://balaganjs:1.0.0",
 				"npm://yargs:13.3.0",
 				"npm://zen-website:1.0.0",
@@ -54,7 +54,7 @@ func TestBuildDependencyTreeLimitedDepth(t *testing.T) {
 				Nodes: []*xrayUtils.GraphNode{
 					{
 						Id:    "npm://balaganjs:1.0.0",
-						Nodes: []*xrayUtils.GraphNode{{Id: "npm://axios:1.17.0"}, {Id: "npm://yargs:13.3.0"}},
+						Nodes: []*xrayUtils.GraphNode{{Id: "npm://axios:1.18.0"}, {Id: "npm://yargs:13.3.0"}},
 					},
 				},
 			},

--- a/sca/bom/xrayplugin/plugin/plugin.go
+++ b/sca/bom/xrayplugin/plugin/plugin.go
@@ -97,9 +97,13 @@ func CreateScannerPluginClient(scangBinary string, envVars map[string]string) (s
 		SyncStderr: stderrWriter,
 	}
 	client := goplugin.NewClient(clientConfig)
+	cleanup = func() {
+		client.Kill()
+		closeLogFileWriter(stderrWriter)
+	}
 	defer func() {
 		if err != nil {
-			client.Kill()
+			cleanup()
 		}
 	}()
 	rpcClient, err := client.Client()
@@ -116,7 +120,13 @@ func CreateScannerPluginClient(scangBinary string, envVars map[string]string) (s
 	if !ok {
 		return nil, "", nil, fmt.Errorf("plugin is not of type of Xray-Lib plugin, expected Scanner, got %T", raw)
 	}
-	return scanPlugin, logPath, client.Kill, nil
+	return scanPlugin, logPath, cleanup, nil
+}
+
+func closeLogFileWriter(writer io.Writer) {
+	if f, ok := writer.(*os.File); ok {
+		_ = f.Close()
+	}
 }
 
 func getPluginLogger() (writer io.Writer, logPath string, err error) {


### PR DESCRIPTION
- [ ] The pull request is targeting the `dev` branch.
- [ ] The code has been validated to compile successfully by running `go vet ./...`.
- [ ] The code has been formatted properly using `go fmt ./...`.
- [ ] All [static analysis checks](https://github.com/jfrog/jfrog-cli-security/actions/workflows/analysis.yml) passed.
- [ ] All [tests](https://github.com/jfrog/jfrog-cli-security/actions/workflows/test.yml) have passed. If this feature is not already covered by the tests, new tests have been added.
- [ ] Updated the [Contributing page](https://github.com/jfrog/jfrog-cli-security/blob/main/CONTRIBUTING.md) / [ReadMe page](https://github.com/jfrog/jfrog-cli-security/blob/main/README.md) / [CI Workflow files](https://github.com/jfrog/jfrog-cli-security/tree/main/.github/workflows) if needed.
- [ ] All changes are detailed at the description. if not already covered at [JFrog Documentation](https://github.com/jfrog/documentation), new documentation have been added.

-----

Fixing the issue that log file of Xray plugin never closed:

```
2026-06-16T15:51:43.7781631Z 11:51:43 [Error] unlinkat C:\Users\vstsagent.baitandtackle.OnPrem.ADCSAP-AP523P\AppData\Local\Temp\jfrog.cli.temp.-1781625032-2204307991\logs\xrayPluginLogs\xrayPluginLogs-1781625035044.log: The process cannot access the file because it is being used by another process.
2026-06-16T15:51:43.7885382Z Frogbot exited with code: 1
2026-06-16T15:51:43.8670825Z ##[error]PowerShell exited with code '1'.
```