### PR TITLE
XRAY-145721 - Added fallback logic for Poetry

### DIFF
--- a/commands/curation/curationaudit.go
+++ b/commands/curation/curationaudit.go
@@ -86,7 +86,7 @@ const (
 	MinXrayPassThroughSupport = "3.92.0"
 	MinArtiGradleGemSupport   = "7.63.5"
 
-	// cvsPartialReportWarning is shown when pip resolution failed because CVS
+	// cvsPartialReportWarning is shown when pip or poetry resolution failed because CVS
 	// stripped a required version from the simple index, but the metadata-API
 	// fallback succeeded in recovering at least one policy violation.
 	cvsPartialReportWarning = "The curation audit was unable to fully resolve the dependency tree because one or more pinned package versions " +

--- a/commands/curation/curationaudit.go
+++ b/commands/curation/curationaudit.go
@@ -92,7 +92,7 @@ const (
 	cvsPartialReportWarning = "The curation audit was unable to fully resolve the dependency tree because one or more pinned package versions " +
 		"are blocked by the curation policy. Details of the policy violations are shown in the table below.\n" +
 		"Dependency analysis cannot proceed until these issues are addressed.\n" +
-		"Once you apply a waiver or switch to an approved version and re-run the audit, additional results will be available."
+		"Once you switch to an approved version and re-run the audit, additional results will be available."
 )
 
 var CurationOutputFormats = []string{string(outFormat.Table), string(outFormat.Json)}
@@ -361,6 +361,12 @@ func (ca *CurationAuditCommand) Run() (err error) {
 
 	for projectPath, packagesStatus := range results {
 		err = errors.Join(err, printResult(ca.OutputFormat(), projectPath, packagesStatus.packagesStatus))
+
+		// A partial report comes from the CVS fallback: the dependency tree could
+		// not be fully resolved. Never offers a waiver when the full tree wasn't built
+		if packagesStatus.isPartial {
+			continue
+		}
 
 		for _, ps := range packagesStatus.packagesStatus {
 			if ps.WaiverAllowed && !utils.IsCI() {
@@ -632,7 +638,7 @@ func (ca *CurationAuditCommand) auditTree(tech techutils.Technology, results map
 		// Instead of aborting with no output, run the metadata-API fallback to
 		// recover the curation policy and render a partial table.
 		var cvsErr *python.CvsBlockedError
-		if tech == techutils.Pip && errors.As(err, &cvsErr) {
+		if (tech == techutils.Pip || tech == techutils.Poetry) && errors.As(err, &cvsErr) {
 			return ca.runCvsFallback(cvsErr, tech, results)
 		}
 		return err
@@ -1218,18 +1224,19 @@ func (nc *treeAnalyzer) fetchNodeStatus(node xrayUtils.GraphNode, p *sync.Map) e
 	return nil
 }
 
-// runCvsFallback is called when pip resolution failed because CVS stripped a
-// pinned version from the simple index (CvsBlockedError). It uses the PyPI
-// metadata API to recover each blocker's real download URL, probes the normal
-// (non-audit) download path, and renders the policy in a partial curation table.
+// runCvsFallback is called when pip or poetry resolution failed because CVS
+// stripped a pinned version from the simple index (CvsBlockedError). It uses
+// the PyPI metadata API to recover each blocker's real download URL, probes
+// the normal (non-audit) download path, and renders the policy in a partial
+// curation table.
 func (ca *CurationAuditCommand) runCvsFallback(cvsErr *python.CvsBlockedError, tech techutils.Technology, results map[string]*CurationReport) error {
 	rtManager, serverDetails, err := ca.getRtManagerAndAuth(tech)
 	if err != nil {
-		return fmt.Errorf("curation-blocked resolution fallback: failed to get Artifactory manager (%w); pip error: %w", err, cvsErr)
+		return fmt.Errorf("curation-blocked resolution fallback: failed to get Artifactory manager (%w); %s error: %w", err, tech, cvsErr)
 	}
 	rtAuth, err := serverDetails.CreateArtAuthConfig()
 	if err != nil {
-		return fmt.Errorf("curation-blocked resolution fallback: failed to create auth config (%w); pip error: %w", err, cvsErr)
+		return fmt.Errorf("curation-blocked resolution fallback: failed to create auth config (%w); %s error: %w", err, tech, cvsErr)
 	}
 	analyzer := treeAnalyzer{
 		rtManager:            rtManager,

--- a/commands/curation/curationaudit_test.go
+++ b/commands/curation/curationaudit_test.go
@@ -2078,6 +2078,79 @@ func TestFetchCvsBlockedStatusTransitive(t *testing.T) {
 	assert.Equal(t, blocked, s.Action)
 }
 
+// TestFetchCvsBlockedStatusPoetry verifies that the CVS fallback works for a
+// poetry-pinned package: wrapPoetryCurationErr produces a *CvsBlockedError
+// and fetchCvsBlockedStatus recovers the policy from the 403 probe, with the
+// package type set to "poetry".
+func TestFetchCvsBlockedStatusPoetry(t *testing.T) {
+	const (
+		repo            = "test-poetry-repo"
+		blockedPkg      = "telnyx"
+		blockedVer      = "4.87.1"
+		expectedPolicy  = "immature-30"
+		expectedCond    = "Package version is immature (strict)"
+		expectedExpl    = "Package version is 5 days old"
+		expectedRec     = "Use an older version or wait until this version is no longer immature"
+		whlRelativePath = "packages/te/ln/telnyx-4.87.1-py3-none-any.whl"
+	)
+
+	blockMsg := fmt.Sprintf(
+		"Package %s:%s download was blocked by JFrog Packages Curation service due to the following policies violated {%s, %s, %s, %s}.",
+		blockedPkg, blockedVer, expectedPolicy, expectedCond, expectedExpl, expectedRec,
+	)
+	blockResponse := fmt.Sprintf(`{"errors":[{"status":403,"message":%q}]}`, blockMsg)
+	versionMetaJSON := fmt.Sprintf(`{"urls":[{"packagetype":"bdist_wheel","url":"../../%s"}]}`, whlRelativePath)
+
+	serverMock, _, rtManager := coreCommonTests.CreateRtRestsMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/pypi/"+blockedPkg+"/"+blockedVer+"/json"):
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(versionMetaJSON))
+		case r.Method == http.MethodHead && strings.Contains(r.URL.Path, whlRelativePath):
+			w.WriteHeader(http.StatusForbidden)
+		case r.Method == http.MethodGet && strings.Contains(r.URL.Path, whlRelativePath):
+			w.WriteHeader(http.StatusForbidden)
+			_, _ = w.Write([]byte(blockResponse))
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	})
+	defer serverMock.Close()
+
+	rtAuth := rtManager.GetConfig().GetServiceDetails()
+	httpClientDetails := rtAuth.CreateHttpClientDetails()
+
+	analyzer := treeAnalyzer{
+		rtManager:            rtManager,
+		extractPoliciesRegex: regexp.MustCompile(extractPoliciesRegexTemplate),
+		rtAuth:               rtAuth,
+		httpClientDetails:    httpClientDetails,
+		url:                  rtAuth.GetUrl(),
+		repo:                 repo,
+		tech:                 techutils.Poetry,
+		parallelRequests:     1,
+	}
+
+	// Exact-pin PinnedRequirement produced by wrapPoetryCurationErr for a poetry project.
+	pins := []python.PinnedRequirement{
+		{Name: blockedPkg, Version: blockedVer, ParentName: blockedPkg, ParentVersion: blockedVer},
+	}
+
+	statuses := analyzer.fetchCvsBlockedStatus(pins)
+	require.Len(t, statuses, 1)
+
+	s := statuses[0]
+	assert.Equal(t, blockedPkg, s.PackageName)
+	assert.Equal(t, blockedVer, s.PackageVersion)
+	assert.Equal(t, string(techutils.Poetry), s.PkgType, "package type must be poetry")
+	require.Len(t, s.Policy, 1)
+	assert.Equal(t, expectedPolicy, s.Policy[0].Policy)
+	assert.Equal(t, expectedCond, s.Policy[0].Condition)
+	assert.Equal(t, expectedExpl, s.Policy[0].Explanation)
+	assert.Equal(t, expectedRec, s.Policy[0].Recommendation)
+	assert.Equal(t, blocked, s.Action)
+}
+
 // TestFetchCvsBlockedStatusNotInMetadataNotRendered verifies that a version absent from the metadata API is not rendered as a blocked row.
 func TestFetchCvsBlockedStatusNotInMetadataNotRendered(t *testing.T) {
 	const (

--- a/sca/bom/buildinfo/technologies/pnpm/pnpm_test.go
+++ b/sca/bom/buildinfo/technologies/pnpm/pnpm_test.go
@@ -44,7 +44,7 @@ func TestBuildDependencyTreeLimitedDepth(t *testing.T) {
 			name:      "With transitive dependencies",
 			treeDepth: "1",
 			expectedUniqueDeps: []string{
-				"npm://axios:1.18.0",
+				"npm://axios:1.18.1",
 				"npm://balaganjs:1.0.0",
 				"npm://yargs:13.3.0",
 				"npm://zen-website:1.0.0",
@@ -54,7 +54,7 @@ func TestBuildDependencyTreeLimitedDepth(t *testing.T) {
 				Nodes: []*xrayUtils.GraphNode{
 					{
 						Id:    "npm://balaganjs:1.0.0",
-						Nodes: []*xrayUtils.GraphNode{{Id: "npm://axios:1.18.0"}, {Id: "npm://yargs:13.3.0"}},
+						Nodes: []*xrayUtils.GraphNode{{Id: "npm://axios:1.18.1"}, {Id: "npm://yargs:13.3.0"}},
 					},
 				},
 			},

--- a/sca/bom/buildinfo/technologies/python/python.go
+++ b/sca/bom/buildinfo/technologies/python/python.go
@@ -636,8 +636,7 @@ func wrapPoetryCurationErr(lockErr error) error {
 		return nil
 	}
 	if isCvsVersionFilteredOutput(lockErr.Error()) {
-		pins := parseCvsFailedPackages(lockErr.Error())
-		lockErr = errors.Join(lockErr, errors.New(formatCvsBlockedRequirementsMessage(pins)))
+		return &CvsBlockedError{Packages: parseCvsFailedPackages(lockErr.Error()), Cause: lockErr}
 	}
 	if msgToUser := technologies.GetMsgToUserForCurationBlock(true, techutils.Poetry, lockErr.Error()); msgToUser != "" {
 		return errors.Join(lockErr, errors.New(msgToUser))

--- a/sca/bom/buildinfo/technologies/python/python_test.go
+++ b/sca/bom/buildinfo/technologies/python/python_test.go
@@ -1,6 +1,7 @@
 package python
 
 import (
+	"errors"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -962,4 +963,27 @@ func TestInstallPoetryDepsNonCurationErrorPropagated(t *testing.T) {
 	})
 
 	require.Error(t, err, "non-curation poetry install failure must propagate to the caller")
+}
+
+func TestWrapPoetryCurationErrReturnsCvsBlockedError(t *testing.T) {
+	// CVS-stripped version: poetry emits "X (version) which doesn't match any versions".
+	lockErr := errors.New("Because sample-project depends on telnyx (4.87.1) which doesn't match any versions, version solving failed.")
+	wrapped := wrapPoetryCurationErr(lockErr)
+
+	var cvsErr *CvsBlockedError
+	require.ErrorAs(t, wrapped, &cvsErr, "CVS-filtered poetry error must be wrapped as *CvsBlockedError")
+	require.Len(t, cvsErr.Packages, 1)
+	assert.Equal(t, "telnyx", cvsErr.Packages[0].Name)
+	assert.Equal(t, "4.87.1", cvsErr.Packages[0].Version)
+	assert.ErrorIs(t, cvsErr, lockErr, "CvsBlockedError must unwrap to the original lock error")
+}
+
+func TestWrapPoetryCurationErrNonCvsPassesThrough(t *testing.T) {
+	// A plain poetry install error (not CVS) must not be wrapped as CvsBlockedError.
+	lockErr := errors.New("SolverProblemError: incompatible package constraint")
+	wrapped := wrapPoetryCurationErr(lockErr)
+
+	var cvsErr *CvsBlockedError
+	assert.False(t, errors.As(wrapped, &cvsErr), "non-CVS poetry error must not be wrapped as *CvsBlockedError")
+	assert.ErrorIs(t, wrapped, lockErr)
 }

--- a/sca/bom/buildinfo/technologies/python/python_test.go
+++ b/sca/bom/buildinfo/technologies/python/python_test.go
@@ -987,3 +987,17 @@ func TestWrapPoetryCurationErrNonCvsPassesThrough(t *testing.T) {
 	assert.False(t, errors.As(wrapped, &cvsErr), "non-CVS poetry error must not be wrapped as *CvsBlockedError")
 	assert.ErrorIs(t, wrapped, lockErr)
 }
+
+func TestWrapPoetryCurationErrMsgToUserPath(t *testing.T) {
+	// Poetry emits an HTTP 403 during poetry lock (real download block, not CVS
+	// index stripping). IsForbiddenOutput recognises "http error 403" for poetry,
+	// so GetMsgToUserForCurationBlock returns a non-empty user-facing message.
+	// wrapPoetryCurationErr must join the original error with that message.
+	lockErr := errors.New("http error 403 downloading https://artifactory.example.com/telnyx-4.87.1.tar.gz")
+	wrapped := wrapPoetryCurationErr(lockErr)
+
+	var cvsErr *CvsBlockedError
+	assert.False(t, errors.As(wrapped, &cvsErr), "403-blocked poetry error must not be wrapped as *CvsBlockedError")
+	assert.ErrorIs(t, wrapped, lockErr, "original lockErr must be in the error chain")
+	assert.Contains(t, wrapped.Error(), "poetry", "user-facing message must mention the package manager")
+}


### PR DESCRIPTION
- [ ] The pull request is targeting the `dev` branch.
- [ ] The code has been validated to compile successfully by running `go vet ./...`.
- [ ] The code has been formatted properly using `go fmt ./...`.
- [ ] All [static analysis checks](https://github.com/jfrog/jfrog-cli-security/actions/workflows/analysis.yml) passed.
- [ ] All [tests](https://github.com/jfrog/jfrog-cli-security/actions/workflows/test.yml) have passed. If this feature is not already covered by the tests, new tests have been added.
- [ ] Updated the [Contributing page](https://github.com/jfrog/jfrog-cli-security/blob/main/CONTRIBUTING.md) / [ReadMe page](https://github.com/jfrog/jfrog-cli-security/blob/main/README.md) / [CI Workflow files](https://github.com/jfrog/jfrog-cli-security/tree/main/.github/workflows) if needed.
- [ ] All changes are detailed at the description. if not already covered at [JFrog Documentation](https://github.com/jfrog/documentation), new documentation have been added.

-----
**Poetry fallback:** When a pinned Poetry package is blocked by CVS, instead of failing with no output, jf ca now uses the Artifactory PyPI metadata API to recover the policy violation and render a partial curation table — same as the existing pip fallback.

**Waiver suppression:** Waiver prompts are now skipped for partial reports (pip and poetry) since the full dependency tree wasn't resolved.