### PR TITLE
Run JAS scans if requested on WD that has no tech, always

### DIFF
--- a/audit_test.go
+++ b/audit_test.go
@@ -1035,7 +1035,7 @@ func TestAuditNewScaSimpleJsonMultipleWorkingDirs(t *testing.T) {
 	)
 	assert.NoError(t, err)
 	validations.VerifySimpleJsonResults(t, output, validations.ValidationParams{
-		Total:             &validations.TotalCount{Vulnerabilities: 11},
+		Total: &validations.TotalCount{Vulnerabilities: 11},
 		Vulnerabilities: &validations.VulnerabilityCount{
 			ValidateScan: &validations.ScanCount{Sca: 8, Sast: 2, Secrets: 1},
 		},

--- a/commands/audit/audit.go
+++ b/commands/audit/audit.go
@@ -720,48 +720,49 @@ func detectScaTargetsFromTechnologies(cmdResults *results.SecurityCommandResults
 		dirsToDetect = append(dirsToDetect, requestedDirectory)
 	}
 	for _, requestedDirectory := range dirsToDetect {
+		targetsBefore := len(cmdResults.Targets)
 		// Detect descriptors and technologies in the requested directory.
 		techToWorkingDirs, err := techutils.DetectTechnologiesDescriptors(requestedDirectory, params.IsRecursiveScan(), params.Technologies(), getRequestedDescriptors(params), utils.GetExcludePattern(exclusions, utils.DefaultScaExcludePatterns, params.IsRecursiveScan()))
 		if err != nil {
 			log.Warn("Couldn't detect technologies in", requestedDirectory, "directory.", err.Error())
-			continue
-		}
-		// Create scans to perform
-		for tech, workingDirs := range techToWorkingDirs {
-			if tech == techutils.Dotnet {
-				// We detect Dotnet and Nuget the same way, if one detected so does the other.
-				// We don't need to scan for both and get duplicate results.
-				continue
-			}
-			// No technology was detected, add scan without descriptors. (so no sca scan will be performed and set at target level)
-			if len(workingDirs) == 0 {
-				// Requested technology (from params) descriptors/indicators were not found or recursive scan with NoTech value, add scan without descriptors.
-				scanTarget := createScanTarget(requestedDirectory, exclusions)
-				if scanTarget == nil {
+		} else {
+			// Create scans to perform
+			for tech, workingDirs := range techToWorkingDirs {
+				if tech == techutils.Dotnet {
+					// We detect Dotnet and Nuget the same way, if one detected so does the other.
+					// We don't need to scan for both and get duplicate results.
 					continue
 				}
-				scanTarget.Technologies = []techutils.Technology{tech}
+				// No technology was detected, add scan without descriptors. (so no sca scan will be performed and set at target level)
+				if len(workingDirs) == 0 {
+					// Requested technology (from params) descriptors/indicators were not found or recursive scan with NoTech value, add scan without descriptors.
+					scanTarget := createScanTarget(requestedDirectory, exclusions)
+					if scanTarget == nil {
+						continue
+					}
+					scanTarget.Technologies = []techutils.Technology{tech}
+					cmdResults.NewScanResults(*scanTarget)
+				}
+				for workingDir, descriptors := range workingDirs {
+					// Add scan for each detected working directory.
+					scanTarget := createScanTarget(workingDir, exclusions)
+					if scanTarget == nil {
+						continue
+					}
+					scanTarget.Technologies = []techutils.Technology{tech}
+					targetResults := cmdResults.NewScanResults(*scanTarget)
+					if tech != techutils.NoTech {
+						targetResults.SetDescriptors(descriptors...)
+					}
+				}
+			}
+		}
+		// If this working dir produced no targets (e.g. JAS-only with no package managers),
+		// still create a target so secrets/IaC/SAST can run.
+		if len(cmdResults.Targets) == targetsBefore {
+			if scanTarget := createScanTarget(requestedDirectory, exclusions); scanTarget != nil {
 				cmdResults.NewScanResults(*scanTarget)
 			}
-			for workingDir, descriptors := range workingDirs {
-				// Add scan for each detected working directory.
-				scanTarget := createScanTarget(workingDir, exclusions)
-				if scanTarget == nil {
-					continue
-				}
-				scanTarget.Technologies = []techutils.Technology{tech}
-				targetResults := cmdResults.NewScanResults(*scanTarget)
-				if tech != techutils.NoTech {
-					targetResults.SetDescriptors(descriptors...)
-				}
-			}
-		}
-	}
-	// If no scan targets were detected (e.g. JAS-only with no package managers), still
-	// create a target so secrets/IaC/SAST can run.
-	if len(dirsToDetect) == 1 && len(cmdResults.Targets) == 0 {
-		if scanTarget := createScanTarget(dirsToDetect[0], exclusions); scanTarget != nil {
-			cmdResults.NewScanResults(*scanTarget)
 		}
 	}
 	// Load deprecated apps config information for all targets

--- a/commands/audit/audit.go
+++ b/commands/audit/audit.go
@@ -758,7 +758,7 @@ func detectScaTargetsFromTechnologies(cmdResults *results.SecurityCommandResults
 		}
 	}
 	// If no scan targets were detected, we should still proceed with the scans.
-	if len(dirsToDetect) == 1 && params.IsRecursiveScan() && len(cmdResults.Targets) == 0 {
+	if len(dirsToDetect) == 1 && len(cmdResults.Targets) == 0 {
 		if scanTarget := createScanTarget(dirsToDetect[0], exclusions); scanTarget != nil {
 			cmdResults.NewScanResults(*scanTarget)
 		}

--- a/commands/audit/audit.go
+++ b/commands/audit/audit.go
@@ -757,7 +757,8 @@ func detectScaTargetsFromTechnologies(cmdResults *results.SecurityCommandResults
 			}
 		}
 	}
-	// If no scan targets were detected, we should still proceed with the scans.
+	// If no scan targets were detected (e.g. JAS-only with no package managers), still
+	// create a target so secrets/IaC/SAST can run.
 	if len(dirsToDetect) == 1 && len(cmdResults.Targets) == 0 {
 		if scanTarget := createScanTarget(dirsToDetect[0], exclusions); scanTarget != nil {
 			cmdResults.NewScanResults(*scanTarget)

--- a/commands/audit/audit_test.go
+++ b/commands/audit/audit_test.go
@@ -472,21 +472,29 @@ func TestDetectScanTargetsOldFlowJasOnlyNoTechnologies(t *testing.T) {
 	defer func() {
 		assert.NoError(t, fileutils.RemoveTempDir(baseDir))
 	}()
-	defer securityTestUtils.ChangeWDWithCallback(t, baseDir)()
 
+	cwdDir := filepath.Join(baseDir, "cwd")
 	emptyDir1 := filepath.Join(baseDir, "wd1")
 	emptyDir2 := filepath.Join(baseDir, "wd2")
 	npmDir := filepath.Join(baseDir, "npm-wd")
+	assert.NoError(t, os.MkdirAll(cwdDir, 0o755))
 	assert.NoError(t, os.MkdirAll(emptyDir1, 0o755))
 	assert.NoError(t, os.MkdirAll(emptyDir2, 0o755))
 	assert.NoError(t, os.MkdirAll(npmDir, 0o755))
 	createEmptyFile(t, filepath.Join(npmDir, "package.json"))
+	defer securityTestUtils.ChangeWDWithCallback(t, cwdDir)()
+	resolvedCwdDir, err := coreutils.GetWorkingDirectory()
+	assert.NoError(t, err)
 
 	tests := []struct {
 		name        string
 		workingDirs []string
 		wantTargets []string
 	}{
+		{
+			name:        "current directory when no working dirs are passed",
+			wantTargets: []string{resolvedCwdDir},
+		},
 		{
 			name:        "single working dir",
 			workingDirs: []string{emptyDir1},
@@ -507,7 +515,10 @@ func TestDetectScanTargetsOldFlowJasOnlyNoTechnologies(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			cmdRes := results.NewCommandResults(utils.SourceCode).SetEntitledForJas(true).SetSecretValidation(true)
-			params := NewAuditParams().SetWorkingDirs(tt.workingDirs)
+			params := NewAuditParams()
+			if tt.workingDirs != nil {
+				params.SetWorkingDirs(tt.workingDirs)
+			}
 			// Mimic GetTargetsInfo for jf audit --secrets: SCA not requested => non-recursive.
 			params.SetIsRecursiveScan(false)
 			params.SetBomGenerator(buildinfo.NewBuildInfoBomGenerator())

--- a/commands/audit/audit_test.go
+++ b/commands/audit/audit_test.go
@@ -464,6 +464,29 @@ func TestDetectScansToPerform(t *testing.T) {
 	cleanUp()
 }
 
+// Old flow with JAS-only (no SCA) leaves IsRecursiveScan false. A directory without
+// technologies must still become a scan target so secrets/IaC/SAST can run.
+func TestDetectScanTargetsOldFlowJasOnlyNoTechnologies(t *testing.T) {
+	emptyDir, err := fileutils.CreateTempDir()
+	assert.NoError(t, err)
+	defer func() {
+		assert.NoError(t, fileutils.RemoveTempDir(emptyDir))
+	}()
+	defer securityTestUtils.ChangeWDWithCallback(t, emptyDir)()
+
+	cmdRes := results.NewCommandResults(utils.SourceCode).SetEntitledForJas(true).SetSecretValidation(true)
+	params := NewAuditParams().SetWorkingDirs([]string{emptyDir})
+	// Mimic GetTargetsInfo for jf audit --secrets: SCA not requested => non-recursive.
+	params.SetIsRecursiveScan(false)
+	params.SetBomGenerator(buildinfo.NewBuildInfoBomGenerator())
+
+	detectScanTargets(cmdRes, params)
+
+	if assert.Len(t, cmdRes.Targets, 1) {
+		assert.Equal(t, emptyDir, cmdRes.Targets[0].Target)
+	}
+}
+
 func TestDetectScanTargetsSkipsCliExcludedCwdSingleTarget(t *testing.T) {
 	baseDir, cleanUp := createTestDir(t)
 	defer cleanUp()

--- a/commands/audit/audit_test.go
+++ b/commands/audit/audit_test.go
@@ -464,26 +464,62 @@ func TestDetectScansToPerform(t *testing.T) {
 	cleanUp()
 }
 
-// Old flow with JAS-only (no SCA) leaves IsRecursiveScan false. A directory without
-// technologies must still become a scan target so secrets/IaC/SAST can run.
+// Old flow with JAS-only (no SCA) leaves IsRecursiveScan false. Directories without
+// technologies must still become scan targets so secrets/IaC/SAST can run.
 func TestDetectScanTargetsOldFlowJasOnlyNoTechnologies(t *testing.T) {
-	emptyDir, err := fileutils.CreateTempDir()
+	baseDir, err := fileutils.CreateTempDir()
 	assert.NoError(t, err)
 	defer func() {
-		assert.NoError(t, fileutils.RemoveTempDir(emptyDir))
+		assert.NoError(t, fileutils.RemoveTempDir(baseDir))
 	}()
-	defer securityTestUtils.ChangeWDWithCallback(t, emptyDir)()
+	defer securityTestUtils.ChangeWDWithCallback(t, baseDir)()
 
-	cmdRes := results.NewCommandResults(utils.SourceCode).SetEntitledForJas(true).SetSecretValidation(true)
-	params := NewAuditParams().SetWorkingDirs([]string{emptyDir})
-	// Mimic GetTargetsInfo for jf audit --secrets: SCA not requested => non-recursive.
-	params.SetIsRecursiveScan(false)
-	params.SetBomGenerator(buildinfo.NewBuildInfoBomGenerator())
+	emptyDir1 := filepath.Join(baseDir, "wd1")
+	emptyDir2 := filepath.Join(baseDir, "wd2")
+	npmDir := filepath.Join(baseDir, "npm-wd")
+	assert.NoError(t, os.MkdirAll(emptyDir1, 0o755))
+	assert.NoError(t, os.MkdirAll(emptyDir2, 0o755))
+	assert.NoError(t, os.MkdirAll(npmDir, 0o755))
+	createEmptyFile(t, filepath.Join(npmDir, "package.json"))
 
-	detectScanTargets(cmdRes, params)
+	tests := []struct {
+		name        string
+		workingDirs []string
+		wantTargets []string
+	}{
+		{
+			name:        "single working dir",
+			workingDirs: []string{emptyDir1},
+			wantTargets: []string{emptyDir1},
+		},
+		{
+			name:        "multiple working dirs (mono-repo)",
+			workingDirs: []string{emptyDir1, emptyDir2},
+			wantTargets: []string{emptyDir1, emptyDir2},
+		},
+		{
+			name:        "mixed tech and no-tech working dirs",
+			workingDirs: []string{npmDir, emptyDir1},
+			wantTargets: []string{npmDir, emptyDir1},
+		},
+	}
 
-	if assert.Len(t, cmdRes.Targets, 1) {
-		assert.Equal(t, emptyDir, cmdRes.Targets[0].Target)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cmdRes := results.NewCommandResults(utils.SourceCode).SetEntitledForJas(true).SetSecretValidation(true)
+			params := NewAuditParams().SetWorkingDirs(tt.workingDirs)
+			// Mimic GetTargetsInfo for jf audit --secrets: SCA not requested => non-recursive.
+			params.SetIsRecursiveScan(false)
+			params.SetBomGenerator(buildinfo.NewBuildInfoBomGenerator())
+
+			detectScanTargets(cmdRes, params)
+
+			got := make([]string, 0, len(cmdRes.Targets))
+			for _, target := range cmdRes.Targets {
+				got = append(got, target.Target)
+			}
+			assert.ElementsMatch(t, tt.wantTargets, got)
+		})
 	}
 }
 


### PR DESCRIPTION
- [ ] The pull request is targeting the `dev` branch.
- [ ] The code has been validated to compile successfully by running `go vet ./...`.
- [ ] The code has been formatted properly using `go fmt ./...`.
- [ ] All [static analysis checks](https://github.com/jfrog/jfrog-cli-security/actions/workflows/analysis.yml) passed.
- [ ] All [tests](https://github.com/jfrog/jfrog-cli-security/actions/workflows/test.yml) have passed. If this feature is not already covered by the tests, new tests have been added.
- [ ] Updated the [Contributing page](https://github.com/jfrog/jfrog-cli-security/blob/main/CONTRIBUTING.md) / [ReadMe page](https://github.com/jfrog/jfrog-cli-security/blob/main/README.md) / [CI Workflow files](https://github.com/jfrog/jfrog-cli-security/tree/main/.github/workflows) if needed.
- [ ] All changes are detailed at the description. if not already covered at [JFrog Documentation](https://github.com/jfrog/documentation), new documentation have been added.

-----

Fixes: https://jfrog-int.atlassian.net/browse/XRAY-149601


When running `jf audit` with (`--secrets`/`--iac`/`--sast` only, no `--static-sca`) on a project without any package-manager files present we got:
```
→ 0 targets → "No scan targets were detected. No scans will be performed."
```

This PR fixes the bug