### PR TITLE
Make sure default index in SARIF is int

### DIFF
--- a/utils/formats/sarifutils/sarifutils.go
+++ b/utils/formats/sarifutils/sarifutils.go
@@ -895,7 +895,7 @@ func GetInvocationWorkingDirectory(invocation *sarif.Invocation) string {
 }
 
 func CreateNewInvocation(success bool, target string, includeDirs ...string) *sarif.Invocation {
-	wd := sarif.NewArtifactLocation().WithURI(utils.ToURI(target))
+	wd := sarif.NewArtifactLocation().WithURI(utils.ToURI(target)).WithIndex(0)
 	if len(includeDirs) > 0 {
 		// Add properties to the working directory
 		properties := sarif.NewPropertyBag()


### PR DESCRIPTION
- [ ] The pull request is targeting the `dev` branch.
- [ ] The code has been validated to compile successfully by running `go vet ./...`.
- [ ] The code has been formatted properly using `go fmt ./...`.
- [ ] All [static analysis checks](https://github.com/jfrog/jfrog-cli-security/actions/workflows/analysis.yml) passed.
- [ ] All [tests](https://github.com/jfrog/jfrog-cli-security/actions/workflows/test.yml) have passed. If this feature is not already covered by the tests, new tests have been added.
- [ ] Updated the [Contributing page](https://github.com/jfrog/jfrog-cli-security/blob/main/CONTRIBUTING.md) / [ReadMe page](https://github.com/jfrog/jfrog-cli-security/blob/main/README.md) / [CI Workflow files](https://github.com/jfrog/jfrog-cli-security/tree/main/.github/workflows) if needed.
- [ ] All changes are detailed at the description. if not already covered at [JFrog Documentation](https://github.com/jfrog/documentation), new documentation have been added.

-----

Xray uses:
* https://github.com/owenrumney/go-sarif/releases/tag/v1.1.1

While we use:
* https://github.com/owenrumney/go-sarif/releases/tag/v3.2.3

Breaking when WD created default with `-1` value. in `v1.1.1` this attribute is `int`...