### PR TITLE
Skip failing tests due to XRAY-138919

### DIFF
--- a/git_test.go
+++ b/git_test.go
@@ -136,9 +136,10 @@ func TestGitAuditSimpleJson(t *testing.T) {
 func TestGitAuditStaticScaSimpleJson(t *testing.T) {
 	// XRAY-136444 will be fixed in 3.141.7
 	integration.InitAuditNewScaTests(t, "3.141.7")
+	securityTestUtils.SkipTestIfDurationNotPassed(t, "01-06-2026", 60, "Bug in Xray Server, should be fixed at XRAY-138919")
 	if coreutils.IsWindows() {
 		// On windows tests are failing due to the bug in Xray Server, should be fixed at XRAY-138079
-		securityTestUtils.SkipTestIfDurationNotPassed(t, "09-04-2026", 60, "Bug in Xray Server, should be fixed at XRAY-138079")
+		securityTestUtils.SkipTestIfDurationNotPassed(t, "01-06-2026", 60, "Bug in Xray Server, should be fixed at XRAY-138079")
 	}
 
 	xrayVersion := integration.GetAndValidateXrayVersion(t, securityUtils.StaticScanMinVersion)

--- a/sca/bom/buildinfo/technologies/pnpm/pnpm_test.go
+++ b/sca/bom/buildinfo/technologies/pnpm/pnpm_test.go
@@ -44,7 +44,7 @@ func TestBuildDependencyTreeLimitedDepth(t *testing.T) {
 			name:      "With transitive dependencies",
 			treeDepth: "1",
 			expectedUniqueDeps: []string{
-				"npm://axios:1.18.0",
+				"npm://axios:1.18.1",
 				"npm://balaganjs:1.0.0",
 				"npm://yargs:13.3.0",
 				"npm://zen-website:1.0.0",
@@ -54,7 +54,7 @@ func TestBuildDependencyTreeLimitedDepth(t *testing.T) {
 				Nodes: []*xrayUtils.GraphNode{
 					{
 						Id:    "npm://balaganjs:1.0.0",
-						Nodes: []*xrayUtils.GraphNode{{Id: "npm://axios:1.18.0"}, {Id: "npm://yargs:13.3.0"}},
+						Nodes: []*xrayUtils.GraphNode{{Id: "npm://axios:1.18.1"}, {Id: "npm://yargs:13.3.0"}},
 					},
 				},
 			},


### PR DESCRIPTION
- [ ] The pull request is targeting the `dev` branch.
- [ ] The code has been validated to compile successfully by running `go vet ./...`.
- [ ] The code has been formatted properly using `go fmt ./...`.
- [ ] All [static analysis checks](https://github.com/jfrog/jfrog-cli-security/actions/workflows/analysis.yml) passed.
- [ ] All [tests](https://github.com/jfrog/jfrog-cli-security/actions/workflows/test.yml) have passed. If this feature is not already covered by the tests, new tests have been added.
- [ ] Updated the [Contributing page](https://github.com/jfrog/jfrog-cli-security/blob/main/CONTRIBUTING.md) / [ReadMe page](https://github.com/jfrog/jfrog-cli-security/blob/main/README.md) / [CI Workflow files](https://github.com/jfrog/jfrog-cli-security/tree/main/.github/workflows) if needed.
- [ ] All changes are detailed at the description. if not already covered at [JFrog Documentation](https://github.com/jfrog/documentation), new documentation have been added.

-----

Skip failing test `TestGitAuditStaticScaSimpleJson` due to:
* https://jfrog-int.atlassian.net/browse/XRAY-138919