### PR TITLE
XRAY-156157 - Obtain configuration by workspace

### DIFF
--- a/cli/docs/flags.go
+++ b/cli/docs/flags.go
@@ -180,6 +180,7 @@ const (
 	GitThreads      = gitPrefix + Threads
 
 	UseConfigProfile = "use-config-profile"
+	Workspace        = "workspace, ws"
 )
 
 // Mapping between security commands (key) and their flags (key).
@@ -220,7 +221,7 @@ var commandFlags = map[string][]string{
 		// Violations params
 		scanProjectKey, Watches, Snippet, ScanVuln, Fail,
 		// Scan params
-		Threads, ExclusionsAudit, WorkingDirs,
+		Threads, ExclusionsAudit, WorkingDirs, Workspace,
 		auditSca, auditIac, auditSast, auditSecrets, auditWithoutCA, SecretValidation, Sbom, UseConfigProfile,
 		// Output params
 		Licenses, OutputFormat, ExtendedTable, OutputDir, UploadRtRepoPath,
@@ -368,6 +369,7 @@ var flagsMap = map[string]components.Flag{
 	Port:         components.NewStringFlag(Port, "Specifies the port to run the SAST server on.", components.SetMandatory()),
 
 	UseConfigProfile: components.NewBoolFlag(UseConfigProfile, "Set to false to override config profile for the audit.", components.WithBoolDefaultValue(true), components.SetHiddenBoolFlag()),
+	Workspace:        components.NewStringFlag(Workspace, "Workspace name used together with the repository URL to fetch the applicable config profile from the platform."),
 
 	// Docker flags
 	DockerImageName: components.NewStringFlag(DockerImageName, "Specifies the Docker image name to audit. Uses the same format as the Docker CLI, including Artifactory-hosted images."),

--- a/cli/docs/flags.go
+++ b/cli/docs/flags.go
@@ -180,7 +180,7 @@ const (
 	GitThreads      = gitPrefix + Threads
 
 	UseConfigProfile = "use-config-profile"
-	Workspace        = "workspace, ws"
+	Workspace        = "workspace"
 )
 
 // Mapping between security commands (key) and their flags (key).

--- a/cli/gitcommands.go
+++ b/cli/gitcommands.go
@@ -59,6 +59,7 @@ func GitAuditCmd(c *components.Context) error {
 	gitAuditCmd.SetServerDetails(serverDetails).SetXrayVersion(xrayVersion).SetXscVersion(xscVersion)
 	// Set config profile params
 	gitAuditCmd.SetUseConfigProfile(c.GetBoolFlagValue(flags.UseConfigProfile))
+	gitAuditCmd.SetWorkspaceName(c.GetStringFlagValue(flags.Workspace))
 	// Set violations params
 	format, err := outputFormat.ParseOutputFormat(c.GetStringFlagValue(flags.OutputFormat), outputFormat.All)
 	if err != nil {

--- a/commands/git/audit/gitaudit.go
+++ b/commands/git/audit/gitaudit.go
@@ -81,8 +81,8 @@ func getJPDConfigProfile(params GitAuditParams) (*services.ConfigProfile, error)
 		// Already set, use it
 		return params.configProfile, nil
 	}
-	log.Debug(fmt.Sprintf("Fetching config profile for git repo URL: %s", params.gitContext.Source.GitRepoHttpsCloneUrl))
-	configProfile, err := xsc.GetConfigProfileByUrl(params.xrayVersion, params.serverDetails, params.gitContext.Source.GitRepoHttpsCloneUrl, params.resultsContext.ProjectKey)
+	log.Debug(fmt.Sprintf("Fetching config profile for git repo URL: %s (workspace: %q)", params.gitContext.Source.GitRepoHttpsCloneUrl, params.workspaceName))
+	configProfile, err := xsc.GetConfigProfileByUrl(params.xrayVersion, params.serverDetails, params.gitContext.Source.GitRepoHttpsCloneUrl, params.resultsContext.ProjectKey, params.workspaceName)
 	if err != nil || configProfile == nil {
 		return nil, fmt.Errorf("failed to get config profile for git audit: %v", err)
 	}

--- a/commands/git/audit/gitaudit.go
+++ b/commands/git/audit/gitaudit.go
@@ -81,8 +81,8 @@ func getJPDConfigProfile(params GitAuditParams) (*services.ConfigProfile, error)
 		// Already set, use it
 		return params.configProfile, nil
 	}
-	log.Debug(fmt.Sprintf("Fetching config profile for git repo URL: %s (workspace: %q)", params.gitContext.Source.GitRepoHttpsCloneUrl, params.workspaceName))
-	configProfile, err := xsc.GetConfigProfileByUrl(params.xrayVersion, params.serverDetails, params.gitContext.Source.GitRepoHttpsCloneUrl, params.resultsContext.ProjectKey, params.workspaceName)
+	log.Debug(fmt.Sprintf("Fetching config profile for git repo URL: %s (workspace: %q)", params.gitContext.Source.GitRepoHttpsCloneUrl, params.resultsContext.WorkspaceName))
+	configProfile, err := xsc.GetConfigProfileByUrl(params.xrayVersion, params.serverDetails, params.gitContext.Source.GitRepoHttpsCloneUrl, params.resultsContext.ProjectKey, params.resultsContext.WorkspaceName)
 	if err != nil || configProfile == nil {
 		return nil, fmt.Errorf("failed to get config profile for git audit: %v", err)
 	}

--- a/commands/git/audit/gitauditparams.go
+++ b/commands/git/audit/gitauditparams.go
@@ -20,6 +20,7 @@ type GitAuditParams struct {
 	serverDetails    *config.ServerDetails
 	useConfigProfile bool
 	configProfile    *services.ConfigProfile
+	workspaceName    string
 	// Violations params
 	resultsContext results.ResultContext
 	failBuild      bool
@@ -223,6 +224,15 @@ func (gap *GitAuditParams) SetConfigProfile(configProfile *services.ConfigProfil
 
 func (gap *GitAuditParams) ConfigProfile() *services.ConfigProfile {
 	return gap.configProfile
+}
+
+func (gap *GitAuditParams) SetWorkspaceName(workspaceName string) *GitAuditParams {
+	gap.workspaceName = workspaceName
+	return gap
+}
+
+func (gap *GitAuditParams) WorkspaceName() string {
+	return gap.workspaceName
 }
 
 func (gap *GitAuditParams) SetGitContext(gitContext *services.XscGitInfoContext) *GitAuditParams {

--- a/commands/git/audit/gitauditparams.go
+++ b/commands/git/audit/gitauditparams.go
@@ -20,7 +20,6 @@ type GitAuditParams struct {
 	serverDetails    *config.ServerDetails
 	useConfigProfile bool
 	configProfile    *services.ConfigProfile
-	workspaceName    string
 	// Violations params
 	resultsContext results.ResultContext
 	failBuild      bool
@@ -227,12 +226,12 @@ func (gap *GitAuditParams) ConfigProfile() *services.ConfigProfile {
 }
 
 func (gap *GitAuditParams) SetWorkspaceName(workspaceName string) *GitAuditParams {
-	gap.workspaceName = workspaceName
+	gap.resultsContext.WorkspaceName = workspaceName
 	return gap
 }
 
 func (gap *GitAuditParams) WorkspaceName() string {
-	return gap.workspaceName
+	return gap.resultsContext.WorkspaceName
 }
 
 func (gap *GitAuditParams) SetGitContext(gitContext *services.XscGitInfoContext) *GitAuditParams {

--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/jfrog/jfrog-apps-config v1.0.1
 	github.com/jfrog/jfrog-cli-artifactory v0.8.1-0.20260714082320-4fd5a71b4b4a
 	github.com/jfrog/jfrog-cli-core/v2 v2.60.1-0.20260624085155-5ba797de2616
-	github.com/jfrog/jfrog-client-go v1.55.1-0.20260624085832-de0c68a23c43
+	github.com/jfrog/jfrog-client-go v1.55.1-0.20260722075451-613a6b6a7603
 	github.com/magiconair/properties v1.8.10
 	github.com/owenrumney/go-sarif/v3 v3.2.3
 	github.com/package-url/packageurl-go v0.1.3

--- a/go.sum
+++ b/go.sum
@@ -175,6 +175,8 @@ github.com/jfrog/jfrog-cli-core/v2 v2.60.1-0.20260624085155-5ba797de2616 h1:bioF
 github.com/jfrog/jfrog-cli-core/v2 v2.60.1-0.20260624085155-5ba797de2616/go.mod h1:9R90mhbczGXwW5EGlDs7F08ejQU/xdoDhYHMvzBiqgE=
 github.com/jfrog/jfrog-client-go v1.55.1-0.20260624085832-de0c68a23c43 h1:akoiWauP27YxVXcRkCC8ahgDLxqiARUAVEB+KUPO2OE=
 github.com/jfrog/jfrog-client-go v1.55.1-0.20260624085832-de0c68a23c43/go.mod h1:FHpjN1nTDoj96xd6obe27EOgGErqzU0rQgC96L3Ch9E=
+github.com/jfrog/jfrog-client-go v1.55.1-0.20260722075451-613a6b6a7603 h1:gwxRPCQRsbwt8rIWQ6LDu09aH4I2F1DFYObBpx1KDHw=
+github.com/jfrog/jfrog-client-go v1.55.1-0.20260722075451-613a6b6a7603/go.mod h1:FHpjN1nTDoj96xd6obe27EOgGErqzU0rQgC96L3Ch9E=
 github.com/jhump/protoreflect v1.15.1 h1:HUMERORf3I3ZdX05WaQ6MIpd/NJ434hTp5YiKgfCL6c=
 github.com/jhump/protoreflect v1.15.1/go.mod h1:jD/2GMKKE6OqX8qTjhADU1e6DShO+gavG9e0Q693nKo=
 github.com/kevinburke/ssh_config v1.6.0 h1:J1FBfmuVosPHf5GRdltRLhPJtJpTlMdKTBjRgTaQBFY=

--- a/utils/results/results.go
+++ b/utils/results/results.go
@@ -103,6 +103,8 @@ type ResultContext struct {
 	ProjectKey string `json:"project_key,omitempty"`
 	// (Resource) If gitRepository is provided we will fetch the watches defined on the git repository.
 	GitRepoHttpsCloneUrl string `json:"git_repo_key,omitempty"`
+	// (Resource) Optional workspace name used together with GitRepoHttpsCloneUrl when fetching the config profile from the platform.
+	WorkspaceName string `json:"workspace_name,omitempty"`
 	// If non of the above is provided or requested, the results will include vulnerabilities
 	IncludeVulnerabilities bool `json:"include_vulnerabilities"`
 	// If requested, the results will include licenses

--- a/utils/xsc/configprofile.go
+++ b/utils/xsc/configprofile.go
@@ -27,7 +27,7 @@ func GetConfigProfileByName(xrayVersion string, serverDetails *config.ServerDeta
 	return configProfile, err
 }
 
-func GetConfigProfileByUrl(xrayVersion string, serverDetails *config.ServerDetails, cloneRepoUrl, projectKey string) (*services.ConfigProfile, error) {
+func GetConfigProfileByUrl(xrayVersion string, serverDetails *config.ServerDetails, cloneRepoUrl, projectKey, workspaceName string) (*services.ConfigProfile, error) {
 	if err := clientutils.ValidateMinimumVersion(clientutils.Xray, xrayVersion, services.ConfigProfileNewSchemaMinXrayVersion); err != nil {
 		log.Info(fmt.Sprintf("Minimal Xray version required to use a configProfile is by url '%s'. All configurations will be induced from provided Env vars and files", services.ConfigProfileNewSchemaMinXrayVersion))
 		return nil, err
@@ -36,7 +36,7 @@ func GetConfigProfileByUrl(xrayVersion string, serverDetails *config.ServerDetai
 	if err != nil {
 		return nil, err
 	}
-	configProfile, err := xscService.GetConfigProfileByUrl(cloneRepoUrl)
+	configProfile, err := xscService.GetConfigProfileByUrlAndWorkspace(cloneRepoUrl, workspaceName)
 	if err != nil {
 		err = fmt.Errorf("failed to get config profile for url '%s': %q", serverDetails.Url, err)
 	}

--- a/utils/xsc/configprofile_test.go
+++ b/utils/xsc/configprofile_test.go
@@ -69,7 +69,7 @@ func TestGetConfigProfileByUrl(t *testing.T) {
 			mockServer, serverDetails, _ := validations.XrayServer(t, testcase.mockParams)
 			defer mockServer.Close()
 
-			configProfile, err := GetConfigProfileByUrl(testcase.mockParams.XrayVersion, serverDetails, testRepoUrl, "")
+			configProfile, err := GetConfigProfileByUrl(testcase.mockParams.XrayVersion, serverDetails, testRepoUrl, "", "")
 			if testcase.expectError {
 				assert.Error(t, err)
 				assert.Nil(t, configProfile)

--- a/utils/xsc/configprofile_test.go
+++ b/utils/xsc/configprofile_test.go
@@ -1,8 +1,14 @@
 package xsc
 
 import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
 	"testing"
 
+	"github.com/jfrog/jfrog-cli-core/v2/utils/config"
 	"github.com/jfrog/jfrog-cli-security/tests/validations"
 	"github.com/jfrog/jfrog-client-go/xsc/services"
 	"github.com/stretchr/testify/assert"
@@ -78,6 +84,60 @@ func TestGetConfigProfileByUrl(t *testing.T) {
 			// Validate results
 			assert.NoError(t, err)
 			assert.Equal(t, getComparisonConfigProfile(), configProfile)
+		})
+	}
+}
+
+func TestGetConfigProfileByUrlAndWorkspace(t *testing.T) {
+	testCases := []struct {
+		name          string
+		workspaceName string
+	}{
+		{
+			name:          "Non-empty workspace is sent in request body",
+			workspaceName: "my-workspace",
+		},
+		{
+			name:          "Empty workspace is omitted from request body",
+			workspaceName: "",
+		},
+	}
+
+	for _, testcase := range testCases {
+		t.Run(testcase.name, func(t *testing.T) {
+			var capturedBody string
+			mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if strings.Contains(r.RequestURI, "/xsc/profile_repos") {
+					assert.Equal(t, http.MethodPost, r.Method)
+					body, err := io.ReadAll(r.Body)
+					if !assert.NoError(t, err) {
+						return
+					}
+					capturedBody = string(body)
+					content, err := os.ReadFile("../../tests/testdata/other/configProfile/configProfileExample.json")
+					if !assert.NoError(t, err) {
+						return
+					}
+					w.WriteHeader(http.StatusOK)
+					_, err = w.Write(content)
+					assert.NoError(t, err)
+					return
+				}
+				w.WriteHeader(http.StatusNotFound)
+			}))
+			defer mockServer.Close()
+
+			serverDetails := &config.ServerDetails{Url: mockServer.URL + "/", XrayUrl: mockServer.URL + "/xray/"}
+			configProfile, err := GetConfigProfileByUrl(services.ConfigProfileNewSchemaMinXrayVersion, serverDetails, testRepoUrl, "", testcase.workspaceName)
+			assert.NoError(t, err)
+			assert.Equal(t, getComparisonConfigProfile(), configProfile)
+
+			assert.Contains(t, capturedBody, `"repo_url":"`+testRepoUrl+`"`)
+			if testcase.workspaceName == "" {
+				assert.NotContains(t, capturedBody, "workspace_name")
+			} else {
+				assert.Contains(t, capturedBody, `"workspace_name":"`+testcase.workspaceName+`"`)
+			}
 		})
 	}
 }


### PR DESCRIPTION
- [x] The pull request is targeting the `dev` branch.
- [x] The code has been validated to compile successfully by running `go vet ./...`.
- [x] The code has been formatted properly using `go fmt ./...`.
- [x] All [static analysis checks](https://github.com/jfrog/jfrog-cli-security/actions/workflows/analysis.yml) passed.
- [x] All [tests](https://github.com/jfrog/jfrog-cli-security/actions/workflows/test.yml) have passed. If this feature is not already covered by the tests, new tests have been added.
- [ ] Updated the [Contributing page](https://github.com/jfrog/jfrog-cli-security/blob/main/CONTRIBUTING.md) / [ReadMe page](https://github.com/jfrog/jfrog-cli-security/blob/main/README.md) / [CI Workflow files](https://github.com/jfrog/jfrog-cli-security/tree/main/.github/workflows) if needed.
- [ ] All changes are detailed at the description. if not already covered at [JFrog Documentation](https://github.com/jfrog/documentation), new documentation have been added.

-----

Add command line flag "workspace". It allows to define more than one configuration for repo.

Depends on:
* https://github.com/jfrog/jfrog-client-go/pull/1358