### PR TITLE
XRAY-146567 - Fixed maven proxy issue

### DIFF
--- a/sca/bom/buildinfo/technologies/java/mvn.go
+++ b/sca/bom/buildinfo/technologies/java/mvn.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 	"text/template"
 
+	"github.com/beevik/etree"
 	"github.com/jfrog/jfrog-cli-security/sca/bom/buildinfo/technologies"
 	"github.com/jfrog/jfrog-cli-security/utils/techutils"
 	"github.com/jfrog/jfrog-cli-security/utils/xray"
@@ -31,6 +32,10 @@ const (
 	// Changing this version also requires a change in MAVEN_DEP_TREE_VERSION within buildscripts/download_jars.sh
 	mavenDepTreeVersion = "1.2.0"
 	settingsXmlFile     = "settings.xml"
+
+	// curationSettingsID is the stable XML id for server/mirror/profile entries injected
+	// into the temp settings.xml. Dedicated id keeps re-runs idempotent.
+	curationSettingsID = "jfrog-curation-audit"
 )
 
 var mavenConfigPath = filepath.Join(".mvn", "maven.config")
@@ -50,15 +55,14 @@ var mavenDepTreeJar []byte
 
 type MavenDepTreeManager struct {
 	DepTreeManager
-	isInstalled bool
-	// isCurationCmd sets a dedicated cache and download URL for curation mode.
-	isCurationCmd bool
-	// mvnIncludePluginDeps enables resolution of Maven build-plugin transitive deps.
+	isInstalled          bool
+	isCurationCmd        bool
 	mvnIncludePluginDeps bool
-	// path to the curation dedicated cache
-	curationCacheFolder string
-	cmdName             MavenDepTreeCmd
-	settingsXmlPath     string
+	curationCacheFolder  string
+	cmdName              MavenDepTreeCmd
+	settingsXmlPath      string
+	// userSettingsXmlPath overrides the ~/.m2/settings.xml seed path (test-only).
+	userSettingsXmlPath string
 }
 
 func NewMavenDepTreeManager(params *DepTreeParams, cmdName MavenDepTreeCmd) *MavenDepTreeManager {
@@ -91,22 +95,17 @@ func buildMavenDependencyTree(params *DepTreeParams) (dependencyTree []*xrayUtil
 	if err != nil {
 		return
 	}
-	// Include Maven build-plugin transitive deps when requested.
-	// They are downloaded during mvn install but never appear in mvn dependency:tree,
-	// so without this step jf ca would miss curation violations that block the build.
-	// Skip if the tree is empty — no roots to attach to.
-	// The "--mvn-include-plugin-deps" literal below mirrors flags.MvnIncludePluginDeps
-	// (cli/docs/flags.go); duplicated as a string to avoid a cli->sca import cycle.
+	// Plugin deps are downloaded during mvn install but absent from mvn dependency:tree;
+	// without injection jf ca would miss curation violations that block the build.
+	// "--mvn-include-plugin-deps" is a string literal to avoid a cli->sca import cycle
+	// (mirrors flags.MvnIncludePluginDeps in cli/docs/flags.go).
 	if manager.mvnIncludePluginDeps && len(dependencyTree) > 0 {
 		switch {
 		case len(pluginDeps) > 0:
 			injectPluginDeps(uniqueDeps, dependencyTree, pluginDeps)
 		case pluginNodesPresent:
-			// Plugin ran but the plugin-deps section is empty: nothing to inject.
 			log.Debug("'--mvn-include-plugin-deps' is set: maven-dep-tree reported no build-plugin dependencies to include.")
 		default:
-			// No plugin-deps section at all: the maven-dep-tree version pre-dates the feature.
-			// Warn so plugin deps aren't silently skipped from the curation evaluation.
 			log.Warn("'--mvn-include-plugin-deps' is set but the resolved maven-dep-tree plugin did not report a " +
 				"plugin-dependencies section; plugin dependencies will not be included in the curation evaluation. " +
 				"This usually means the maven-dep-tree plugin version does not support plugin dependency resolution.")
@@ -115,8 +114,7 @@ func buildMavenDependencyTree(params *DepTreeParams) (dependencyTree []*xrayUtil
 	return
 }
 
-// injectPluginDeps adds plugin deps to uniqueDeps and fans them out to every module root.
-// Split out so the dedup guard and fan-out are unit-testable without spawning Maven.
+// injectPluginDeps adds plugin deps to uniqueDeps and attaches them to every module root.
 func injectPluginDeps(uniqueDeps map[string]*xray.DepTreeNode, dependencyTree []*xrayUtils.GraphNode, pluginDeps map[string]*xray.DepTreeNode) {
 	for id, node := range pluginDeps {
 		gavID := GavPackageTypeIdentifier + id
@@ -130,8 +128,7 @@ func injectPluginDeps(uniqueDeps map[string]*xray.DepTreeNode, dependencyTree []
 	}
 }
 
-// Runs maven-dep-tree according to cmdName. Returns the plugin output along with a function pointer to revert the plugin side effects.
-// If a non-nil clearMavenDepTreeRun pointer is returns it means we had no error during the entire function execution
+// RunMavenDepTree runs maven-dep-tree and returns the output path along with a cleanup function.
 func (mdt *MavenDepTreeManager) RunMavenDepTree() (depTreeOutput string, clearMavenDepTreeRun func() error, err error) {
 	if mdt.useWrapper {
 		mdt.useWrapper, err = isMavenWrapperExist()
@@ -139,7 +136,6 @@ func (mdt *MavenDepTreeManager) RunMavenDepTree() (depTreeOutput string, clearMa
 			return
 		}
 	}
-	// depTreeExecDir is a temp directory for all the files that are required for the maven-dep-tree run
 	depTreeExecDir, clearMavenDepTreeRun, err := mdt.CreateTempDirWithSettingsXmlIfNeeded()
 	if err != nil {
 		return
@@ -147,11 +143,7 @@ func (mdt *MavenDepTreeManager) RunMavenDepTree() (depTreeOutput string, clearMa
 	if err = mdt.installMavenDepTreePlugin(depTreeExecDir); err != nil {
 		return
 	}
-
 	depTreeOutput, err = mdt.execMavenDepTree(depTreeExecDir)
-	if err != nil {
-		return
-	}
 	return
 }
 
@@ -195,7 +187,6 @@ func (mdt *MavenDepTreeManager) runTreeCmd(depTreeExecDir string) (string, error
 	if _, err := mdt.RunMvnCmd(goals); err != nil {
 		return "", err
 	}
-
 	mavenDepTreeOutput, err := os.ReadFile(mavenDepTreePath)
 	if err != nil {
 		return "", errorutils.CheckError(err)
@@ -217,7 +208,6 @@ func (mdt *MavenDepTreeManager) RunMvnCmd(goals []string) (cmdOutput []byte, err
 	if err != nil {
 		return
 	}
-
 	defer func() {
 		if restoreMavenConfig != nil {
 			err = errors.Join(err, restoreMavenConfig())
@@ -253,8 +243,8 @@ func (mdt *MavenDepTreeManager) SetSettingsXmlPath(settingsXmlPath string) {
 	mdt.settingsXmlPath = settingsXmlPath
 }
 
-// Constructs the command to run mvnw/mvn with the given goals.
-// When using the Maven wrapper on non-Windows systems, the wrapper script is invoked via 'sh' in order to avoid "permission denied" errors.
+// buildMvnExecCommand constructs the mvn/mvnw command. On non-Windows the wrapper is
+// invoked via 'sh' to avoid "permission denied" errors on scripts without +x.
 func buildMvnExecCommand(useWrapper bool, mvnExecPath string, goals []string) *exec.Cmd {
 	var cmd *exec.Cmd
 	if useWrapper && !coreutils.IsWindows() {
@@ -272,9 +262,7 @@ func getMavenExecPath(useWrapper bool) string {
 		if coreutils.IsWindows() {
 			wrapperName += ".cmd"
 		}
-		// Prefix with "." + separator to form an explicit relative path (e.g. "./mvnw" or ".\mvnw.cmd").
-		// This is required since Go 1.19, which no longer resolves executables in the current directory
-		// via PATH unless an explicit relative path is provided.
+		// Explicit relative path required since Go 1.19 no longer resolves CWD executables via PATH.
 		return "." + string(os.PathSeparator) + wrapperName
 	}
 	return "mvn"
@@ -307,8 +295,9 @@ func removeMavenConfig() (func() error, error) {
 	return restoreMavenConfig, err
 }
 
-// Creates a new settings.xml file configured with the provided server and repository from the current MavenDepTreeManager instance.
-// The settings.xml will be written to the given path.
+// createSettingsXmlWithConfiguredArtifactory writes a temp settings.xml for the Maven run.
+// For curation runs it seeds from ~/.m2/settings.xml (preserving proxies etc.) and upserts
+// curation entries on top. For plain audit runs it uses the built-in template directly.
 func (mdt *MavenDepTreeManager) createSettingsXmlWithConfiguredArtifactory(settingsXmlPath string) error {
 	username, password, err := getArtifactoryAuthFromServer(mdt.server)
 	if err != nil {
@@ -324,6 +313,35 @@ func (mdt *MavenDepTreeManager) createSettingsXmlWithConfiguredArtifactory(setti
 	}
 
 	mdt.settingsXmlPath = filepath.Join(settingsXmlPath, settingsXmlFile)
+
+	// Plain audit runs use the template directly; only curation seeds from ~/.m2/settings.xml.
+	if !mdt.isCurationCmd {
+		return mdt.createSettingsXmlFromTemplate(username, password, remoteRepositoryFullPath)
+	}
+
+	userSettingsPath := mdt.userSettingsXmlPath
+	if userSettingsPath == "" {
+		homeDir, homeErr := os.UserHomeDir()
+		if homeErr != nil {
+			log.Debug("Could not resolve user home directory, using settings.xml template:", homeErr.Error())
+			return mdt.createSettingsXmlFromTemplate(username, password, remoteRepositoryFullPath)
+		}
+		userSettingsPath = filepath.Join(homeDir, ".m2", settingsXmlFile)
+	}
+
+	exists, err := fileutils.IsFileExists(userSettingsPath, false)
+	if err != nil {
+		log.Warn(fmt.Sprintf("Could not stat settings.xml at %s (%v); falling back to built-in template.", userSettingsPath, err))
+		return mdt.createSettingsXmlFromTemplate(username, password, remoteRepositoryFullPath)
+	}
+	if exists {
+		log.Debug("Seeding temp settings.xml from existing user settings:", userSettingsPath)
+		return mdt.createSettingsXmlFromExisting(userSettingsPath, username, password, remoteRepositoryFullPath)
+	}
+	return mdt.createSettingsXmlFromTemplate(username, password, remoteRepositoryFullPath)
+}
+
+func (mdt *MavenDepTreeManager) createSettingsXmlFromTemplate(username, password, remoteRepositoryFullPath string) error {
 	SettingsTemplate, err := template.New("settings").Parse(settingsXmlTemplate)
 	if err != nil {
 		return err
@@ -331,7 +349,7 @@ func (mdt *MavenDepTreeManager) createSettingsXmlWithConfiguredArtifactory(setti
 	buf := &bytes.Buffer{}
 	err = SettingsTemplate.Execute(buf, struct {
 		Username                 string
-		Password                 string // #nosec G117 -- required by settings.xml template; value written to local file only
+		Password                 string // #nosec G117 -- written to local temp file only
 		RemoteRepositoryFullPath string
 	}{
 		Username:                 username,
@@ -344,17 +362,113 @@ func (mdt *MavenDepTreeManager) createSettingsXmlWithConfiguredArtifactory(setti
 	return errorutils.CheckError(os.WriteFile(mdt.settingsXmlPath, buf.Bytes(), 0600))
 }
 
-// Creates a temporary directory.
-// If Artifactory resolution repo is provided, a settings.xml file with the provided server and repository will be created inside the temporarily directory.
+// createSettingsXmlFromExisting seeds the temp settings.xml from the user's file and
+// upserts curation entries. Falls back to the built-in template if the file is
+// unparsable (e.g. mid-write) or missing the <settings> root.
+func (mdt *MavenDepTreeManager) createSettingsXmlFromExisting(userSettingsPath, username, password, remoteRepositoryFullPath string) error {
+	doc := etree.NewDocument()
+	if err := doc.ReadFromFile(userSettingsPath); err != nil {
+		log.Warn(fmt.Sprintf("Could not parse settings.xml at %s (%v); falling back to built-in template.", userSettingsPath, err))
+		return mdt.createSettingsXmlFromTemplate(username, password, remoteRepositoryFullPath)
+	}
+	root := doc.SelectElement("settings")
+	if root == nil {
+		log.Warn(fmt.Sprintf("settings.xml at %s has no <settings> root; falling back to built-in template.", userSettingsPath))
+		return mdt.createSettingsXmlFromTemplate(username, password, remoteRepositoryFullPath)
+	}
+
+	upsertCurationServer(root, username, password)
+	upsertCurationMirror(root, remoteRepositoryFullPath)
+	upsertCurationProfile(root, remoteRepositoryFullPath)
+	upsertCurationActiveProfile(root)
+
+	doc.Indent(4)
+	buf, err := doc.WriteToBytes()
+	if err != nil {
+		return errorutils.CheckError(err)
+	}
+	return errorutils.CheckError(os.WriteFile(mdt.settingsXmlPath, buf, 0600))
+}
+
+func xmlGetOrCreate(parent *etree.Element, name string) *etree.Element {
+	if el := parent.SelectElement(name); el != nil {
+		return el
+	}
+	return parent.CreateElement(name)
+}
+
+func xmlFindByID(parent *etree.Element, elementName, id string) *etree.Element {
+	for _, el := range parent.SelectElements(elementName) {
+		if idEl := el.SelectElement("id"); idEl != nil && idEl.Text() == id {
+			return el
+		}
+	}
+	return nil
+}
+
+func xmlGetOrCreateByID(parent *etree.Element, elementName, id string) *etree.Element {
+	if el := xmlFindByID(parent, elementName, id); el != nil {
+		return el
+	}
+	return parent.CreateElement(elementName)
+}
+
+func xmlSetChild(parent *etree.Element, name, text string) {
+	xmlGetOrCreate(parent, name).SetText(text)
+}
+
+func upsertCurationServer(root *etree.Element, username, password string) {
+	servers := xmlGetOrCreate(root, "servers")
+	server := xmlGetOrCreateByID(servers, "server", curationSettingsID)
+	xmlSetChild(server, "id", curationSettingsID)
+	xmlSetChild(server, "username", username)
+	xmlSetChild(server, "password", password) // #nosec G117 -- written to local temp file only
+}
+
+func upsertCurationMirror(root *etree.Element, repoURL string) {
+	mirrors := xmlGetOrCreate(root, "mirrors")
+	mirror := xmlFindByID(mirrors, "mirror", curationSettingsID)
+	if mirror == nil {
+		// Insert first: a pre-existing catch-all mirror would otherwise win in document order.
+		mirror = etree.NewElement("mirror")
+		mirrors.InsertChildAt(0, mirror)
+	}
+	xmlSetChild(mirror, "id", curationSettingsID)
+	xmlSetChild(mirror, "url", repoURL)
+	xmlSetChild(mirror, "mirrorOf", "*")
+}
+
+func upsertCurationProfile(root *etree.Element, repoURL string) {
+	profiles := xmlGetOrCreate(root, "profiles")
+	profile := xmlGetOrCreateByID(profiles, "profile", curationSettingsID)
+	xmlSetChild(profile, "id", curationSettingsID)
+
+	repos := xmlGetOrCreate(profile, "repositories")
+	repo := xmlGetOrCreateByID(repos, "repository", curationSettingsID)
+	xmlSetChild(xmlGetOrCreate(repo, "snapshots"), "enabled", "true")
+	xmlSetChild(repo, "id", curationSettingsID)
+	xmlSetChild(repo, "name", "mavenRepo")
+	xmlSetChild(repo, "url", repoURL)
+}
+
+func upsertCurationActiveProfile(root *etree.Element) {
+	activeProfiles := xmlGetOrCreate(root, "activeProfiles")
+	for _, ap := range activeProfiles.SelectElements("activeProfile") {
+		if ap.Text() == curationSettingsID {
+			return
+		}
+	}
+	activeProfiles.CreateElement("activeProfile").SetText(curationSettingsID)
+}
+
+// CreateTempDirWithSettingsXmlIfNeeded creates a temp dir and, when a deps repo is
+// configured, writes a settings.xml into it.
 func (mdt *MavenDepTreeManager) CreateTempDirWithSettingsXmlIfNeeded() (tempDirPath string, clearMavenDepTreeRun func() error, err error) {
 	tempDirPath, err = fileutils.CreateTempDir()
 	if err != nil {
 		return
 	}
-
 	clearMavenDepTreeRun = func() error { return fileutils.RemoveTempDir(tempDirPath) }
-
-	// Create a settings.xml file that sets the dependency resolution from the given server and repository
 	if mdt.depsRepo != "" {
 		err = mdt.createSettingsXmlWithConfiguredArtifactory(tempDirPath)
 	}

--- a/sca/bom/buildinfo/technologies/java/mvn_test.go
+++ b/sca/bom/buildinfo/technologies/java/mvn_test.go
@@ -6,8 +6,10 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/beevik/etree"
 	"github.com/jfrog/build-info-go/utils"
 	"github.com/jfrog/jfrog-cli-core/v2/utils/config"
+	"github.com/jfrog/jfrog-cli-core/v2/utils/coreutils"
 	coreTests "github.com/jfrog/jfrog-cli-core/v2/utils/tests"
 	"github.com/jfrog/jfrog-cli-security/sca/bom/buildinfo/technologies"
 	"github.com/jfrog/jfrog-cli-security/utils/xray"
@@ -357,6 +359,9 @@ func TestCreateSettingsXmlWithConfiguredArtifactory(t *testing.T) {
 			},
 			depsRepo: "testRepo",
 		},
+		// Point to a non-existent path so the test always exercises the template
+		// code path regardless of whether ~/.m2/settings.xml exists on the CI machine.
+		userSettingsXmlPath: filepath.Join(t.TempDir(), "no-settings.xml"),
 	}
 	// Create a temporary directory for testing and settings.xml creation
 	tempDir := t.TempDir()
@@ -401,6 +406,241 @@ func TestCreateSettingsXmlWithConfiguredArtifactory(t *testing.T) {
 	actualContent = []byte(strings.ReplaceAll(string(actualContent), "\r\n", "\n"))
 	assert.NoError(t, err)
 	assert.Equal(t, settingsXmlWithAccessToken, string(actualContent))
+}
+
+// TestCreateSettingsXmlPreservesExistingProxy verifies that when the user already has a
+// settings.xml (containing e.g. a <proxies> block), the curation-audit temp file is
+// seeded from that file so the proxy configuration is preserved.
+func TestCreateSettingsXmlPreservesExistingProxy(t *testing.T) {
+	//#nosec G101 - test credentials only
+	userSettings := `<?xml version="1.0" encoding="UTF-8"?>
+<settings xmlns="http://maven.apache.org/SETTINGS/1.2.0"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.2.0 http://maven.apache.org/xsd/settings-1.2.0.xsd">
+    <proxies>
+        <proxy>
+            <id>corp-proxy</id>
+            <active>true</active>
+            <protocol>http</protocol>
+            <host>10.56.80.80</host>
+            <port>8080</port>
+        </proxy>
+    </proxies>
+</settings>`
+
+	userSettingsPath := filepath.Join(t.TempDir(), "settings.xml")
+	require.NoError(t, os.WriteFile(userSettingsPath, []byte(userSettings), 0600))
+
+	mdt := MavenDepTreeManager{
+		DepTreeManager: DepTreeManager{
+			server: &config.ServerDetails{
+				ArtifactoryUrl: "https://myartifactory.com/artifactory",
+				User:           "testUser",
+				Password:       "testPass",
+			},
+			depsRepo: "testRepo",
+		},
+		isCurationCmd:       true,
+		userSettingsXmlPath: userSettingsPath,
+	}
+
+	tempDir := t.TempDir()
+	require.NoError(t, mdt.createSettingsXmlWithConfiguredArtifactory(tempDir))
+
+	resultBytes, err := os.ReadFile(filepath.Join(tempDir, settingsXmlFile))
+	require.NoError(t, err)
+	result := string(resultBytes)
+
+	// Proxy must be preserved from the user's original settings.
+	assert.Contains(t, result, "10.56.80.80", "proxy host must be preserved")
+	assert.Contains(t, result, "corp-proxy", "proxy id must be preserved")
+
+	// Curation entries must be injected.
+	assert.Contains(t, result, "api/curation/audit/testRepo", "curation mirror URL must be present")
+	assert.Contains(t, result, "<mirrorOf>*</mirrorOf>", "catch-all mirror must be present")
+	assert.Contains(t, result, "testUser", "username must be present")
+	assert.Contains(t, result, "testPass", "password must be present")
+	assert.Contains(t, result, "<activeProfile>"+curationSettingsID+"</activeProfile>", "activeProfile must be present")
+
+	// The user's original settings.xml must be untouched.
+	originalContent, err := os.ReadFile(userSettingsPath)
+	require.NoError(t, err)
+	assert.Equal(t, userSettings, string(originalContent), "user's settings.xml must not be modified")
+}
+
+// TestCreateSettingsXmlIdempotent verifies that calling createSettingsXmlWithConfiguredArtifactory
+// multiple times with the same user settings does not create duplicate entries in the temp file.
+func TestCreateSettingsXmlIdempotent(t *testing.T) {
+	//#nosec G101 - test credentials only
+	userSettings := `<?xml version="1.0" encoding="UTF-8"?>
+<settings xmlns="http://maven.apache.org/SETTINGS/1.2.0"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.2.0 http://maven.apache.org/xsd/settings-1.2.0.xsd">
+    <proxies>
+        <proxy>
+            <id>corp-proxy</id>
+            <active>true</active>
+            <protocol>http</protocol>
+            <host>10.56.80.80</host>
+            <port>8080</port>
+        </proxy>
+    </proxies>
+</settings>`
+
+	userSettingsPath := filepath.Join(t.TempDir(), "settings.xml")
+	require.NoError(t, os.WriteFile(userSettingsPath, []byte(userSettings), 0600))
+
+	mdt := MavenDepTreeManager{
+		DepTreeManager: DepTreeManager{
+			server: &config.ServerDetails{
+				ArtifactoryUrl: "https://myartifactory.com/artifactory",
+				User:           "testUser",
+				Password:       "testPass",
+			},
+			depsRepo: "testRepo",
+		},
+		isCurationCmd:       true,
+		userSettingsXmlPath: userSettingsPath,
+	}
+
+	tempDir := t.TempDir()
+	// Run twice — each invocation reads the unchanged user settings and writes to tempDir.
+	require.NoError(t, mdt.createSettingsXmlWithConfiguredArtifactory(tempDir))
+
+	firstRun, err := os.ReadFile(filepath.Join(tempDir, settingsXmlFile))
+	require.NoError(t, err)
+
+	require.NoError(t, mdt.createSettingsXmlWithConfiguredArtifactory(tempDir))
+
+	secondRun, err := os.ReadFile(filepath.Join(tempDir, settingsXmlFile))
+	require.NoError(t, err)
+
+	// Both runs must produce identical output — no duplicate entries.
+	assert.Equal(t, string(firstRun), string(secondRun), "second run must produce identical output (no duplicates)")
+
+	result := string(secondRun)
+	// Structural uniqueness: exactly one <server>, one <mirror>, one top-level <profile>,
+	// and one <activeProfile> entry with the curation ID.
+	assert.Equal(t, 1, strings.Count(result, "<server>"), "expected exactly one <server> block")
+	assert.Equal(t, 1, strings.Count(result, "<mirror>"), "expected exactly one <mirror> block")
+	assert.Equal(t, 1, strings.Count(result, "<activeProfile>"+curationSettingsID+"</activeProfile>"),
+		"expected exactly one curation <activeProfile>")
+}
+
+// TestCreateSettingsXmlCurationMirrorIsFirst verifies that when the user already has a
+// catch-all <mirror> (mirrorOf=*), the curation mirror is inserted first so Maven's
+// document-order selection routes through curation. It also covers the id-collision case:
+// the pre-existing mirror uses id="artifactory", which must not be overwritten.
+func TestCreateSettingsXmlCurationMirrorIsFirst(t *testing.T) {
+	userSettings := `<?xml version="1.0" encoding="UTF-8"?>
+<settings xmlns="http://maven.apache.org/SETTINGS/1.2.0"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.2.0 http://maven.apache.org/xsd/settings-1.2.0.xsd">
+    <mirrors>
+        <mirror>
+            <id>artifactory</id>
+            <url>https://existing-internal.corp/artifactory/repo</url>
+            <mirrorOf>*</mirrorOf>
+        </mirror>
+    </mirrors>
+</settings>`
+
+	userSettingsPath := filepath.Join(t.TempDir(), "settings.xml")
+	require.NoError(t, os.WriteFile(userSettingsPath, []byte(userSettings), 0600))
+
+	mdt := MavenDepTreeManager{
+		DepTreeManager: DepTreeManager{
+			server: &config.ServerDetails{
+				ArtifactoryUrl: "https://myartifactory.com/artifactory",
+				User:           "testUser",
+				Password:       "testPass",
+			},
+			depsRepo: "testRepo",
+		},
+		isCurationCmd:       true,
+		userSettingsXmlPath: userSettingsPath,
+	}
+
+	tempDir := t.TempDir()
+	require.NoError(t, mdt.createSettingsXmlWithConfiguredArtifactory(tempDir))
+
+	doc := etree.NewDocument()
+	require.NoError(t, doc.ReadFromFile(filepath.Join(tempDir, settingsXmlFile)))
+	mirrorEls := doc.SelectElement("settings").SelectElement("mirrors").SelectElements("mirror")
+	require.Len(t, mirrorEls, 2, "both the curation mirror and the user's mirror must be present")
+
+	// The curation mirror must come first so Maven picks it for the '*' match.
+	firstID := mirrorEls[0].SelectElement("id").Text()
+	assert.Equal(t, curationSettingsID, firstID, "curation mirror must be the first <mirror>")
+	assert.Contains(t, mirrorEls[0].SelectElement("url").Text(), "api/curation/audit/testRepo")
+
+	// The user's pre-existing mirror (id=artifactory) must be preserved untouched.
+	assert.Equal(t, "artifactory", mirrorEls[1].SelectElement("id").Text())
+	assert.Equal(t, "https://existing-internal.corp/artifactory/repo", mirrorEls[1].SelectElement("url").Text())
+}
+
+// TestCreateSettingsXmlFromExistingIsPrivate verifies the generated temp settings.xml,
+// which carries credentials, is written with restrictive 0600 permissions.
+func TestCreateSettingsXmlFromExistingIsPrivate(t *testing.T) {
+	userSettings := `<?xml version="1.0" encoding="UTF-8"?>
+<settings xmlns="http://maven.apache.org/SETTINGS/1.2.0"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.2.0 http://maven.apache.org/xsd/settings-1.2.0.xsd">
+</settings>`
+
+	userSettingsPath := filepath.Join(t.TempDir(), "settings.xml")
+	require.NoError(t, os.WriteFile(userSettingsPath, []byte(userSettings), 0600))
+
+	mdt := MavenDepTreeManager{
+		DepTreeManager: DepTreeManager{
+			server: &config.ServerDetails{
+				ArtifactoryUrl: "https://myartifactory.com/artifactory",
+				User:           "testUser",
+				Password:       "testPass",
+			},
+			depsRepo: "testRepo",
+		},
+		isCurationCmd:       true,
+		userSettingsXmlPath: userSettingsPath,
+	}
+
+	tempDir := t.TempDir()
+	require.NoError(t, mdt.createSettingsXmlWithConfiguredArtifactory(tempDir))
+
+	info, err := os.Stat(filepath.Join(tempDir, settingsXmlFile))
+	require.NoError(t, err)
+	assert.Equal(t, os.FileMode(0600), info.Mode().Perm(), "temp settings.xml must be private (0600)")
+}
+
+// TestCreateSettingsXmlFallsBackWhenNoHome verifies that an unresolvable home directory
+// falls back to the built-in template instead of failing the whole scan.
+func TestCreateSettingsXmlFallsBackWhenNoHome(t *testing.T) {
+	if coreutils.IsWindows() {
+		t.Skip("os.UserHomeDir resolves home from different env vars on Windows")
+	}
+	// Empty HOME makes os.UserHomeDir return an error on unix-like systems.
+	t.Setenv("HOME", "")
+
+	mdt := MavenDepTreeManager{
+		DepTreeManager: DepTreeManager{
+			server: &config.ServerDetails{
+				ArtifactoryUrl: "https://myartifactory.com/artifactory",
+				User:           "testUser",
+				Password:       "testPass",
+			},
+			depsRepo: "testRepo",
+		},
+		// userSettingsXmlPath left empty so the default (home-based) lookup runs and fails.
+	}
+
+	tempDir := t.TempDir()
+	require.NoError(t, mdt.createSettingsXmlWithConfiguredArtifactory(tempDir))
+
+	actualContent, err := os.ReadFile(filepath.Join(tempDir, settingsXmlFile))
+	require.NoError(t, err)
+	actualContent = []byte(strings.ReplaceAll(string(actualContent), "\r\n", "\n"))
+	// Template path uses the generic "artifactory" id and the direct (non-curation) repo path.
+	assert.Equal(t, settingsXmlWithUsernameAndPassword, string(actualContent))
 }
 
 func TestRunProjectsCmd(t *testing.T) {
@@ -582,4 +822,111 @@ func TestInjectPluginDeps(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestCreateSettingsXmlMalformedFallsBackToTemplate verifies that a settings.xml that
+// cannot be parsed (e.g. mid-write by an IDE or CI script) is treated as absent and the
+// built-in template is used, rather than aborting the whole scan (Finding 5).
+func TestCreateSettingsXmlMalformedFallsBackToTemplate(t *testing.T) {
+	malformed := `<?xml version="1.0"?><settings><UNCLOSED`
+	userSettingsPath := filepath.Join(t.TempDir(), "settings.xml")
+	require.NoError(t, os.WriteFile(userSettingsPath, []byte(malformed), 0600))
+
+	mdt := MavenDepTreeManager{
+		isCurationCmd:       true,
+		userSettingsXmlPath: userSettingsPath,
+		DepTreeManager: DepTreeManager{
+			server:   &config.ServerDetails{ArtifactoryUrl: "https://example.jfrog.io/artifactory/", User: "u", Password: "p"},
+			depsRepo: "testRepo",
+		},
+	}
+	tempDir := t.TempDir()
+	err := mdt.createSettingsXmlWithConfiguredArtifactory(tempDir)
+	require.NoError(t, err, "malformed user settings.xml must not abort the scan")
+
+	result, err := os.ReadFile(filepath.Join(tempDir, settingsXmlFile))
+	require.NoError(t, err)
+	assert.Contains(t, string(result), "testRepo", "template output must contain the repo")
+}
+
+// TestCreateSettingsXmlNoRootFallsBackToTemplate verifies that a settings.xml missing the
+// <settings> root element is treated as absent and falls back to the built-in template.
+func TestCreateSettingsXmlNoRootFallsBackToTemplate(t *testing.T) {
+	noRoot := `<?xml version="1.0"?><notSettings><foo/></notSettings>`
+	userSettingsPath := filepath.Join(t.TempDir(), "settings.xml")
+	require.NoError(t, os.WriteFile(userSettingsPath, []byte(noRoot), 0600))
+
+	mdt := MavenDepTreeManager{
+		isCurationCmd:       true,
+		userSettingsXmlPath: userSettingsPath,
+		DepTreeManager: DepTreeManager{
+			server:   &config.ServerDetails{ArtifactoryUrl: "https://example.jfrog.io/artifactory/", User: "u", Password: "p"},
+			depsRepo: "testRepo",
+		},
+	}
+	tempDir := t.TempDir()
+	err := mdt.createSettingsXmlWithConfiguredArtifactory(tempDir)
+	require.NoError(t, err, "settings.xml with no <settings> root must not abort the scan")
+
+	result, err := os.ReadFile(filepath.Join(tempDir, settingsXmlFile))
+	require.NoError(t, err)
+	assert.Contains(t, string(result), "testRepo")
+}
+
+// TestNonCurationSkipsUserSettingsXml verifies that a plain jf audit --deps-repo run
+// uses the built-in template directly without consulting ~/.m2/settings.xml, so the
+// jf audit code path is fully unaffected by the proxy-preservation feature (Finding 6).
+func TestNonCurationSkipsUserSettingsXml(t *testing.T) {
+	// Point userSettingsXmlPath at a file with valid but distinct proxy config.
+	// If the code incorrectly reads it, the proxy host would appear in the output.
+	userSettings := `<?xml version="1.0"?><settings><proxies><proxy><id>should-not-appear</id><host>1.2.3.4</host></proxy></proxies></settings>`
+	userSettingsPath := filepath.Join(t.TempDir(), "settings.xml")
+	require.NoError(t, os.WriteFile(userSettingsPath, []byte(userSettings), 0600))
+
+	mdt := MavenDepTreeManager{
+		isCurationCmd:       false, // plain jf audit
+		userSettingsXmlPath: userSettingsPath,
+		DepTreeManager: DepTreeManager{
+			server:   &config.ServerDetails{ArtifactoryUrl: "https://example.jfrog.io/artifactory/", User: "u", Password: "p"},
+			depsRepo: "testRepo",
+		},
+	}
+	tempDir := t.TempDir()
+	require.NoError(t, mdt.createSettingsXmlWithConfiguredArtifactory(tempDir))
+
+	result, err := os.ReadFile(filepath.Join(tempDir, settingsXmlFile))
+	require.NoError(t, err)
+	assert.NotContains(t, string(result), "should-not-appear", "non-curation run must not seed from user settings.xml")
+	assert.NotContains(t, string(result), "1.2.3.4", "non-curation run must not seed from user settings.xml")
+}
+
+// TestCreateSettingsXmlStatErrorFallsBackToTemplate verifies that a stat error on
+// ~/.m2/settings.xml (e.g. EACCES on a volume owned by a different UID in containerised
+// CI) falls back to the built-in template rather than aborting the scan.
+func TestCreateSettingsXmlStatErrorFallsBackToTemplate(t *testing.T) {
+	if os.Getuid() == 0 {
+		t.Skip("running as root — permission checks do not apply")
+	}
+	// Create a directory where settings.xml would live, then chmod it 000 so stat fails.
+	unreadableDir := t.TempDir()
+	userSettingsPath := filepath.Join(unreadableDir, "settings.xml")
+	require.NoError(t, os.WriteFile(userSettingsPath, []byte(`<?xml version="1.0"?><settings></settings>`), 0600))
+	require.NoError(t, os.Chmod(unreadableDir, 0000))
+	defer func() { _ = os.Chmod(unreadableDir, 0700) }()
+
+	mdt := MavenDepTreeManager{
+		isCurationCmd:       true,
+		userSettingsXmlPath: userSettingsPath,
+		DepTreeManager: DepTreeManager{
+			server:   &config.ServerDetails{ArtifactoryUrl: "https://example.jfrog.io/artifactory/", User: "u", Password: "p"},
+			depsRepo: "testRepo",
+		},
+	}
+	tempDir := t.TempDir()
+	err := mdt.createSettingsXmlWithConfiguredArtifactory(tempDir)
+	require.NoError(t, err, "stat error on settings.xml must not abort the scan")
+
+	result, err := os.ReadFile(filepath.Join(tempDir, settingsXmlFile))
+	require.NoError(t, err)
+	assert.Contains(t, string(result), "testRepo")
 }


### PR DESCRIPTION
- [ ] The pull request is targeting the `dev` branch.
- [ ] The code has been validated to compile successfully by running `go vet ./...`.
- [ ] The code has been formatted properly using `go fmt ./...`.
- [ ] All [static analysis checks](https://github.com/jfrog/jfrog-cli-security/actions/workflows/analysis.yml) passed.
- [ ] All [tests](https://github.com/jfrog/jfrog-cli-security/actions/workflows/test.yml) have passed. If this feature is not already covered by the tests, new tests have been added.
- [ ] Updated the [Contributing page](https://github.com/jfrog/jfrog-cli-security/blob/main/CONTRIBUTING.md) / [ReadMe page](https://github.com/jfrog/jfrog-cli-security/blob/main/README.md) / [CI Workflow files](https://github.com/jfrog/jfrog-cli-security/tree/main/.github/workflows) if needed.
- [ ] All changes are detailed at the description. if not already covered at [JFrog Documentation](https://github.com/jfrog/documentation), new documentation have been added.

-----

Curation-audit's temp settings.xml for Maven was rendered from scratch, dropping any <proxies> configuration from the customer's real ~/.m2/settings.xml. This broke dependency resolution for customers whose Artifactory is only reachable through a corporate proxy, since Maven only reads proxy config from the active settings.xml (not env vars or JVM system-proxy flags).

The temp settings.xml is now seeded from the user's existing file (when present) and only upserts the curation-specific server/mirror/profile entries on top, under a dedicated jfrog-curation-audit id — preserving <proxies> and any other existing config untouched. Falls back to the original template when no user settings.xml exists, so behavior for unaffected customers is unchanged.