### PR TITLE
XRAY-145620 - Report actual module count in git audit config profile error

### DIFF
--- a/commands/git/audit/gitaudit.go
+++ b/commands/git/audit/gitaudit.go
@@ -91,7 +91,7 @@ func getJPDConfigProfile(params GitAuditParams) (*services.ConfigProfile, error)
 
 func verifyConfigProfile(configProfile *services.ConfigProfile) error {
 	if len(configProfile.Modules) != 1 {
-		return fmt.Errorf("more than one module was found '%s' profile. Frogbot currently supports only one module per config profile", configProfile.ProfileName)
+		return fmt.Errorf("expected exactly 1 module in '%s' profile, found %d. Frogbot currently supports only one module per config profile", configProfile.ProfileName, len(configProfile.Modules))
 	}
 	if configProfile.Modules[0].PathFromRoot != "." {
 		return fmt.Errorf("module '%s' in profile '%s' contains the following path from root: '%s'. Frogbot currently supports only a single module with a '.' path from root", configProfile.Modules[0].ModuleName, configProfile.ProfileName, configProfile.Modules[0].PathFromRoot)


### PR DESCRIPTION
## Summary

Align `jf git audit` config-profile validation with Frogbot ([XRAY-145620](https://jfrog-int.atlassian.net/browse/XRAY-145620)).

`verifyConfigProfile` now reports `expected exactly 1 module in '<profile>' profile, found %d` instead of the misleading `more than one module` message when centralized config profiles are empty.

## Companion PRs

- Xray (fix): https://github.jfrog.info/JFROG/xray/pull/20535
- Frogbot v3: https://github.com/jfrog/frogbot/pull/1371
- Frogbot v2: https://github.com/jfrog/frogbot/pull/1369

## Test plan

- [x] `go build ./commands/git/audit/...`
- [ ] `jf git audit` against 0-module profile → `found 0`