### PR TITLE
XRAY-156190 - Implement all packages blocked in packument fallback logic for npm

### DIFF
--- a/commands/curation/curationaudit.go
+++ b/commands/curation/curationaudit.go
@@ -62,11 +62,13 @@ import (
 
 const (
 	// The "blocked" represents the unapproved status that can be returned by the Curation Service for dependencies..
-	blocked                = "blocked"
-	BlockingReasonPolicy   = "Policy violations"
-	BlockingReasonNotFound = "Package pending update"
-	BlockingReasonOnDemand = "Package pending — Curation on-demand scan in progress"
-	BlockingReasonUnknown  = "Blocked by curation (response could not be parsed)"
+	blocked                    = "blocked"
+	notEvaluated               = "not evaluated"
+	BlockingReasonPolicy       = "Policy violations"
+	BlockingReasonNotFound     = "Package pending update"
+	BlockingReasonOnDemand     = "Package pending — Curation on-demand scan in progress"
+	BlockingReasonUnknown      = "Blocked by curation (response could not be parsed)"
+	BlockingReasonNotEvaluated = "Not evaluated — non-registry dependency"
 
 	directRelation   = "direct"
 	indirectRelation = "indirect"
@@ -105,10 +107,20 @@ const (
 
 	// hfUnresolvedReportKey is used when an HF scan found only dynamic references — no table, just warnings.
 	hfUnresolvedReportKey = "huggingface (unresolved references)"
+
+	// npmLogPartialReportWarning is shown when runNpmLogFallback recovers a partial report.
+	// npmLogOriginalErr (the real underlying npm error) goes to log.Debug only, not here —
+	// npm's own error text can include its full captured stdout/stderr, far too noisy for a
+	// console warning.
+	npmLogPartialReportWarning = "npm install could not fully resolve the dependency tree because one or more packages " +
+		"are blocked by the curation policy. This report was reconstructed from npm's debug log after the installation " +
+		"failed, so it may be incomplete. Dependencies of blocked packages could not be analyzed because their metadata " +
+		"was unavailable."
 )
 
 var CurationOutputFormats = []string{string(outFormat.Table), string(outFormat.Json)}
 var osGetwd = os.Getwd
+var npmGetConfigValue = npmtech.GetNpmConfigValue
 
 var supportedTech = map[techutils.Technology]func(ca *CurationAuditCommand) (bool, error){
 	techutils.Npm:  func(ca *CurationAuditCommand) (bool, error) { return true, nil },
@@ -289,6 +301,12 @@ type CurationReport struct {
 	// Kept separate from isPartial, which also triggers the CVS-specific warning
 	// and skips the waiver flow.
 	hfPartial bool
+	// npmLogPartial marks a report produced by runNpmLogFallback. Set alongside isPartial
+	// (to reuse its waiver-skip gate), but kept distinct for its own warning text and
+	// partialReason.
+	npmLogPartial bool
+	// npmLogOriginalErr is the real install error, surfaced alongside npmLogPartialReportWarning.
+	npmLogOriginalErr string
 	// warnings holds user-facing messages from tree-build (e.g. unresolved HF references).
 	warnings []string
 	// huggingFaceReport marks reports produced by the Hugging Face audit path (including
@@ -426,7 +444,12 @@ func (ca *CurationAuditCommand) Run() (err error) {
 	}
 	for projectPath, report := range results {
 		if report.isPartial {
-			log.Warn(fmt.Sprintf("[%s] %s", projectPath, cvsPartialReportWarning))
+			warningText := cvsPartialReportWarning
+			if report.npmLogPartial {
+				warningText = npmLogPartialReportWarning
+				log.Debug(fmt.Sprintf("[%s] underlying npm error: %s", projectPath, report.npmLogOriginalErr))
+			}
+			log.Warn(fmt.Sprintf("[%s] %s", projectPath, warningText))
 		}
 	}
 
@@ -475,20 +498,31 @@ func (ca *CurationAuditCommand) Run() (err error) {
 func convertResultsToSummary(results map[string]*CurationReport) formats.ResultsSummary {
 	summaryResults := formats.ResultsSummary{}
 	for projectPath, packagesStatus := range results {
-		// hfPartial reports must still be recorded, not treated as "HF wasn't attempted".
-		if isWarningsOnlyReport(packagesStatus) && !packagesStatus.hfPartial {
+		// hfPartial/npmLogPartial reports must still be recorded, not treated as "not attempted".
+		if isWarningsOnlyReport(packagesStatus) && !packagesStatus.hfPartial && !packagesStatus.npmLogPartial {
 			continue
 		}
 		var partialReason string
 		switch {
+		// npmLogPartial is checked before isPartial: an npm-log-fallback report sets both
+		// (isPartial to reuse the existing waiver-skip gate below), so npmLogPartial must
+		// win here or it would incorrectly report "cvs_fallback".
+		case packagesStatus.npmLogPartial:
+			// jfrog-ignore: categorical tag, not hardcoded credentials
+			partialReason = "npm_log_fallback"
 		case packagesStatus.isPartial:
 			partialReason = "cvs_fallback"
 		case packagesStatus.hfPartial:
 			partialReason = "hf_unresolved"
 		}
+		// npmLogPartial's totalNumberOfPackages includes non-remediable "not evaluated" rows, so use the blocked-row count instead.
+		packageCount := packagesStatus.totalNumberOfPackages
+		if packagesStatus.npmLogPartial {
+			packageCount = countBlockedPackages(packagesStatus.packagesStatus)
+		}
 		summaryResults.Scans = append(summaryResults.Scans, formats.ScanSummary{Target: projectPath,
 			CuratedPackages: &formats.CuratedPackages{
-				PackageCount:  packagesStatus.totalNumberOfPackages,
+				PackageCount:  packageCount,
 				Blocked:       getBlocked(packagesStatus.packagesStatus),
 				IsPartial:     packagesStatus.isPartial || packagesStatus.hfPartial,
 				PartialReason: partialReason,
@@ -498,9 +532,23 @@ func convertResultsToSummary(results map[string]*CurationReport) formats.Results
 	return summaryResults
 }
 
+// countBlockedPackages counts only rows with Action == blocked, excluding "not evaluated" rows.
+func countBlockedPackages(packagesStatus []*PackageStatus) int {
+	count := 0
+	for _, ps := range packagesStatus {
+		if ps.Action == blocked {
+			count++
+		}
+	}
+	return count
+}
+
 func getBlocked(pkgStatus []*PackageStatus) []formats.BlockedPackages {
 	blockedMap := map[string]formats.BlockedPackages{}
 	for _, pkg := range pkgStatus {
+		if pkg.Action != blocked {
+			continue
+		}
 		for _, policy := range pkg.Policy {
 			polAndCondKey := getPolicyAndConditionId(policy.Policy, policy.Condition)
 			if _, ok := blockedMap[polAndCondKey]; !ok {
@@ -949,6 +997,42 @@ func (ca *CurationAuditCommand) auditTree(tech techutils.Technology, results map
 	if err != nil {
 		return err
 	}
+	// Discovered before installing, not after: npm writes a log on every invocation, so running
+	// this after a crash would make its own log newer than the crash's. Failure isn't fatal.
+	//
+	// Uses logs-dir, not cache: <cache>/_logs is only npm's default, overridable independently.
+	// "npm config get logs-dir" prints the literal string "null" when unset, hence the fallback.
+	var npmLogsDir string
+	var npmLogsMaxWasZero bool
+	var npmLogBaselineKey int64
+	var npmConfigLookupErr error
+	if tech == techutils.Npm {
+		if workDir, wdErr := osGetwd(); wdErr != nil {
+			npmConfigLookupErr = fmt.Errorf("failed to determine working directory for npm config lookup: %w", wdErr)
+		} else if logsDirValue, logsDirErr := npmGetConfigValue(workDir, "logs-dir"); logsDirErr != nil {
+			npmConfigLookupErr = fmt.Errorf("failed to determine npm logs-dir: %w", logsDirErr)
+		} else if logsMaxValue, logsMaxErr := npmGetConfigValue(workDir, "logs-max"); logsMaxErr != nil {
+			npmConfigLookupErr = fmt.Errorf("failed to determine npm logs-max config: %w", logsMaxErr)
+		} else if logsDirValue != "" && logsDirValue != "null" {
+			npmLogsDir, npmLogsMaxWasZero = logsDirValue, logsMaxValue == "0"
+		} else if cacheDir, cacheErr := npmGetConfigValue(workDir, "cache"); cacheErr != nil {
+			npmConfigLookupErr = fmt.Errorf("failed to determine npm cache directory: %w", cacheErr)
+		} else {
+			npmLogsDir, npmLogsMaxWasZero = filepath.Join(cacheDir, "_logs"), logsMaxValue == "0"
+		}
+		if npmConfigLookupErr != nil {
+			log.Debug(fmt.Sprintf("npm curation debug-log fallback will be unavailable if the install fails: %v", npmConfigLookupErr))
+		}
+		if npmLogsMaxWasZero {
+			// Only override when the ambient config would otherwise suppress the debug log
+			// entirely — never force a value that prunes a user's own nonzero retention setting.
+			params.NpmForceLogsMax = "1"
+		}
+		if npmLogsDir != "" {
+			// Snapshotted last so the baseline includes the config-lookup calls' own logs too.
+			npmLogBaselineKey, _ = npmDebugLogNewestKey(npmLogsDir)
+		}
+	}
 	depTreeResult, err := buildinfo.GetTechDependencyTree(params, serverDetails, tech)
 	if err != nil {
 		// When CVS strips a pinned version from the simple index, pip can't
@@ -959,7 +1043,18 @@ func (ca *CurationAuditCommand) auditTree(tech techutils.Technology, results map
 		if (tech == techutils.Pip || tech == techutils.Poetry) && errors.As(err, &cvsErr) {
 			return ca.runCvsFallback(cvsErr, tech, results)
 		}
+		// npm's install error is a plain opaque error, nothing to type-match on — trigger the
+		// debug-log fallback unconditionally, unless the config lookup above already failed.
+		if tech == techutils.Npm {
+			if npmConfigLookupErr != nil {
+				return err
+			}
+			return ca.runNpmLogFallback(npmLogsDir, tech, results, err, npmLogsMaxWasZero, npmLogBaselineKey)
+		}
 		return err
+	}
+	if tech == techutils.Npm {
+		defer cleanupForcedNpmDebugLog(npmLogsDir, npmLogsMaxWasZero, npmLogBaselineKey)
 	}
 	// Validate the graph isn't empty.
 	if len(depTreeResult.FullDepTrees) == 0 {
@@ -1212,7 +1307,7 @@ func printResult(format outFormat.OutputFormat, projectPath string, packagesStat
 	if format == "" {
 		format = outFormat.Table
 	}
-	log.Output(fmt.Sprintf("Found %v blocked packages for project %s", len(packagesStatus), projectPath))
+	log.Output(fmt.Sprintf("Found %v blocked packages for project %s", countBlockedPackages(packagesStatus), projectPath))
 	switch format {
 	case outFormat.Json:
 		if len(packagesStatus) > 0 {
@@ -1722,6 +1817,233 @@ func (ca *CurationAuditCommand) runCvsFallback(cvsErr *python.CvsBlockedError, t
 		isPartial:             true,
 	}
 	return nil
+}
+
+// cleanupForcedNpmDebugLog removes the log our forced --logs-max override caused npm to write,
+// when logs-max=0. Success-path counterpart to runNpmLogFallback's cleanup; baselineKey (see
+// npmDebugLogNewestKey) ensures a stale pre-existing log is never removed by mistake.
+func cleanupForcedNpmDebugLog(logsDir string, logsMaxWasZero bool, baselineKey int64) {
+	if !logsMaxWasZero {
+		return
+	}
+	logFilePaths, err := findNewestNpmDebugLogChunksAfter(logsDir, baselineKey)
+	if err != nil {
+		return
+	}
+	for _, logFilePath := range logFilePaths {
+		if rmErr := os.Remove(logFilePath); rmErr != nil {
+			log.Debug(fmt.Sprintf("npm curation: failed to remove forced debug log %q: %v", logFilePath, rmErr))
+		}
+	}
+}
+
+// runNpmLogFallback reconstructs a partial curation report from npm's debug log (under
+// logsDir — npm's "logs-dir" config) when the npm tree-build install crashes, since buildDeps
+// completes before reify can fail. Falls back to originalErr unchanged if nothing is recoverable.
+//
+// baselineKey (see npmDebugLogNewestKey) is the newest log's identity captured just before this
+// invocation ran — only a log newer than that is read, so a stale log from an earlier run
+// sharing the same logs-dir (e.g. a shared CI cache) is never mistaken for this crash's own.
+//
+// logsMaxWasZero means our forced --logs-max override is the only reason a debug log exists
+// for this run, so the log files read here are removed afterward; otherwise npm's own
+// rotation manages them like any other run.
+func (ca *CurationAuditCommand) runNpmLogFallback(logsDir string, tech techutils.Technology, results map[string]*CurationReport, originalErr error, logsMaxWasZero bool, baselineKey int64) error {
+	entries, blockedPackages, logFilePaths, parseErr := parseNpmDebugLog(logsDir, baselineKey)
+	if logsMaxWasZero {
+		defer func() {
+			for _, logFilePath := range logFilePaths {
+				_ = os.Remove(logFilePath)
+			}
+		}()
+	}
+	if parseErr != nil {
+		log.Debug(fmt.Sprintf("npm curation debug-log fallback: failed to parse debug log (%v); original error: %s", parseErr, originalErr.Error()))
+		return originalErr
+	}
+	if len(entries) == 0 {
+		// Nothing recoverable — install likely failed before buildDeps ever started.
+		return originalErr
+	}
+
+	rtManager, serverDetails, err := ca.getRtManagerAndAuth(tech)
+	if err != nil {
+		return fmt.Errorf("npm curation debug-log fallback: failed to get Artifactory manager (%w); %s error: %w", err, tech, originalErr)
+	}
+	rtAuth, err := serverDetails.CreateArtAuthConfig()
+	if err != nil {
+		return fmt.Errorf("npm curation debug-log fallback: failed to create auth config (%w); %s error: %w", err, tech, originalErr)
+	}
+
+	workPath, wdErr := osGetwd()
+	if wdErr != nil {
+		log.Warn(fmt.Sprintf("npm curation debug-log fallback: could not determine working directory (%v) — reporting under fallback key", wdErr))
+		workPath = "unknown-project"
+	}
+	rootName, rootVersion, pkgErr := readNpmProjectNameVersion(workPath)
+	if pkgErr != nil {
+		// The graph walk only reaches anything if rootName/rootVersion match the log's real root.
+		if logRootName, logRootVersion, ok := rootIdentityFromLogEntries(entries); ok {
+			rootName, rootVersion = logRootName, logRootVersion
+		} else {
+			// Same convention auditTree itself uses when a project doesn't declare a name.
+			rootName = filepath.Base(workPath)
+		}
+	}
+
+	analyzer := treeAnalyzer{
+		rtManager:            rtManager,
+		extractPoliciesRegex: ca.extractPoliciesRegex,
+		rtAuth:               rtAuth,
+		httpClientDetails:    rtAuth.CreateHttpClientDetails(),
+		url:                  rtAuth.GetUrl(),
+		repo:                 ca.PackageManagerConfig.TargetRepo(),
+		tech:                 tech,
+	}
+
+	preProcessMap := &sync.Map{}
+	var advisoryWarnings []string
+	seenKeys := map[string]bool{}
+	seenRangeWarnings := map[string]bool{}
+	for _, entry := range sortedNpmLogEntries(entries) {
+		category := classifyBlankVersionEntry(entry, blockedPackages)
+
+		if category == npmEntryUnresolvableRange {
+			// Dedupe on (Name, Specifier) — never preempts a same-name entry in a probeable category.
+			rangeKey := entry.Name + "@" + entry.Specifier
+			if seenRangeWarnings[rangeKey] {
+				continue
+			}
+			seenRangeWarnings[rangeKey] = true
+			advisoryWarnings = append(advisoryWarnings, fmt.Sprintf(
+				"Package '%s' (requested as '%s') could not be resolved to a specific version, so its curation status could not be checked. This is not necessarily a curation block — verify the dependency resolves correctly.",
+				entry.Name, entry.Specifier))
+			continue
+		}
+
+		// effectiveGraphVersion avoids collapsing distinct ETARGET/non-registry specifiers onto one key.
+		effectiveVersion := effectiveGraphVersion(entry, blockedPackages)
+		key, keyErr := npmPackageKey(tech, analyzer.url, analyzer.repo, entry.Name, effectiveVersion)
+		if keyErr != nil {
+			advisoryWarnings = append(advisoryWarnings, fmt.Sprintf(
+				"Package '%s@%s' could not be checked against the curation policy (%v) — its status is unknown, not confirmed clean.",
+				entry.Name, effectiveVersion, keyErr))
+			continue
+		}
+		if seenKeys[key] {
+			continue
+		}
+		seenKeys[key] = true
+
+		switch category {
+		case npmEntryResolved:
+			pkgStatus, probeErr := analyzer.getBlockedPackageDetails(key, entry.Name, entry.Version)
+			if probeErr != nil {
+				advisoryWarnings = append(advisoryWarnings, fmt.Sprintf(
+					"Package '%s@%s' could not be checked against the curation policy (%v) — its status is unknown, not confirmed clean.",
+					entry.Name, entry.Version, probeErr))
+				continue
+			}
+			if pkgStatus == nil {
+				continue // genuinely clean — no row needed
+			}
+			preProcessMap.Store(key, pkgStatus)
+		case npmEntryWholePackageBlocked:
+			preProcessMap.Store(key, wholePackageBlockedStatus(entry, blockedPackages[entry.Name], tech))
+		case npmEntryNonRegistrySpecifier:
+			// Advisory only, not a table/JSON row — same treatment as the other
+			// "curation never applied" categories, so it can't be mistaken for a real block.
+			advisoryWarnings = append(advisoryWarnings, fmt.Sprintf(
+				"Package '%s' (%s): Not evaluated: This dependency was not evaluated because it is resolved from a source "+
+					"other than an npm registry (such as a Git URL, local path, or npm alias), bypassing Artifactory. "+
+					"As a result, curation policies do not apply.",
+				entry.Name, entry.Specifier))
+		case npmEntryETARGET:
+			pkgStatus, probeErr := analyzer.getBlockedPackageDetails(key, entry.Name, entry.Specifier)
+			if probeErr != nil {
+				advisoryWarnings = append(advisoryWarnings, fmt.Sprintf(
+					"Package '%s@%s' could not be checked against the curation policy (%v) — its status is unknown, not confirmed clean.",
+					entry.Name, entry.Specifier, probeErr))
+				continue
+			}
+			if pkgStatus == nil {
+				// Plain 404, no curation signal — not curation-relevant, advisory only.
+				advisoryWarnings = append(advisoryWarnings, fmt.Sprintf(
+					"Package '%s@%s' could not be resolved (no matching version found in the registry) — this is not a curation policy block. Verify the version in package.json.",
+					entry.Name, entry.Specifier))
+				continue
+			}
+			preProcessMap.Store(key, pkgStatus)
+		}
+	}
+
+	graph := buildGraphFromLogEntries(entries, rootName, rootVersion, blockedPackages)
+	var packagesStatus []*PackageStatus
+	analyzer.GraphsRelations([]*xrayUtils.GraphNode{graph}, preProcessMap, &packagesStatus)
+
+	// DepRelation is set per-edge by GraphsRelations, so this is correct even when the same
+	// package name occurs as both a direct and a transitive dependency.
+	for _, ps := range packagesStatus {
+		if ps.PackageVersion == allVersionsBlockedText {
+			applyTransitiveAwareRecommendation(ps, ps.DepRelation == directRelation)
+		}
+	}
+
+	if len(packagesStatus) == 0 && len(advisoryWarnings) == 0 {
+		return originalErr
+	}
+
+	results[uniqueReportKey(results, filepath.Base(workPath), tech)] = &CurationReport{
+		packagesStatus:        packagesStatus,
+		totalNumberOfPackages: len(packagesStatus),
+		isPartial:             true,
+		npmLogPartial:         true,
+		npmLogOriginalErr:     originalErr.Error(),
+		warnings:              advisoryWarnings,
+	}
+	return nil
+}
+
+// allVersionsBlockedText also doubles as the marker applyTransitiveAwareRecommendation uses
+// to identify whole-package-blocked rows after the graph walk.
+const allVersionsBlockedText = "All versions blocked"
+
+// wholePackageBlockedStatus synthesizes a *PackageStatus straight from the log's notice+403
+// evidence — no HEAD-check needed. Recommendation is filled in later by
+// applyTransitiveAwareRecommendation, once the graph walk knows the parent.
+func wholePackageBlockedStatus(entry npmLogEntry, info npmBlockedInfo, tech techutils.Technology) *PackageStatus {
+	return &PackageStatus{
+		PackageName:    entry.Name,
+		PackageVersion: allVersionsBlockedText,
+		Action:         blocked,
+		BlockingReason: BlockingReasonPolicy,
+		PkgType:        string(tech),
+		Policy: []Policy{{
+			Policy:      info.Policy,
+			Condition:   info.Condition,
+			Explanation: allVersionsBlockedText,
+			// Recommendation is filled in by applyTransitiveAwareRecommendation.
+		}},
+	}
+}
+
+// applyTransitiveAwareRecommendation: "remove and replace" is only actionable when the
+// blocked package is itself a direct dependency; otherwise name the real direct dependency.
+// ps.Policy is reassigned, not mutated in place — fillGraphRelations clones *PackageStatus
+// per edge via a shallow copy, so edges sharing a preProcessMap entry share the same array.
+func applyTransitiveAwareRecommendation(ps *PackageStatus, isDirectDependency bool) {
+	policies := make([]Policy, len(ps.Policy))
+	copy(policies, ps.Policy)
+	for i := range policies {
+		if isDirectDependency {
+			policies[i].Recommendation = "Remove this package from your project and replace with an alternate package"
+		} else {
+			policies[i].Recommendation = fmt.Sprintf(
+				"%s is a transitive dependency of %s and cannot be removed directly. Apply a waiver if acceptable, or replace %s with an alternative that doesn't depend on %s.",
+				ps.PackageName, ps.ParentName, ps.ParentName, ps.PackageName)
+		}
+	}
+	ps.Policy = policies
 }
 
 // lookupPypiAllVersions calls the Artifactory PyPI metadata API for a package

--- a/commands/curation/curationaudit_test.go
+++ b/commands/curation/curationaudit_test.go
@@ -1655,6 +1655,43 @@ func Test_convertResultsToSummary_RecordsAllUnresolvedHFReport(t *testing.T) {
 	assert.Equal(t, "hf_unresolved", summary.Scans[0].CuratedPackages.PartialReason)
 }
 
+// PackageCount must reflect remediation-needed rows, not the raw row count including "not evaluated" ones.
+func Test_convertResultsToSummary_NpmLogPartialPackageCountExcludesNotEvaluated(t *testing.T) {
+	results := map[string]*CurationReport{
+		"npm-project": {
+			packagesStatus: []*PackageStatus{
+				{PackageName: "blocked-a", Action: blocked},
+				{PackageName: "blocked-b", Action: blocked},
+				{PackageName: "git-dep", Action: notEvaluated},
+			},
+			totalNumberOfPackages: 3,
+			isPartial:             true,
+			npmLogPartial:         true,
+		},
+	}
+	summary := convertResultsToSummary(results)
+	require.Len(t, summary.Scans, 1)
+	assert.Equal(t, 2, summary.Scans[0].CuratedPackages.PackageCount,
+		"PackageCount must count only rows needing remediation, not the not-evaluated row")
+}
+
+// An advisory-only npm-log-fallback report must still be recorded in the summary, like hfPartial already is.
+func Test_convertResultsToSummary_RecordsAdvisoryOnlyNpmLogPartialReport(t *testing.T) {
+	results := map[string]*CurationReport{
+		"npm-project": {
+			totalNumberOfPackages: 0,
+			isPartial:             true,
+			npmLogPartial:         true,
+			warnings:              []string{"lodash@99.99.99 could not be resolved"},
+		},
+	}
+	summary := convertResultsToSummary(results)
+	require.Len(t, summary.Scans, 1)
+	assert.Equal(t, "npm-project", summary.Scans[0].Target)
+	assert.True(t, summary.Scans[0].CuratedPackages.IsPartial)
+	assert.Equal(t, "npm_log_fallback", summary.Scans[0].CuratedPackages.PartialReason)
+}
+
 func Test_doCurateAudit_ExplicitHuggingFaceRequiresHFEndpoint(t *testing.T) {
 	cleanUpFlags := setCurationFlagsForTest(t)
 	defer cleanUpFlags()
@@ -2821,6 +2858,827 @@ func TestRunCvsFallback_KeepsSeparateTableFromExistingReport(t *testing.T) {
 	assert.Len(t, pipReport.packagesStatus, 1)
 	assert.True(t, pipReport.isPartial)
 	assert.False(t, pipReport.huggingFaceReport, "pip's own report must not carry the HF marker")
+}
+
+// Feeds the mixed-crash.log fixture through the full runNpmLogFallback end to end.
+func TestRunNpmLogFallback(t *testing.T) {
+	const repo = "my-pnpm-remote"
+	acceptsBlockMsg := "Package accepts:2.0.0 download was blocked by jfrog packages curation service due to the following policies violated " +
+		"{cve-high, CVE with CVSS score of 9 or above, Package version contains a vulnerability, Upgrade to a fixed version}."
+	acceptsBlockJSON := fmt.Sprintf(`{"errors":[{"status":403,"message":%q}]}`, acceptsBlockMsg)
+
+	serverMock, serverDetails, _ := coreCommonTests.CreateRtRestsMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case strings.Contains(r.URL.Path, "/accepts-2.0.0.tgz"):
+			w.WriteHeader(http.StatusForbidden)
+			_, _ = w.Write([]byte(acceptsBlockJSON))
+		case strings.Contains(r.URL.Path, "/lodash-99.99.99.tgz"):
+			// Genuine ETARGET: plain 404, no curation signal.
+			w.WriteHeader(http.StatusNotFound)
+		case strings.Contains(r.URL.Path, "/express-5.2.1.tgz"), strings.Contains(r.URL.Path, "/typescript-5.3.3.tgz"):
+			w.WriteHeader(http.StatusOK)
+		case strings.Contains(r.URL.Path, "/depd-"), strings.Contains(r.URL.Path, "/is-thirteen-"), strings.Contains(r.URL.Path, "/some-range-pkg-"):
+			t.Errorf("unexpected HEAD-check for a whole-package-blocked/non-registry/unresolvable-range entry: %s", r.URL.Path)
+			w.WriteHeader(http.StatusInternalServerError)
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	})
+	defer serverMock.Close()
+
+	repoConfig := (&project.RepositoryConfig{}).
+		SetTargetRepo(repo).
+		SetServerDetails(serverDetails)
+	ca := &CurationAuditCommand{
+		PackageManagerConfig: repoConfig,
+		extractPoliciesRegex: regexp.MustCompile(extractPoliciesRegexTemplate),
+	}
+
+	projectDir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(projectDir, "package.json"),
+		[]byte(`{"name":"mypnpmproject-v11","version":"1.0.0"}`), 0644))
+	orig := osGetwd
+	osGetwd = func() (string, error) { return projectDir, nil }
+	t.Cleanup(func() { osGetwd = orig })
+
+	results := map[string]*CurationReport{}
+	originalErr := errors.New("error while running 'npm install': exit status 1")
+	logsDir := filepath.Join(TestDataDir, "curation", "npmlogs", "mixed-crash", "_logs")
+
+	err := ca.runNpmLogFallback(logsDir, techutils.Npm, results, originalErr, false, 0)
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+
+	var report *CurationReport
+	for _, r := range results {
+		report = r
+	}
+	require.NotNil(t, report)
+	assert.True(t, report.isPartial)
+	assert.True(t, report.npmLogPartial)
+	assert.Equal(t, originalErr.Error(), report.npmLogOriginalErr,
+		"the real underlying npm error must be preserved, not just a generic curation-blamed message")
+
+	byName := map[string]*PackageStatus{}
+	for _, ps := range report.packagesStatus {
+		byName[ps.PackageName] = ps
+	}
+
+	// Whole-package-blocked, transitive via express: "All versions blocked" and the
+	// transitive-aware recommendation naming both packages.
+	depd := byName["depd"]
+	require.NotNil(t, depd, "depd should be reported as a whole-package block")
+	assert.Equal(t, allVersionsBlockedText, depd.PackageVersion)
+	assert.Equal(t, "express", depd.ParentName, "depd's direct-dependency attribution must walk to express, not stop at an intermediate parent")
+	require.Len(t, depd.Policy, 1)
+	assert.Contains(t, depd.Policy[0].Recommendation, "transitive dependency of express")
+
+	// Resolved and blocked via the normal HEAD-check path (getBlockedPackageDetails,
+	// unmodified) — full policy detail recovered from the 403 body.
+	accepts := byName["accepts"]
+	require.NotNil(t, accepts, "accepts should be reported as blocked via the standard HEAD-check")
+	assert.Equal(t, "2.0.0", accepts.PackageVersion)
+	require.Len(t, accepts.Policy, 1)
+	assert.Equal(t, "cve-high", accepts.Policy[0].Policy)
+
+	// Clean packages never appear as rows.
+	assert.NotContains(t, byName, "express")
+	assert.NotContains(t, byName, "typescript")
+
+	// Git-URL, genuine ETARGET, and unresolvable range: never probed, never a row — advisory
+	// warnings only, so none can be mistaken for a real block in the table/JSON output.
+	assert.NotContains(t, byName, "is-thirteen")
+	assert.NotContains(t, byName, "lodash")
+	assert.NotContains(t, byName, "some-range-pkg")
+	require.Len(t, report.warnings, 3)
+	warningsText := strings.Join(report.warnings, "\n")
+	assert.Contains(t, warningsText, "is-thirteen")
+	assert.Contains(t, warningsText, "github:jonschlinkert/is-thirteen")
+	assert.Contains(t, warningsText, "lodash@99.99.99")
+	assert.Contains(t, warningsText, "not a curation policy block")
+	assert.Contains(t, warningsText, "some-range-pkg")
+	assert.Contains(t, warningsText, "^3.0.0")
+}
+
+// An ETARGET-confirmed-blocked package must not be stored under a key the graph lookup never finds.
+func TestRunNpmLogFallback_ETARGETConfirmedBlockAppearsInReport(t *testing.T) {
+	blockMsg := "Package pinned-blocked:9.9.9 download was blocked by jfrog packages curation service due to the following policies violated " +
+		"{cve-high, CVE with CVSS score of 9 or above, Package version contains a vulnerability, Upgrade to a fixed version}."
+	blockJSON := fmt.Sprintf(`{"errors":[{"status":403,"message":%q}]}`, blockMsg)
+
+	serverMock, serverDetails, _ := coreCommonTests.CreateRtRestsMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+		if strings.Contains(r.URL.Path, "/pinned-blocked-9.9.9.tgz") {
+			w.WriteHeader(http.StatusForbidden)
+			_, _ = w.Write([]byte(blockJSON))
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	})
+	defer serverMock.Close()
+
+	repoConfig := (&project.RepositoryConfig{}).SetTargetRepo("my-npm-remote").SetServerDetails(serverDetails)
+	ca := &CurationAuditCommand{
+		PackageManagerConfig: repoConfig,
+		extractPoliciesRegex: regexp.MustCompile(extractPoliciesRegexTemplate),
+	}
+
+	logDir := t.TempDir()
+	logsDir := filepath.Join(logDir, "_logs")
+	require.NoError(t, os.MkdirAll(logsDir, 0755))
+	logContent := "0 verbose cli node npm\n" +
+		"46 silly placeDep ROOT pinned-blocked@ OK for: myproj@1.0.0 want: 9.9.9\n"
+	require.NoError(t, os.WriteFile(filepath.Join(logsDir, "2026-01-01T00_00_00_000Z-debug-0.log"), []byte(logContent), 0644))
+
+	projectDir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(projectDir, "package.json"), []byte(`{"name":"myproj","version":"1.0.0"}`), 0644))
+	orig := osGetwd
+	osGetwd = func() (string, error) { return projectDir, nil }
+	t.Cleanup(func() { osGetwd = orig })
+
+	results := map[string]*CurationReport{}
+	originalErr := errors.New("error while running 'npm install': exit status 1")
+
+	err := ca.runNpmLogFallback(logsDir, techutils.Npm, results, originalErr, false, 0)
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+
+	var report *CurationReport
+	for _, r := range results {
+		report = r
+	}
+	require.Len(t, report.packagesStatus, 1, "the confirmed-blocked ETARGET package must appear as a row")
+	assert.Equal(t, "pinned-blocked", report.packagesStatus[0].PackageName)
+	assert.Equal(t, "9.9.9", report.packagesStatus[0].PackageVersion)
+}
+
+// An advisory-only entry must not claim the shared dedup key and skip a same-name probeable entry.
+func TestRunNpmLogFallback_SeenKeysDoesNotSkipCrossCategoryEntry(t *testing.T) {
+	blockMsg := "Package widget:2.0.0 download was blocked by jfrog packages curation service due to the following policies violated " +
+		"{cve-high, CVE with CVSS score of 9 or above, Package version contains a vulnerability, Upgrade to a fixed version}."
+	blockJSON := fmt.Sprintf(`{"errors":[{"status":403,"message":%q}]}`, blockMsg)
+
+	var widgetTarballHits int
+	serverMock, serverDetails, _ := coreCommonTests.CreateRtRestsMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+		if strings.Contains(r.URL.Path, "/widget-2.0.0.tgz") {
+			widgetTarballHits++
+			w.WriteHeader(http.StatusForbidden)
+			_, _ = w.Write([]byte(blockJSON))
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	})
+	defer serverMock.Close()
+
+	repoConfig := (&project.RepositoryConfig{}).SetTargetRepo("my-npm-remote").SetServerDetails(serverDetails)
+	ca := &CurationAuditCommand{
+		PackageManagerConfig: repoConfig,
+		extractPoliciesRegex: regexp.MustCompile(extractPoliciesRegexTemplate),
+	}
+
+	logDir := t.TempDir()
+	logsDir := filepath.Join(logDir, "_logs")
+	require.NoError(t, os.MkdirAll(logsDir, 0755))
+	// "widget" appears twice: once via an unresolvable range (advisory-only, no probe),
+	// once via a bare, exact, genuinely blocked version (ETARGET, must be probed).
+	logContent := "0 verbose cli node npm\n" +
+		"44 silly placeDep ROOT dep-a@1.0.0 OK for: myproj@1.0.0 want: ^1.0.0\n" +
+		"45 silly placeDep ROOT dep-b@1.0.0 OK for: myproj@1.0.0 want: ^1.0.0\n" +
+		"46 silly placeDep node_modules/dep-a widget@ OK for: dep-a@1.0.0 want: ^1.0.0\n" +
+		"47 silly placeDep node_modules/dep-b widget@ OK for: dep-b@1.0.0 want: 2.0.0\n"
+	require.NoError(t, os.WriteFile(filepath.Join(logsDir, "2026-01-01T00_00_00_000Z-debug-0.log"), []byte(logContent), 0644))
+
+	projectDir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(projectDir, "package.json"), []byte(`{"name":"myproj","version":"1.0.0"}`), 0644))
+	orig := osGetwd
+	osGetwd = func() (string, error) { return projectDir, nil }
+	t.Cleanup(func() { osGetwd = orig })
+
+	results := map[string]*CurationReport{}
+	originalErr := errors.New("error while running 'npm install': exit status 1")
+
+	err := ca.runNpmLogFallback(logsDir, techutils.Npm, results, originalErr, false, 0)
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+
+	var report *CurationReport
+	for _, r := range results {
+		report = r
+	}
+	assert.Equal(t, 1, widgetTarballHits, "the ETARGET occurrence's own HTTP probe must run exactly once, not be skipped by the unresolvable-range occurrence's dedup entry")
+	require.NotEmpty(t, report.packagesStatus, "widget's confirmed block must surface as a row (once per parent edge that pulls it in)")
+	for _, ps := range report.packagesStatus {
+		assert.Equal(t, "widget", ps.PackageName)
+		assert.Equal(t, "2.0.0", ps.PackageVersion)
+	}
+}
+
+// Two ETARGET entries for the same name but different pinned specifiers must both surface, not collide.
+func TestRunNpmLogFallback_SameNameDifferentSpecifierETARGETEntriesDoNotCollide(t *testing.T) {
+	blockJSON := func(name, version string) string {
+		msg := fmt.Sprintf("Package %s:%s download was blocked by jfrog packages curation service due to the following policies violated "+
+			"{cve-high, CVE with CVSS score of 9 or above, Package version contains a vulnerability, Upgrade to a fixed version}.", name, version)
+		return fmt.Sprintf(`{"errors":[{"status":403,"message":%q}]}`, msg)
+	}
+
+	serverMock, serverDetails, _ := coreCommonTests.CreateRtRestsMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case strings.Contains(r.URL.Path, "/widget-2.0.0.tgz"):
+			w.WriteHeader(http.StatusForbidden)
+			_, _ = w.Write([]byte(blockJSON("widget", "2.0.0")))
+		case strings.Contains(r.URL.Path, "/widget-3.0.0.tgz"):
+			w.WriteHeader(http.StatusForbidden)
+			_, _ = w.Write([]byte(blockJSON("widget", "3.0.0")))
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	})
+	defer serverMock.Close()
+
+	repoConfig := (&project.RepositoryConfig{}).SetTargetRepo("my-npm-remote").SetServerDetails(serverDetails)
+	ca := &CurationAuditCommand{
+		PackageManagerConfig: repoConfig,
+		extractPoliciesRegex: regexp.MustCompile(extractPoliciesRegexTemplate),
+	}
+
+	logDir := t.TempDir()
+	logsDir := filepath.Join(logDir, "_logs")
+	require.NoError(t, os.MkdirAll(logsDir, 0755))
+	// "widget" pinned at two different blocked versions by two different parents.
+	logContent := "0 verbose cli node npm\n" +
+		"44 silly placeDep ROOT dep-a@1.0.0 OK for: myproj@1.0.0 want: ^1.0.0\n" +
+		"45 silly placeDep ROOT dep-b@1.0.0 OK for: myproj@1.0.0 want: ^1.0.0\n" +
+		"46 silly placeDep node_modules/dep-a widget@ OK for: dep-a@1.0.0 want: 2.0.0\n" +
+		"47 silly placeDep node_modules/dep-b widget@ OK for: dep-b@1.0.0 want: 3.0.0\n"
+	require.NoError(t, os.WriteFile(filepath.Join(logsDir, "2026-01-01T00_00_00_000Z-debug-0.log"), []byte(logContent), 0644))
+
+	projectDir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(projectDir, "package.json"), []byte(`{"name":"myproj","version":"1.0.0"}`), 0644))
+	orig := osGetwd
+	osGetwd = func() (string, error) { return projectDir, nil }
+	t.Cleanup(func() { osGetwd = orig })
+
+	results := map[string]*CurationReport{}
+	originalErr := errors.New("error while running 'npm install': exit status 1")
+
+	err := ca.runNpmLogFallback(logsDir, techutils.Npm, results, originalErr, false, 0)
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+
+	var report *CurationReport
+	for _, r := range results {
+		report = r
+	}
+	versionsSeen := map[string]bool{}
+	for _, ps := range report.packagesStatus {
+		assert.Equal(t, "widget", ps.PackageName)
+		versionsSeen[ps.PackageVersion] = true
+	}
+	assert.True(t, versionsSeen["2.0.0"], "dep-a's genuinely blocked 2.0.0 must appear, not be overwritten by 3.0.0")
+	assert.True(t, versionsSeen["3.0.0"], "dep-b's genuinely blocked 3.0.0 must appear, not be lost to the shared blank-version key")
+}
+
+// When package.json can't be read, the root identity must be recovered from the log itself.
+func TestRunNpmLogFallback_MissingPackageJsonStillRecoversReport(t *testing.T) {
+	serverMock, serverDetails, _ := coreCommonTests.CreateRtRestsMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+		t.Errorf("unexpected HEAD-check for a whole-package-blocked entry: %s", r.URL.Path)
+		w.WriteHeader(http.StatusInternalServerError)
+	})
+	defer serverMock.Close()
+
+	repoConfig := (&project.RepositoryConfig{}).SetTargetRepo("my-npm-remote").SetServerDetails(serverDetails)
+	ca := &CurationAuditCommand{
+		PackageManagerConfig: repoConfig,
+		extractPoliciesRegex: regexp.MustCompile(extractPoliciesRegexTemplate),
+	}
+
+	logDir := t.TempDir()
+	logsDir := filepath.Join(logDir, "_logs")
+	require.NoError(t, os.MkdirAll(logsDir, 0755))
+	// Root-level entry carries the real project identity ("realproj@9.9.9"); the working
+	// directory's basename below is deliberately something else.
+	logContent := "0 verbose cli node npm\n" +
+		"43 notice All versions blocked - {policy:blocks open ssf,condition:open ssf}\n" +
+		"44 http fetch GET 403 https://z0test.jfrogdev.org/artifactory/api/npm/my-npm-remote/blockedpkg 100ms (cache skip)\n" +
+		"45 silly placeDep ROOT blockedpkg@ OK for: realproj@9.9.9 want: ^1.0.0\n"
+	require.NoError(t, os.WriteFile(filepath.Join(logsDir, "2026-01-01T00_00_00_000Z-debug-0.log"), []byte(logContent), 0644))
+
+	// No package.json written — readNpmProjectNameVersion fails.
+	projectDir := filepath.Join(t.TempDir(), "unrelated-dir-name")
+	require.NoError(t, os.MkdirAll(projectDir, 0755))
+	orig := osGetwd
+	osGetwd = func() (string, error) { return projectDir, nil }
+	t.Cleanup(func() { osGetwd = orig })
+
+	results := map[string]*CurationReport{}
+	originalErr := errors.New("error while running 'npm install': exit status 1")
+
+	err := ca.runNpmLogFallback(logsDir, techutils.Npm, results, originalErr, false, 0)
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+
+	var report *CurationReport
+	for _, r := range results {
+		report = r
+	}
+	require.NotEmpty(t, report.packagesStatus, "blockedpkg must still surface as a row even when package.json can't be read")
+	assert.Equal(t, "blockedpkg", report.packagesStatus[0].PackageName)
+	assert.True(t, directDepNamesContains(report, "blockedpkg"), "blockedpkg is a direct dependency of the real (log-recovered) root, so its recommendation must say so, not treat it as transitive")
+}
+
+// directDepNamesContains checks pkgName's recommendation uses the direct, not transitive, wording.
+func directDepNamesContains(report *CurationReport, pkgName string) bool {
+	for _, ps := range report.packagesStatus {
+		if ps.PackageName != pkgName {
+			continue
+		}
+		for _, p := range ps.Policy {
+			if strings.Contains(p.Recommendation, "Remove this package from your project and replace with an alternate package") {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// A key-construction failure must not silently vanish the package from the report the same way
+// as ordinary dedup — it must surface as a warning, same as a probe failure.
+func TestRunNpmLogFallback_KeyErrSurfacesAsWarningNotSilentDrop(t *testing.T) {
+	serverMock, serverDetails, _ := coreCommonTests.CreateRtRestsMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	})
+	defer serverMock.Close()
+
+	repoConfig := (&project.RepositoryConfig{}).SetTargetRepo("my-npm-remote").SetServerDetails(serverDetails)
+	ca := &CurationAuditCommand{
+		PackageManagerConfig: repoConfig,
+		extractPoliciesRegex: regexp.MustCompile(extractPoliciesRegexTemplate),
+	}
+
+	logDir := t.TempDir()
+	logsDir := filepath.Join(logDir, "_logs")
+	require.NoError(t, os.MkdirAll(logsDir, 0755))
+	// "widget-abc123"@0.0.0 matches isYarnBerryWorkspaceMember's pattern (name ends in
+	// "-" + 6 hex chars, version "0.0.0"), so getNpmNameScopeAndVersion returns zero URLs
+	// and npmPackageKey genuinely fails to derive a key — a real trigger, not a mock.
+	logContent := "0 verbose cli node npm\n" +
+		"10 silly placeDep ROOT widget-abc123@0.0.0 OK for: myproj@1.0.0 want: ^0.0.0\n"
+	require.NoError(t, os.WriteFile(filepath.Join(logsDir, "2026-01-01T00_00_00_000Z-debug-0.log"), []byte(logContent), 0644))
+
+	projectDir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(projectDir, "package.json"), []byte(`{"name":"myproj","version":"1.0.0"}`), 0644))
+	orig := osGetwd
+	osGetwd = func() (string, error) { return projectDir, nil }
+	t.Cleanup(func() { osGetwd = orig })
+
+	results := map[string]*CurationReport{}
+	originalErr := errors.New("error while running 'npm install': exit status 1")
+
+	err := ca.runNpmLogFallback(logsDir, techutils.Npm, results, originalErr, false, 0)
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+
+	var report *CurationReport
+	for _, r := range results {
+		report = r
+	}
+	for _, ps := range report.packagesStatus {
+		assert.NotEqual(t, "widget-abc123", ps.PackageName, "a package whose key couldn't be derived must not be reported as confirmed clean or blocked")
+	}
+	require.NotEmpty(t, report.warnings, "a key-construction failure must surface as a warning, not vanish silently")
+	assert.Contains(t, strings.Join(report.warnings, "\n"), "widget-abc123")
+}
+
+// A probe failure (network/5xx) for a resolved entry must not be silently treated as "clean" — it must surface as a warning.
+func TestRunNpmLogFallback_ProbeErrorSurfacesAsWarningNotClean(t *testing.T) {
+	serverMock, serverDetails, _ := coreCommonTests.CreateRtRestsMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+		if strings.Contains(r.URL.Path, "/flaky-pkg-1.0.0.tgz") {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	})
+	defer serverMock.Close()
+
+	repoConfig := (&project.RepositoryConfig{}).SetTargetRepo("my-npm-remote").SetServerDetails(serverDetails)
+	ca := &CurationAuditCommand{
+		PackageManagerConfig: repoConfig,
+		extractPoliciesRegex: regexp.MustCompile(extractPoliciesRegexTemplate),
+	}
+
+	logDir := t.TempDir()
+	logsDir := filepath.Join(logDir, "_logs")
+	require.NoError(t, os.MkdirAll(logsDir, 0755))
+	logContent := "0 verbose cli node npm\n" +
+		"10 silly placeDep ROOT flaky-pkg@1.0.0 OK for: myproj@1.0.0 want: ^1.0.0\n"
+	require.NoError(t, os.WriteFile(filepath.Join(logsDir, "2026-01-01T00_00_00_000Z-debug-0.log"), []byte(logContent), 0644))
+
+	projectDir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(projectDir, "package.json"), []byte(`{"name":"myproj","version":"1.0.0"}`), 0644))
+	orig := osGetwd
+	osGetwd = func() (string, error) { return projectDir, nil }
+	t.Cleanup(func() { osGetwd = orig })
+
+	results := map[string]*CurationReport{}
+	originalErr := errors.New("error while running 'npm install': exit status 1")
+
+	err := ca.runNpmLogFallback(logsDir, techutils.Npm, results, originalErr, false, 0)
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+
+	var report *CurationReport
+	for _, r := range results {
+		report = r
+	}
+	for _, ps := range report.packagesStatus {
+		assert.NotEqual(t, "flaky-pkg", ps.PackageName, "a package whose probe failed must not be reported as confirmed clean or blocked")
+	}
+	require.NotEmpty(t, report.warnings, "a probe failure must surface as a warning, not vanish silently")
+	assert.Contains(t, strings.Join(report.warnings, "\n"), "flaky-pkg")
+}
+
+// A blocked name shared by a direct edge and a transitive edge must get the recommendation for each edge, not one shared answer.
+func TestRunNpmLogFallback_RecommendationIsPerEdgeNotPerName(t *testing.T) {
+	serverMock, serverDetails, _ := coreCommonTests.CreateRtRestsMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	})
+	defer serverMock.Close()
+
+	repoConfig := (&project.RepositoryConfig{}).SetTargetRepo("my-npm-remote").SetServerDetails(serverDetails)
+	ca := &CurationAuditCommand{
+		PackageManagerConfig: repoConfig,
+		extractPoliciesRegex: regexp.MustCompile(extractPoliciesRegexTemplate),
+	}
+
+	logDir := t.TempDir()
+	logsDir := filepath.Join(logDir, "_logs")
+	require.NoError(t, os.MkdirAll(logsDir, 0755))
+	// "blocked-name" is both a direct dep of myproj and a transitive dep of "otherdirect".
+	logContent := "0 verbose cli node npm\n" +
+		"10 silly placeDep ROOT blocked-name@ OK for: myproj@1.0.0 want: ^1.0.0\n" +
+		"11 silly placeDep ROOT otherdirect@1.0.0 OK for: myproj@1.0.0 want: ^1.0.0\n" +
+		"12 silly placeDep node_modules/otherdirect blocked-name@ OK for: otherdirect@1.0.0 want: ^2.0.0\n" +
+		"40 notice All versions blocked - {policy:blocks open ssf,condition:open ssf}\n" +
+		"41 http fetch GET 403 https://z0test.jfrogdev.org/artifactory/api/npm/my-npm-remote/blocked-name 50ms (cache skip)\n"
+	require.NoError(t, os.WriteFile(filepath.Join(logsDir, "2026-01-01T00_00_00_000Z-debug-0.log"), []byte(logContent), 0644))
+
+	projectDir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(projectDir, "package.json"), []byte(`{"name":"myproj","version":"1.0.0"}`), 0644))
+	orig := osGetwd
+	osGetwd = func() (string, error) { return projectDir, nil }
+	t.Cleanup(func() { osGetwd = orig })
+
+	results := map[string]*CurationReport{}
+	originalErr := errors.New("error while running 'npm install': exit status 1")
+
+	err := ca.runNpmLogFallback(logsDir, techutils.Npm, results, originalErr, false, 0)
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+
+	var report *CurationReport
+	for _, r := range results {
+		report = r
+	}
+	var directRow, transitiveRow *PackageStatus
+	for _, ps := range report.packagesStatus {
+		if ps.PackageName != "blocked-name" {
+			continue
+		}
+		switch {
+		case ps.DepRelation == directRelation:
+			directRow = ps
+		case ps.DepRelation == indirectRelation && ps.ParentName == "otherdirect":
+			transitiveRow = ps
+		}
+	}
+	require.NotNil(t, directRow, "blocked-name must appear as a direct edge")
+	require.NotNil(t, transitiveRow, "blocked-name must appear as a transitive edge under otherdirect")
+
+	require.Len(t, directRow.Policy, 1)
+	assert.Equal(t, "Remove this package from your project and replace with an alternate package", directRow.Policy[0].Recommendation)
+
+	require.Len(t, transitiveRow.Policy, 1)
+	assert.Contains(t, transitiveRow.Policy[0].Recommendation, "transitive dependency of otherdirect",
+		"the transitive edge must not get the direct-removal recommendation just because the same name is also a direct dependency elsewhere")
+}
+
+// The ETARGET probe path has the same probe-error-swallowing bug the npmEntryResolved case
+// had (Fix #1) — a transient probe failure must surface as a warning, and must not make the
+// whole report vanish (return originalErr) when it's the only recoverable entry.
+func TestRunNpmLogFallback_ETARGETProbeErrorSurfacesAsWarningNotDiscarded(t *testing.T) {
+	serverMock, serverDetails, _ := coreCommonTests.CreateRtRestsMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	})
+	defer serverMock.Close()
+
+	repoConfig := (&project.RepositoryConfig{}).SetTargetRepo("my-npm-remote").SetServerDetails(serverDetails)
+	ca := &CurationAuditCommand{
+		PackageManagerConfig: repoConfig,
+		extractPoliciesRegex: regexp.MustCompile(extractPoliciesRegexTemplate),
+	}
+
+	logDir := t.TempDir()
+	logsDir := filepath.Join(logDir, "_logs")
+	require.NoError(t, os.MkdirAll(logsDir, 0755))
+	logContent := "0 verbose cli node npm\n" +
+		"10 silly placeDep ROOT flaky-etarget@ OK for: myproj@1.0.0 want: 9.9.9\n"
+	require.NoError(t, os.WriteFile(filepath.Join(logsDir, "2026-01-01T00_00_00_000Z-debug-0.log"), []byte(logContent), 0644))
+
+	projectDir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(projectDir, "package.json"), []byte(`{"name":"myproj","version":"1.0.0"}`), 0644))
+	orig := osGetwd
+	osGetwd = func() (string, error) { return projectDir, nil }
+	t.Cleanup(func() { osGetwd = orig })
+
+	results := map[string]*CurationReport{}
+	originalErr := errors.New("error while running 'npm install': exit status 1")
+
+	err := ca.runNpmLogFallback(logsDir, techutils.Npm, results, originalErr, false, 0)
+	require.NoError(t, err, "a probe failure must not make the whole recovered report vanish")
+	require.Len(t, results, 1)
+
+	var report *CurationReport
+	for _, r := range results {
+		report = r
+	}
+	require.NotEmpty(t, report.warnings, "a probe failure must surface as a warning, not vanish silently")
+	assert.Contains(t, strings.Join(report.warnings, "\n"), "flaky-etarget")
+}
+
+// If the log has no placeDep lines at all, the original error is returned unchanged.
+func TestRunNpmLogFallback_NoRecoverableEntries(t *testing.T) {
+	ca := &CurationAuditCommand{
+		PackageManagerConfig: (&project.RepositoryConfig{}).SetTargetRepo("repo"),
+		extractPoliciesRegex: regexp.MustCompile(extractPoliciesRegexTemplate),
+	}
+	results := map[string]*CurationReport{}
+	originalErr := errors.New("npm install failed before any resolution")
+
+	err := ca.runNpmLogFallback(t.TempDir(), techutils.Npm, results, originalErr, false, 0)
+	assert.Equal(t, originalErr, err)
+	assert.Empty(t, results)
+}
+
+// A stale log left over from an earlier, unrelated run (e.g. a shared CI cache) must never be
+// mistaken for this crash's own log — if npm never wrote a NEW log for this invocation (e.g. it
+// failed before writing anything at all, missing binary, bad package.json), the fallback must
+// return originalErr unchanged rather than fabricate a report from someone else's old log.
+func TestRunNpmLogFallback_StaleLogPredatingBaselineIsIgnored(t *testing.T) {
+	logsDir := t.TempDir()
+	staleLogContent := "0 verbose cli node npm\n" +
+		"10 silly placeDep ROOT stale-pkg@1.0.0 OK for: otherproj@1.0.0 want: ^1.0.0\n"
+	staleLogPath := filepath.Join(logsDir, "2026-01-01T00_00_00_000Z-debug-0.log")
+	require.NoError(t, os.WriteFile(staleLogPath, []byte(staleLogContent), 0644))
+
+	// The baseline is captured AFTER the stale log already exists — exactly like the real
+	// eager-lookup snapshot taken right before an install that then fails without logging.
+	baselineKey, err := npmDebugLogNewestKey(logsDir)
+	require.NoError(t, err)
+	require.NotZero(t, baselineKey)
+
+	ca := &CurationAuditCommand{
+		PackageManagerConfig: (&project.RepositoryConfig{}).SetTargetRepo("repo"),
+		extractPoliciesRegex: regexp.MustCompile(extractPoliciesRegexTemplate),
+	}
+	results := map[string]*CurationReport{}
+	originalErr := errors.New("npm: command not found")
+
+	gotErr := ca.runNpmLogFallback(logsDir, techutils.Npm, results, originalErr, false, baselineKey)
+	assert.Equal(t, originalErr, gotErr, "no log newer than the baseline exists, so the original error must pass through unchanged")
+	assert.Empty(t, results, "must not fabricate a report from a stale pre-existing log")
+
+	// The stale log itself must survive untouched — it's not ours to touch.
+	_, statErr := os.Stat(staleLogPath)
+	assert.NoError(t, statErr)
+}
+
+// When logs-max was 0, only the specific log file read is removed — not the whole directory.
+func TestRunNpmLogFallback_CleansUpLogWhenLogsMaxWasZero(t *testing.T) {
+	cacheDir := t.TempDir()
+	logsDir := filepath.Join(cacheDir, "_logs")
+	require.NoError(t, os.MkdirAll(logsDir, 0755))
+	logPath := filepath.Join(logsDir, "2026-01-01T00_00_00_000Z-debug-0.log")
+	require.NoError(t, os.WriteFile(logPath, []byte("0 verbose cli npm\n"), 0644))
+	otherPath := filepath.Join(logsDir, "unrelated-file.txt")
+	require.NoError(t, os.WriteFile(otherPath, []byte("leave me alone\n"), 0644))
+
+	ca := &CurationAuditCommand{
+		PackageManagerConfig: (&project.RepositoryConfig{}).SetTargetRepo("repo"),
+		extractPoliciesRegex: regexp.MustCompile(extractPoliciesRegexTemplate),
+	}
+	results := map[string]*CurationReport{}
+	originalErr := errors.New("npm install failed before any resolution")
+
+	// No placeDep lines in this fixture, so this hits the "nothing recoverable" early
+	// return — cleanup must still fire on that path, not only on a fully successful one.
+	err := ca.runNpmLogFallback(logsDir, techutils.Npm, results, originalErr, true, 0)
+	assert.Equal(t, originalErr, err)
+
+	_, statErr := os.Stat(logPath)
+	assert.True(t, os.IsNotExist(statErr), "the log file itself should have been removed")
+	_, otherStatErr := os.Stat(otherPath)
+	assert.NoError(t, otherStatErr, "an unrelated file in the same directory must not be touched")
+}
+
+// The install-succeeded path forces the same --logs-max=10 override as the failure path, so it
+// must clean up the resulting debug log the same way when the user had configured logs-max=0.
+func TestCleanupForcedNpmDebugLog_RemovesLogWhenLogsMaxWasZero(t *testing.T) {
+	cacheDir := t.TempDir()
+	logsDir := filepath.Join(cacheDir, "_logs")
+	require.NoError(t, os.MkdirAll(logsDir, 0755))
+	logPath := filepath.Join(logsDir, "2026-01-01T00_00_00_000Z-debug-0.log")
+	require.NoError(t, os.WriteFile(logPath, []byte("0 verbose cli npm\n"), 0644))
+
+	cleanupForcedNpmDebugLog(logsDir, true, 0)
+
+	_, statErr := os.Stat(logPath)
+	assert.True(t, os.IsNotExist(statErr), "the forced debug log must be removed when logs-max was actually 0")
+}
+
+// When the user hadn't set logs-max=0 themselves, npm's own rotation already manages the log —
+// nothing forced it into existence, so nothing should be removed here.
+func TestCleanupForcedNpmDebugLog_LeavesLogWhenLogsMaxWasNotZero(t *testing.T) {
+	cacheDir := t.TempDir()
+	logsDir := filepath.Join(cacheDir, "_logs")
+	require.NoError(t, os.MkdirAll(logsDir, 0755))
+	logPath := filepath.Join(logsDir, "2026-01-01T00_00_00_000Z-debug-0.log")
+	require.NoError(t, os.WriteFile(logPath, []byte("0 verbose cli npm\n"), 0644))
+
+	cleanupForcedNpmDebugLog(logsDir, false, 0)
+
+	_, statErr := os.Stat(logPath)
+	assert.NoError(t, statErr, "must not remove a log npm would have written anyway")
+}
+
+// A transient npm-config-lookup failure must not abort an install that would've succeeded.
+func TestDoCurationAudit_NpmConfigLookupFailureDoesNotAbortSuccessfulInstall(t *testing.T) {
+	var fixture testCase
+	for _, tt := range getTestCasesForDoCurationAudit() {
+		if tt.name == "npm tree - two blocked package " {
+			fixture = tt
+			break
+		}
+	}
+	require.NotEmpty(t, fixture.name, "expected fixture not found")
+
+	basePathToTests, err := filepath.Abs(TestDataDir)
+	require.NoError(t, err)
+	cleanUpFlags := setCurationFlagsForTest(t)
+	defer cleanUpFlags()
+
+	runFixture := func(t *testing.T) (map[string]*CurationReport, error) {
+		mockServer, config := curationServer(t, fixture.expectedBuildRequest, fixture.expectedRequest, fixture.requestToFail, fixture.requestToError, fixture.serveResources)
+		defer mockServer.Close()
+		cleanUp := createCurationTestEnv(t, basePathToTests, fixture, config)
+		defer cleanUp()
+		return createCurationCmdAndRun(fixture)
+	}
+
+	t.Run("baseline_succeeds_unmodified", func(t *testing.T) {
+		t.Setenv("NPM_CONFIG_CACHE", t.TempDir())
+		results, err := runFixture(t)
+		require.NoError(t, err)
+		assert.NotEmpty(t, results)
+	})
+
+	t.Run("forced_config_lookup_failure_must_not_abort", func(t *testing.T) {
+		t.Setenv("NPM_CONFIG_CACHE", t.TempDir())
+		orig := npmGetConfigValue
+		npmGetConfigValue = func(string, string) (string, error) {
+			return "", errors.New("simulated: npm config get failed")
+		}
+		t.Cleanup(func() { npmGetConfigValue = orig })
+
+		results, err := runFixture(t)
+		assert.NoError(t, err, "a transient npm-config-lookup failure must not abort an audit whose install would otherwise have succeeded")
+		assert.NotEmpty(t, results, "the real, successful install result must still be reported")
+	})
+
+	// End-to-end with real ambient npm config (NPM_CONFIG_CACHE/LOGS_MAX), not just the Go-level mock.
+	t.Run("logs_max_zero_leaves_no_stray_log_after_real_success", func(t *testing.T) {
+		isolatedCache := t.TempDir()
+		t.Setenv("NPM_CONFIG_CACHE", isolatedCache)
+		t.Setenv("NPM_CONFIG_LOGS_MAX", "0")
+
+		results, err := runFixture(t)
+		require.NoError(t, err)
+		require.NotEmpty(t, results)
+
+		entries, readErr := os.ReadDir(filepath.Join(isolatedCache, "_logs"))
+		if readErr != nil {
+			require.True(t, os.IsNotExist(readErr), "unexpected error reading _logs dir: %v", readErr)
+			return
+		}
+		names := make([]string, len(entries))
+		for i, e := range entries {
+			names[i] = e.Name()
+		}
+		assert.Empty(t, names, "no stray debug log should remain in a fresh, isolated cache after a successful install when logs-max was 0")
+	})
+
+	// A user's own, already-nonzero logs-max retention setting must never be forced down —
+	// only logs-max=0 (which would suppress npm's debug log entirely) justifies an override.
+	t.Run("nonzero_logs_max_is_never_overridden", func(t *testing.T) {
+		isolatedCache := t.TempDir()
+		logsDir := filepath.Join(isolatedCache, "_logs")
+		require.NoError(t, os.MkdirAll(logsDir, 0755))
+		// Seed more pre-existing logs than the old forced value (10) ever allowed, in npm's
+		// real filename shape, so npm's own rotation would recognize and count them.
+		for i := 0; i < 20; i++ {
+			name := fmt.Sprintf("2025-01-01T00_00_%02d_000Z-debug-0.log", i)
+			require.NoError(t, os.WriteFile(filepath.Join(logsDir, name), []byte("0 verbose cli npm\n"), 0644))
+		}
+
+		t.Setenv("NPM_CONFIG_CACHE", isolatedCache)
+		t.Setenv("NPM_CONFIG_LOGS_MAX", "50")
+
+		results, err := runFixture(t)
+		require.NoError(t, err)
+		require.NotEmpty(t, results)
+
+		entries, readErr := os.ReadDir(logsDir)
+		require.NoError(t, readErr)
+		assert.GreaterOrEqual(t, len(entries), 20,
+			"a user's own logs-max=50 must not be overridden/pruned by a smaller forced value")
+	})
+
+	// An independently-configured logs-dir (not <cache>/_logs, npm's own default) must still be
+	// found — assuming the default would silently defeat the whole fallback for anyone who sets it.
+	t.Run("independent_logs_dir_is_respected_not_assumed_from_cache", func(t *testing.T) {
+		isolatedCache := t.TempDir()
+		isolatedLogsDir := t.TempDir()
+		t.Setenv("NPM_CONFIG_CACHE", isolatedCache)
+		t.Setenv("NPM_CONFIG_LOGS_DIR", isolatedLogsDir)
+		t.Setenv("NPM_CONFIG_LOGS_MAX", "0")
+
+		results, err := runFixture(t)
+		require.NoError(t, err)
+		require.NotEmpty(t, results)
+
+		// The forced-then-cleaned log must have gone to the configured logs-dir, not <cache>/_logs.
+		_, cacheLogsErr := os.ReadDir(filepath.Join(isolatedCache, "_logs"))
+		assert.True(t, os.IsNotExist(cacheLogsErr), "no log should ever land under <cache>/_logs when logs-dir is set independently")
+
+		entries, readErr := os.ReadDir(isolatedLogsDir)
+		require.NoError(t, readErr)
+		assert.Empty(t, entries, "the log written to the independently-configured logs-dir must still be cleaned up when logs-max was 0")
+	})
+}
+
+// A never-contacted dependency must not report the same BlockingReason/Action as a real block.
+// The console warning must not embed npm's own error text (which can include its full
+// captured stdout/stderr) — that goes to log.Debug only, so the console stays a clean one-liner.
+func TestNpmLogPartialReportWarning_DoesNotEmbedRawNpmOutput(t *testing.T) {
+	assert.NotContains(t, npmLogPartialReportWarning, "%s",
+		"must be a fixed string, not a template that could embed npm's raw (potentially huge) error output")
+}
+
+// The "Found N blocked packages" count must not count non-registry "not evaluated" rows as blocked.
+func TestCountBlockedPackages_ExcludesNotEvaluatedRows(t *testing.T) {
+	rows := []*PackageStatus{
+		{PackageName: "real-block", Action: blocked},
+		{PackageName: "is-thirteen", Action: notEvaluated},
+		{PackageName: "another-block", Action: blocked},
+	}
+	assert.Equal(t, 2, countBlockedPackages(rows))
+}
+
+// A not-evaluated row's placeholder Policy{"—","—"} must not leak into the Blocked list.
+func TestGetBlocked_ExcludesNotEvaluatedRows(t *testing.T) {
+	rows := []*PackageStatus{
+		{PackageName: "real-block", PackageVersion: "1.0.0", Action: blocked,
+			Policy: []Policy{{Policy: "cve-high", Condition: "cond1"}}},
+		{PackageName: "git-dep", PackageVersion: "github:foo/bar (not evaluated)", Action: notEvaluated,
+			Policy: []Policy{{Policy: "—", Condition: "—"}}},
+	}
+	blockedList := getBlocked(rows)
+	require.Len(t, blockedList, 1)
+	assert.Equal(t, "cve-high", blockedList[0].Policy)
+	for _, bp := range blockedList {
+		assert.NotContains(t, bp.Packages, getPackageId("git-dep", "github:foo/bar (not evaluated)"))
+	}
+}
+
+// Cleanup must still fire when parsing itself fails partway through (e.g. an oversized line).
+func TestRunNpmLogFallback_CleansUpLogEvenOnScanError(t *testing.T) {
+	cacheDir := t.TempDir()
+	logsDir := filepath.Join(cacheDir, "_logs")
+	require.NoError(t, os.MkdirAll(logsDir, 0755))
+	logPath := filepath.Join(logsDir, "2026-01-01T00_00_00_000Z-debug-0.log")
+	oversizedLine := strings.Repeat("a", 9*1024*1024) // exceeds scanner.Buffer's 8MB max token size
+	require.NoError(t, os.WriteFile(logPath, []byte(oversizedLine+"\n"), 0644))
+
+	ca := &CurationAuditCommand{
+		PackageManagerConfig: (&project.RepositoryConfig{}).SetTargetRepo("repo"),
+		extractPoliciesRegex: regexp.MustCompile(extractPoliciesRegexTemplate),
+	}
+	results := map[string]*CurationReport{}
+	originalErr := errors.New("npm install failed before any resolution")
+
+	err := ca.runNpmLogFallback(logsDir, techutils.Npm, results, originalErr, true, 0)
+	assert.Equal(t, originalErr, err)
+
+	_, statErr := os.Stat(logPath)
+	assert.True(t, os.IsNotExist(statErr), "the log file should be removed even though parsing hit a scan error, since logsMaxWasZero means it only exists because of our own --logs-max override")
 }
 
 // TestUniqueReportKey covers the disambiguation loop, including a 3-way collision where both

--- a/commands/curation/npmlogparser.go
+++ b/commands/curation/npmlogparser.go
@@ -1,0 +1,440 @@
+package curation
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/jfrog/jfrog-cli-security/utils/techutils"
+	"github.com/jfrog/jfrog-cli-security/utils/xray"
+	"github.com/jfrog/jfrog-client-go/utils/errorutils"
+	xrayUtils "github.com/jfrog/jfrog-client-go/xray/services/utils"
+)
+
+// One reconstructed `silly placeDep` line:
+//
+//	<n> silly placeDep <Location> <Name>@<Version> OK for: <ParentName>@<ParentVersion> want: <Specifier>
+//
+// Version is blank when Arborist never resolved it — see classifyBlankVersionEntry.
+type npmLogEntry struct {
+	Location      string
+	Name          string
+	Version       string
+	ParentName    string
+	ParentVersion string
+	Specifier     string
+}
+
+// npmEntryCategory classifies a blank-version npmLogEntry — see classifyBlankVersionEntry.
+type npmEntryCategory int
+
+const (
+	// Concrete version in the log — standard per-package HEAD-check, same as the normal flow.
+	npmEntryResolved npmEntryCategory = iota
+	// Packument fetch itself 403'd (all versions blocked) — no HEAD-check needed or possible.
+	npmEntryWholePackageBlocked
+	// Non-registry specifier (git URL/shorthand, local file/link/workspace/patch, npm alias) — never probed.
+	npmEntryNonRegistrySpecifier
+	// Range/wildcard/dist-tag with no concrete version — never probed, since guessing one would be
+	// misleading rather than just incomplete. Advisory only.
+	npmEntryUnresolvableRange
+	// Genuine "no matching version" for an already-bare, exact version — still probed to rule out a block.
+	npmEntryETARGET
+)
+
+// npmBlockedInfo carries the policy/condition parsed from a whole-package-block notice line.
+type npmBlockedInfo struct {
+	Policy    string
+	Condition string
+}
+
+var (
+	// Matches: 42 notice All versions blocked - {policy:X,condition:Y}
+	npmNoticeBlockedRegex = regexp.MustCompile(`^\d+\s+notice\s+All versions blocked - \{policy:([^,]+),condition:([^}]+)\}`)
+	// Matches: 43 http fetch GET 403 https://.../api/npm/<repo>/<name> ... — excludes tarball fetches (path has /-/).
+	npmFetch403Regex = regexp.MustCompile(`^\d+\s+http fetch GET 403\s+\S*/api/npm/[^/\s]+/((?:@[^/\s]+/)?[^/\s]+)\s`)
+	// Matches: 110 silly placeDep ROOT accepts@2.0.0 OK for: express@5.2.1 want: ^2.0.0
+	// want is `.+?` since OR-ranges ("1.0.0 || 2.0.0") and hyphen-ranges contain spaces.
+	npmPlaceDepRegex = regexp.MustCompile(
+		`^\d+\s+silly\s+placeDep\s+(\S+)\s+((?:@[^@\s]+/)?[^@\s]+)@(\S*)\s+OK for:\s+((?:@[^@\s]+/)?[^@\s]+)@(\S+)\s+want:\s+(.+?)\s*$`)
+)
+
+// parseNpmDebugLog reads every chunk of the newest npm run under logsDir newer than afterKey
+// (see findNewestNpmDebugLogChunksAfter) as one continuous stream. Returns the chunk paths
+// read too, so the caller can decide whether to remove them.
+func parseNpmDebugLog(logsDir string, afterKey int64) (entries []npmLogEntry, blockedPackages map[string]npmBlockedInfo, logFilePaths []string, err error) {
+	logFilePaths, err = findNewestNpmDebugLogChunksAfter(logsDir, afterKey)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	if len(logFilePaths) == 0 {
+		return nil, nil, nil, nil
+	}
+
+	blockedPackages = map[string]npmBlockedInfo{}
+	// FIFO queue, not a single value: concurrent fetches can leave multiple notices pending at
+	// once. Notices and their matching 403 lines come from separate emit paths (a
+	// response-header handler vs. a request-completion logger), so same-relative-order isn't
+	// provable under concurrency — see pendingNotice.ambiguous for how that's handled.
+	var pendingNotices []pendingNotice
+	for _, logFile := range logFilePaths {
+		entries, pendingNotices, err = scanNpmDebugLogChunk(logFile, entries, blockedPackages, pendingNotices)
+		if err != nil {
+			return nil, nil, logFilePaths, err
+		}
+	}
+	return entries, blockedPackages, logFilePaths, nil
+}
+
+// npmUnknownBlockedInfo replaces a guessed policy/condition when the notice→403 FIFO pairing
+// is ambiguous — a wrong guess is worse than an honest "unknown".
+var npmUnknownBlockedInfo = npmBlockedInfo{Policy: "unknown", Condition: "unknown"}
+
+// pendingNotice is a queued "notice" awaiting its matching 403. ambiguous is set once it has
+// ever overlapped with another unresolved notice, since FIFO order can no longer be trusted
+// from that point on — it then degrades to npmUnknownBlockedInfo when matched.
+type pendingNotice struct {
+	info      npmBlockedInfo
+	ambiguous bool
+}
+
+// scanNpmDebugLogChunk scans one chunk file; pendingNotices threads through since chunks of one run are a continuous stream.
+func scanNpmDebugLogChunk(logFile string, entries []npmLogEntry, blockedPackages map[string]npmBlockedInfo, pendingNotices []pendingNotice) ([]npmLogEntry, []pendingNotice, error) {
+	f, err := os.Open(logFile)
+	if err != nil {
+		return entries, pendingNotices, errorutils.CheckErrorf("failed to open npm debug log %q: %v", logFile, err)
+	}
+	defer func() {
+		_ = f.Close()
+	}()
+
+	scanner := bufio.NewScanner(f)
+	// Some policy-violation lines are long; grow past bufio's 64KB default to avoid truncation.
+	buf := make([]byte, 0, 64*1024)
+	scanner.Buffer(buf, 8*1024*1024)
+	for scanner.Scan() {
+		line := scanner.Text()
+
+		if m := npmNoticeBlockedRegex.FindStringSubmatch(line); m != nil {
+			next := pendingNotice{info: npmBlockedInfo{Policy: strings.TrimSpace(m[1]), Condition: strings.TrimSpace(m[2])}}
+			if len(pendingNotices) > 0 {
+				// A prior notice is still unresolved — both it and this one become ambiguous,
+				// since same-relative-order with their eventual 403s is no longer provable.
+				next.ambiguous = true
+				for i := range pendingNotices {
+					pendingNotices[i].ambiguous = true
+				}
+			}
+			pendingNotices = append(pendingNotices, next)
+			continue
+		}
+		if len(pendingNotices) > 0 {
+			if m := npmFetch403Regex.FindStringSubmatch(line); m != nil {
+				// npm-package-arg percent-encodes the scope separator in this URL (@scope/name
+				// -> @scope%2fname), unlike placeDep's literal "/" form — decode so the two agree.
+				name := m[1]
+				if decoded, decodeErr := url.PathUnescape(name); decodeErr == nil {
+					name = decoded
+				}
+				popped := pendingNotices[0]
+				info := popped.info
+				if popped.ambiguous {
+					info = npmUnknownBlockedInfo
+				}
+				blockedPackages[name] = info
+				pendingNotices = pendingNotices[1:]
+			}
+			// Fall through on a non-match too — this line may also be a placeDep line.
+		}
+
+		if m := npmPlaceDepRegex.FindStringSubmatch(line); m != nil {
+			entries = append(entries, npmLogEntry{
+				Location:      m[1],
+				Name:          m[2],
+				Version:       m[3],
+				ParentName:    m[4],
+				ParentVersion: m[5],
+				Specifier:     m[6],
+			})
+		}
+	}
+	if scanErr := scanner.Err(); scanErr != nil {
+		return entries, pendingNotices, errorutils.CheckErrorf("failed to scan npm debug log %q: %v", logFile, scanErr)
+	}
+	return entries, pendingNotices, nil
+}
+
+// npmDebugLogChunkRegex matches npm's debug-log filenames, e.g. "2026-01-01T00_00_00_000Z-debug-0.log".
+// The trailing digit is the chunk index — npm splits one run past 50,000 log lines, same timestamp.
+var npmDebugLogChunkRegex = regexp.MustCompile(`^(\d{4}-\d{2}-\d{2}T\d{2}_\d{2}_\d{2}_\d{3}Z)-debug-(\d+)\.log$`)
+
+// npmDebugLogFilenameTimeLayout is the captured group above with "_" restored to ":" and ".".
+const npmDebugLogFilenameTimeLayout = "2006-01-02T15:04:05.000Z"
+
+// npmDebugLogChunkInfo parses the embedded run timestamp (nanoseconds since epoch, for ranking
+// runs) and the chunk index (for ordering multiple files of the same run) from a filename.
+func npmDebugLogChunkInfo(name string) (timestamp int64, chunk int, ok bool) {
+	m := npmDebugLogChunkRegex.FindStringSubmatch(name)
+	if m == nil {
+		return 0, 0, false
+	}
+	raw := m[1]
+	standard := raw[:13] + ":" + raw[14:16] + ":" + raw[17:19] + "." + raw[20:]
+	t, err := time.Parse(npmDebugLogFilenameTimeLayout, standard)
+	if err != nil {
+		return 0, 0, false
+	}
+	chunkNum, err := strconv.Atoi(m[2])
+	if err != nil {
+		return 0, 0, false
+	}
+	return t.UnixNano(), chunkNum, true
+}
+
+// newestNpmDebugLogGroup scans logsDir and returns the most recent run's timestamp key and its
+// chunk file paths in ascending chunk order (0 key, nil paths if none exist). Groups by embedded
+// timestamp (falls back to ModTime(), its own single-chunk group, since ModTime() alone can tie).
+func newestNpmDebugLogGroup(logsDir string) (int64, []string, error) {
+	dirEntries, err := os.ReadDir(logsDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return 0, nil, nil
+		}
+		return 0, nil, errorutils.CheckErrorf("failed to read npm debug log directory %q: %v", logsDir, err)
+	}
+
+	type chunkFile struct {
+		name  string
+		chunk int
+	}
+	groups := map[int64][]chunkFile{}
+	var newestKey int64
+	haveAny := false
+	for _, de := range dirEntries {
+		if de.IsDir() || !strings.HasSuffix(de.Name(), ".log") {
+			continue
+		}
+		key, chunk, ok := npmDebugLogChunkInfo(de.Name())
+		if !ok {
+			info, infoErr := de.Info()
+			if infoErr != nil {
+				continue
+			}
+			key = info.ModTime().UnixNano()
+			chunk = 0
+		}
+		groups[key] = append(groups[key], chunkFile{name: de.Name(), chunk: chunk})
+		if !haveAny || key > newestKey {
+			newestKey = key
+			haveAny = true
+		}
+	}
+	if !haveAny {
+		return 0, nil, nil
+	}
+	newestGroup := groups[newestKey]
+	sort.Slice(newestGroup, func(i, j int) bool { return newestGroup[i].chunk < newestGroup[j].chunk })
+	paths := make([]string, len(newestGroup))
+	for i, c := range newestGroup {
+		paths[i] = filepath.Join(logsDir, c.name)
+	}
+	return newestKey, paths, nil
+}
+
+// npmDebugLogNewestKey returns logsDir's current newest run's timestamp key (0 if none exist
+// yet) — a pre-install baseline so the fallback can later tell a genuinely new log from a stale one.
+func npmDebugLogNewestKey(logsDir string) (int64, error) {
+	key, _, err := newestNpmDebugLogGroup(logsDir)
+	return key, err
+}
+
+// findNewestNpmDebugLogChunksAfter returns the newest run's chunk files, in order — but only
+// if newer than afterKey. Returns nil otherwise (nothing exists, or it predates afterKey).
+func findNewestNpmDebugLogChunksAfter(logsDir string, afterKey int64) ([]string, error) {
+	key, paths, err := newestNpmDebugLogGroup(logsDir)
+	if err != nil || key <= afterKey {
+		return nil, err
+	}
+	return paths, nil
+}
+
+// classifyBlankVersionEntry categorizes an npmLogEntry whose Version is blank (non-blank is
+// always npmEntryResolved). A range/wildcard/dist-tag is never treated as probeable even after
+// stripping its operator (e.g. "^2.0.0" -> "2.0.0") — that stripped value is a guess at what npm
+// might have installed, not the real answer, so it'd be misleading rather than just incomplete.
+func classifyBlankVersionEntry(entry npmLogEntry, blockedPackages map[string]npmBlockedInfo) npmEntryCategory {
+	if entry.Version != "" {
+		return npmEntryResolved
+	}
+	if _, blocked := blockedPackages[entry.Name]; blocked {
+		return npmEntryWholePackageBlocked
+	}
+	resolvedVer, probeable, rangeOrTag := classifyNpmSpecifier(entry.Specifier)
+	switch {
+	case !probeable && !rangeOrTag:
+		return npmEntryNonRegistrySpecifier
+	case !probeable && rangeOrTag:
+		return npmEntryUnresolvableRange
+	case entry.Specifier != resolvedVer:
+		return npmEntryUnresolvableRange
+	default:
+		return npmEntryETARGET
+	}
+}
+
+// effectiveGraphVersion falls back to entry.Specifier for ETARGET/non-registry rows, since those vary by specifier even with a blank Version.
+func effectiveGraphVersion(entry npmLogEntry, blockedPackages map[string]npmBlockedInfo) string {
+	if entry.Version != "" {
+		return entry.Version
+	}
+	switch classifyBlankVersionEntry(entry, blockedPackages) {
+	case npmEntryETARGET, npmEntryNonRegistrySpecifier:
+		return entry.Specifier
+	default:
+		return entry.Version
+	}
+}
+
+// npmConcreteVersionRegex matches a single concrete semver, optional pre-release/build metadata.
+var npmConcreteVersionRegex = regexp.MustCompile(`^\d+\.\d+\.\d+([-+][0-9A-Za-z.\-]+)*$`)
+
+// classifyNpmSpecifier inspects a package.json version specifier: probeable=true means it
+// resolves to a single concrete semver after stripping range operators; rangeOrTag=true means
+// a range/wildcard/dist-tag; both false means a non-registry protocol (file:, link:, workspace:,
+// patch:, portal:, git+, git:, http(s):, npm:) or git host shorthand (github:, gitlab:,
+// bitbucket:, gist:).
+//
+// Deliberate self-contained copy of yarn.go's classifyNpmVersionSpec (PR #759/XRAY-138688) —
+// kept scoped to npm only so this doesn't touch yarn's code. The two have since diverged
+// (npm handles extra git-host prefixes yarn doesn't); unifying them is unrequested cleanup.
+func classifyNpmSpecifier(spec string) (resolvedVer string, probeable, rangeOrTag bool) {
+	s := strings.TrimSpace(spec)
+	if s == "" {
+		return "", false, false
+	}
+	lc := strings.ToLower(s)
+	for _, p := range []string{
+		"file:", "link:", "workspace:", "patch:", "portal:", "git+", "git:", "http://", "https://", "npm:",
+		"github:", "gitlab:", "bitbucket:", "gist:",
+	} {
+		if strings.HasPrefix(lc, p) {
+			return "", false, false
+		}
+	}
+	for len(s) > 0 {
+		switch s[0] {
+		case '^', '~', '=':
+			s = s[1:]
+			continue
+		case '>', '<':
+			s = s[1:]
+			if len(s) > 0 && s[0] == '=' {
+				s = s[1:]
+			}
+			continue
+		}
+		break
+	}
+	s = strings.TrimSpace(s)
+	if npmConcreteVersionRegex.MatchString(s) {
+		return s, true, false
+	}
+	return "", false, true
+}
+
+type npmProjectPackageJSON struct {
+	Name    string `json:"name"`
+	Version string `json:"version"`
+}
+
+// rootIdentityFromLogEntries recovers the true project name/version from a ROOT-location
+// entry, for when package.json can't be read.
+func rootIdentityFromLogEntries(entries []npmLogEntry) (name, version string, ok bool) {
+	for _, e := range entries {
+		if e.Location == "ROOT" {
+			return e.ParentName, e.ParentVersion, true
+		}
+	}
+	return "", "", false
+}
+
+func readNpmProjectNameVersion(projectDir string) (name, version string, err error) {
+	data, err := os.ReadFile(filepath.Join(projectDir, "package.json"))
+	if err != nil {
+		return "", "", errorutils.CheckErrorf("failed to read package.json in %q: %v", projectDir, err)
+	}
+	var pkg npmProjectPackageJSON
+	if err = json.Unmarshal(data, &pkg); err != nil {
+		return "", "", errorutils.CheckErrorf("failed to parse package.json in %q: %v", projectDir, err)
+	}
+	return pkg.Name, pkg.Version, nil
+}
+
+// npmNodeId matches the "npm://name:version" format parseNpmDependenciesList uses in the
+// normal flow, so the reconstructed tree is indistinguishable from a real one downstream.
+func npmNodeId(name, version string) string {
+	return techutils.Npm.GetXrayPackageTypeId() + name + ":" + version
+}
+
+// buildGraphFromLogEntries reconstructs a *xrayUtils.GraphNode tree from placeDep entries.
+// Only immediate parent->child edges are recorded; resolving a deep node to its root-level
+// direct-dependency ancestor is fillGraphRelations's job, reused unmodified.
+func buildGraphFromLogEntries(entries []npmLogEntry, rootName, rootVersion string, blockedPackages map[string]npmBlockedInfo) *xrayUtils.GraphNode {
+	treeMap := make(map[string]xray.DepTreeNode)
+	for _, entry := range entries {
+		childId := npmNodeId(entry.Name, effectiveGraphVersion(entry, blockedPackages))
+		parentId := npmNodeId(entry.ParentName, entry.ParentVersion)
+		depTreeNode := treeMap[parentId]
+		depTreeNode.Children = appendUniqueChildId(depTreeNode.Children, childId)
+		treeMap[parentId] = depTreeNode
+	}
+	rootId := npmNodeId(rootName, rootVersion)
+	graph, _ := xray.BuildXrayDependencyTree(treeMap, rootId)
+	return graph
+}
+
+// npmSyntheticNodeForKey wraps just the id needed to derive a preProcessMap key, so
+// whole-package-blocked/non-registry entries (synthesized directly) land under the same key
+// fillGraphRelations will later compute for the same package.
+func npmSyntheticNodeForKey(name, version string) *xrayUtils.GraphNode {
+	return &xrayUtils.GraphNode{Id: npmNodeId(name, version)}
+}
+
+func npmPackageKey(tech techutils.Technology, artiUrl, repo, name, version string) (string, error) {
+	urls, _, _, _ := getUrlNameAndVersionByTech(tech, npmSyntheticNodeForKey(name, version), nil, artiUrl, repo)
+	if len(urls) == 0 {
+		return "", fmt.Errorf("could not derive a preProcessMap key for %s:%s", name, version)
+	}
+	return urls[0], nil
+}
+
+// appendUniqueChildId is a local copy of the npm tech package's own unexported appendUniqueChild.
+func appendUniqueChildId(children []string, childId string) []string {
+	for _, existing := range children {
+		if existing == childId {
+			return children
+		}
+	}
+	return append(children, childId)
+}
+
+// sortedNpmLogEntries sorts by Name then Version for deterministic, reproducible output.
+func sortedNpmLogEntries(entries []npmLogEntry) []npmLogEntry {
+	sorted := make([]npmLogEntry, len(entries))
+	copy(sorted, entries)
+	sort.Slice(sorted, func(i, j int) bool {
+		if sorted[i].Name != sorted[j].Name {
+			return sorted[i].Name < sorted[j].Name
+		}
+		return sorted[i].Version < sorted[j].Version
+	})
+	return sorted
+}

--- a/commands/curation/npmlogparser_test.go
+++ b/commands/curation/npmlogparser_test.go
@@ -1,0 +1,372 @@
+package curation
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+	// TestDataDir is defined in curationaudit_test.go (same package).
+
+	"github.com/jfrog/jfrog-cli-security/utils/techutils"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseNpmDebugLog(t *testing.T) {
+	entries, blockedPackages, logFilePaths, err := parseNpmDebugLog(filepath.Join(TestDataDir, "curation", "npmlogs", "mixed-crash", "_logs"), 0)
+	require.NoError(t, err)
+	require.NotEmpty(t, entries)
+	require.Len(t, logFilePaths, 1)
+	assert.Equal(t, "2026-01-01T00_00_00_000Z-debug-0.log", filepath.Base(logFilePaths[0]))
+
+	// Whole-package block: notice immediately followed by the matching 403 fetch line.
+	require.Contains(t, blockedPackages, "depd")
+	assert.Equal(t, "blocks open ssf", blockedPackages["depd"].Policy)
+	assert.Equal(t, "open ssf", blockedPackages["depd"].Condition)
+
+	byName := map[string]npmLogEntry{}
+	for _, e := range entries {
+		byName[e.Name] = e
+	}
+
+	// Resolved.
+	require.Contains(t, byName, "express")
+	assert.Equal(t, "5.2.1", byName["express"].Version)
+	assert.Equal(t, "mypnpmproject-v11", byName["express"].ParentName)
+
+	// Whole-package-blocked placeDep line: blank version, real parent.
+	require.Contains(t, byName, "depd")
+	assert.Empty(t, byName["depd"].Version)
+	assert.Equal(t, "express", byName["depd"].ParentName)
+
+	// Git-URL: blank version, specifier contains "/".
+	require.Contains(t, byName, "is-thirteen")
+	assert.Empty(t, byName["is-thirteen"].Version)
+	assert.Equal(t, "github:jonschlinkert/is-thirteen", byName["is-thirteen"].Specifier)
+
+	// Genuine ETARGET: blank version, no notice, specifier has no "/".
+	require.Contains(t, byName, "lodash")
+	assert.Empty(t, byName["lodash"].Version)
+	assert.Equal(t, "99.99.99", byName["lodash"].Specifier)
+	assert.NotContains(t, blockedPackages, "lodash")
+
+	// Unresolvable range: blank version, not blocked, not a bare version.
+	require.Contains(t, byName, "some-range-pkg")
+	assert.Empty(t, byName["some-range-pkg"].Version)
+	assert.Equal(t, "^3.0.0", byName["some-range-pkg"].Specifier)
+	assert.NotContains(t, blockedPackages, "some-range-pkg")
+}
+
+// An unrelated line between a notice and its matching 403 must not discard the notice.
+func TestParseNpmDebugLog_NoticeSurvivesInterleavedLine(t *testing.T) {
+	dir := t.TempDir()
+	logsDir := filepath.Join(dir, "_logs")
+	require.NoError(t, os.MkdirAll(logsDir, 0755))
+	logContent := "1 verbose cli npm\n" +
+		"52 notice All versions blocked - {policy:blocks open ssf,condition:open ssf}\n" +
+		"53 http fetch GET 200 https://z0test.jfrogdev.org/artifactory/api/npm/my-pnpm-remote/otherpkg 100ms (cache revalidated)\n" +
+		"54 http fetch GET 403 https://z0test.jfrogdev.org/artifactory/api/npm/my-pnpm-remote/depd 196ms (cache skip)\n"
+	require.NoError(t, os.WriteFile(filepath.Join(logsDir, "2026-01-01T00_00_00_000Z-debug-0.log"), []byte(logContent), 0644))
+
+	_, blockedPackages, _, err := parseNpmDebugLog(logsDir, 0)
+	require.NoError(t, err)
+	assert.Contains(t, blockedPackages, "depd", "notice+403 pair separated only by an unrelated concurrent fetch line must still be attributed")
+}
+
+// A want: specifier containing a literal space (OR-ranges, hyphen-ranges) must still match.
+func TestParseNpmDebugLog_WantSpecifierWithSpaceStillMatches(t *testing.T) {
+	dir := t.TempDir()
+	logsDir := filepath.Join(dir, "_logs")
+	require.NoError(t, os.MkdirAll(logsDir, 0755))
+	logContent := "1 verbose cli npm\n" +
+		"10 silly placeDep ROOT or-range-pkg@ OK for: myproj@1.0.0 want: 1.0.0 || 2.0.0\n" +
+		"11 silly placeDep ROOT hyphen-range-pkg@ OK for: myproj@1.0.0 want: 1.0.0 - 2.0.0\n"
+	require.NoError(t, os.WriteFile(filepath.Join(logsDir, "2026-01-01T00_00_00_000Z-debug-0.log"), []byte(logContent), 0644))
+
+	entries, _, _, err := parseNpmDebugLog(logsDir, 0)
+	require.NoError(t, err)
+	byName := map[string]npmLogEntry{}
+	for _, e := range entries {
+		byName[e.Name] = e
+	}
+	require.Contains(t, byName, "or-range-pkg", "an OR-range want specifier must not silently drop the whole line")
+	assert.Equal(t, "1.0.0 || 2.0.0", byName["or-range-pkg"].Specifier)
+	require.Contains(t, byName, "hyphen-range-pkg", "a hyphen-range want specifier must not silently drop the whole line")
+	assert.Equal(t, "1.0.0 - 2.0.0", byName["hyphen-range-pkg"].Specifier)
+}
+
+// A tarball-fetch 403 must not be mistaken for a packument-fetch 403 and desync the pendingNotices FIFO.
+func TestParseNpmDebugLog_TarballFetch403DoesNotConsumePendingNotice(t *testing.T) {
+	dir := t.TempDir()
+	logsDir := filepath.Join(dir, "_logs")
+	require.NoError(t, os.MkdirAll(logsDir, 0755))
+	logContent := "1 verbose cli npm\n" +
+		"50 notice All versions blocked - {policy:blocks-cve,condition:cve}\n" +
+		"51 http fetch GET 403 https://z0test.jfrogdev.org/artifactory/api/npm/my-pnpm-remote/otherpkg/-/otherpkg-1.0.0.tgz 100ms (cache skip)\n" +
+		"52 http fetch GET 403 https://z0test.jfrogdev.org/artifactory/api/npm/my-pnpm-remote/depd 196ms (cache skip)\n"
+	require.NoError(t, os.WriteFile(filepath.Join(logsDir, "2026-01-01T00_00_00_000Z-debug-0.log"), []byte(logContent), 0644))
+
+	_, blockedPackages, _, err := parseNpmDebugLog(logsDir, 0)
+	require.NoError(t, err)
+	assert.Contains(t, blockedPackages, "depd", "the real packument 403 must still consume the pending notice")
+	assert.NotContains(t, blockedPackages, "otherpkg", "a tarball-fetch 403 must never be mistaken for a packument block")
+	assert.NotContains(t, blockedPackages, "otherpkg/-/otherpkg-1.0.0.tgz", "the tarball path must never be captured as a package name")
+}
+
+// npm-package-arg percent-encodes the scope separator in the packument-fetch URL (@babel/core
+// -> @babel%2fcore) while placeDep lines use the literal "/" form. blockedPackages must be
+// keyed on the decoded name so classifyBlankVersionEntry's entry.Name lookup actually matches,
+// or a genuinely whole-package-blocked scoped package silently downgrades to an
+// npmEntryUnresolvableRange advisory instead of npmEntryWholePackageBlocked.
+func TestParseNpmDebugLog_ScopedPackageBlockedPercentEncodedSlashStillMatches(t *testing.T) {
+	dir := t.TempDir()
+	logsDir := filepath.Join(dir, "_logs")
+	require.NoError(t, os.MkdirAll(logsDir, 0755))
+	logContent := "1 verbose cli npm\n" +
+		"50 notice All versions blocked - {policy:blocks open ssf,condition:open ssf}\n" +
+		"51 http fetch GET 403 https://z0test.jfrogdev.org/artifactory/api/npm/my-npm-remote/@babel%2fcore 100ms (cache skip)\n" +
+		"10 silly placeDep ROOT @babel/core@ OK for: myproj@1.0.0 want: ^7.0.0\n"
+	require.NoError(t, os.WriteFile(filepath.Join(logsDir, "2026-01-01T00_00_00_000Z-debug-0.log"), []byte(logContent), 0644))
+
+	entries, blockedPackages, _, err := parseNpmDebugLog(logsDir, 0)
+	require.NoError(t, err)
+	require.Contains(t, blockedPackages, "@babel/core", "blockedPackages must be keyed on the decoded scoped name")
+
+	var babelEntry npmLogEntry
+	for _, e := range entries {
+		if e.Name == "@babel/core" {
+			babelEntry = e
+		}
+	}
+	require.Equal(t, "@babel/core", babelEntry.Name)
+	assert.Equal(t, npmEntryWholePackageBlocked, classifyBlankVersionEntry(babelEntry, blockedPackages),
+		"a genuinely blocked scoped package must not downgrade to an unresolvable-range advisory")
+}
+
+// Two packages with notices pending at once must not have their policies misattributed.
+// Both pkg-a and pkg-b overlap (two notices queue up before either 403 arrives), so FIFO order
+// can't be trusted for either — both must degrade to "unknown" rather than risk a confidently
+// wrong policy/condition, even though this particular log happens to be in the correct order.
+func TestParseNpmDebugLog_OverlappingPendingNoticesDegradeToUnknownPolicy(t *testing.T) {
+	dir := t.TempDir()
+	logsDir := filepath.Join(dir, "_logs")
+	require.NoError(t, os.MkdirAll(logsDir, 0755))
+	logContent := "1 verbose cli npm\n" +
+		"50 notice All versions blocked - {policy:blocks-cve,condition:cve}\n" +
+		"51 notice All versions blocked - {policy:blocks-license,condition:license}\n" +
+		"52 http fetch GET 403 https://z0test.jfrogdev.org/artifactory/api/npm/my-pnpm-remote/pkg-a 100ms (cache skip)\n" +
+		"53 http fetch GET 403 https://z0test.jfrogdev.org/artifactory/api/npm/my-pnpm-remote/pkg-b 100ms (cache skip)\n"
+	require.NoError(t, os.WriteFile(filepath.Join(logsDir, "2026-01-01T00_00_00_000Z-debug-0.log"), []byte(logContent), 0644))
+
+	_, blockedPackages, _, err := parseNpmDebugLog(logsDir, 0)
+	require.NoError(t, err)
+	require.Contains(t, blockedPackages, "pkg-a", "still reported as blocked — just with unknown policy, not dropped entirely")
+	require.Contains(t, blockedPackages, "pkg-b")
+	assert.Equal(t, "unknown", blockedPackages["pkg-a"].Policy)
+	assert.Equal(t, "unknown", blockedPackages["pkg-b"].Policy)
+}
+
+// A single notice resolved before the next one ever queues is unambiguous — FIFO order is
+// trivially correct here, so the real policy must still be reported, not degraded.
+func TestParseNpmDebugLog_SequentialNonOverlappingNoticesKeepRealPolicy(t *testing.T) {
+	dir := t.TempDir()
+	logsDir := filepath.Join(dir, "_logs")
+	require.NoError(t, os.MkdirAll(logsDir, 0755))
+	logContent := "1 verbose cli npm\n" +
+		"50 notice All versions blocked - {policy:blocks-cve,condition:cve}\n" +
+		"51 http fetch GET 403 https://z0test.jfrogdev.org/artifactory/api/npm/my-pnpm-remote/pkg-a 100ms (cache skip)\n" +
+		"52 notice All versions blocked - {policy:blocks-license,condition:license}\n" +
+		"53 http fetch GET 403 https://z0test.jfrogdev.org/artifactory/api/npm/my-pnpm-remote/pkg-b 100ms (cache skip)\n"
+	require.NoError(t, os.WriteFile(filepath.Join(logsDir, "2026-01-01T00_00_00_000Z-debug-0.log"), []byte(logContent), 0644))
+
+	_, blockedPackages, _, err := parseNpmDebugLog(logsDir, 0)
+	require.NoError(t, err)
+	require.Contains(t, blockedPackages, "pkg-a")
+	require.Contains(t, blockedPackages, "pkg-b")
+	assert.Equal(t, "blocks-cve", blockedPackages["pkg-a"].Policy)
+	assert.Equal(t, "blocks-license", blockedPackages["pkg-b"].Policy)
+}
+
+// npm splits one run's debug log into multiple numbered chunk files past 50,000 log lines,
+// all sharing the same run timestamp. All chunks of the newest run must be read, in order, as
+// one continuous stream — including pendingNotices state carrying across the chunk boundary.
+func TestParseNpmDebugLog_MultipleChunksOfSameRunAreAllRead(t *testing.T) {
+	dir := t.TempDir()
+	logsDir := filepath.Join(dir, "_logs")
+	require.NoError(t, os.MkdirAll(logsDir, 0755))
+
+	// Chunk 0: ROOT placeDep entries plus a notice with no matching 403 yet (still pending).
+	chunk0 := "0 verbose cli npm\n" +
+		"1 silly placeDep ROOT accepts@2.0.0 OK for: myproj@1.0.0 want: ^2.0.0\n" +
+		"2 notice All versions blocked - {policy:blocks open ssf,condition:open ssf}\n"
+	// Chunk 1: the matching 403 for chunk 0's pending notice, plus another placeDep entry.
+	chunk1 := "50000 http fetch GET 403 https://z0test.jfrogdev.org/artifactory/api/npm/my-npm-remote/depd 100ms (cache skip)\n" +
+		"50001 silly placeDep node_modules/accepts depd@ OK for: accepts@2.0.0 want: ^1.0.0\n"
+
+	require.NoError(t, os.WriteFile(filepath.Join(logsDir, "2026-01-01T00_00_00_000Z-debug-0.log"), []byte(chunk0), 0644))
+	require.NoError(t, os.WriteFile(filepath.Join(logsDir, "2026-01-01T00_00_00_000Z-debug-1.log"), []byte(chunk1), 0644))
+
+	entries, blockedPackages, logFilePaths, err := parseNpmDebugLog(logsDir, 0)
+	require.NoError(t, err)
+	require.Len(t, logFilePaths, 2, "both chunks of the run must be read")
+	assert.Contains(t, logFilePaths[0], "debug-0.log")
+	assert.Contains(t, logFilePaths[1], "debug-1.log")
+
+	byName := map[string]npmLogEntry{}
+	for _, e := range entries {
+		byName[e.Name] = e
+	}
+	require.Contains(t, byName, "accepts", "chunk 0's placeDep entry must survive")
+	require.Contains(t, byName, "depd", "chunk 1's placeDep entry must survive")
+
+	require.Contains(t, blockedPackages, "depd",
+		"the notice from chunk 0 must still pair with its matching 403 in chunk 1")
+	assert.Equal(t, "blocks open ssf", blockedPackages["depd"].Policy)
+}
+
+func TestParseNpmDebugLog_NoLogsDir(t *testing.T) {
+	entries, blockedPackages, logFilePaths, err := parseNpmDebugLog(t.TempDir(), 0)
+	require.NoError(t, err)
+	assert.Nil(t, entries)
+	assert.Nil(t, blockedPackages)
+	assert.Empty(t, logFilePaths)
+}
+
+// Git host shorthand (github:/gitlab:/bitbucket:/gist:) must not regress — real evidence
+// (github:jonschlinkert/is-thirteen) depends on it.
+func TestClassifyNpmSpecifier(t *testing.T) {
+	cases := []struct {
+		spec           string
+		wantVer        string
+		wantProbeable  bool
+		wantRangeOrTag bool
+	}{
+		{"3.0.1", "3.0.1", true, false},
+		{"^3.0.1", "3.0.1", true, false},
+		{"~1.2.3", "1.2.3", true, false},
+		{"1.2.3-beta.1", "1.2.3-beta.1", true, false},
+		{"1.x", "", false, true},
+		{"*", "", false, true},
+		{"latest", "", false, true},
+		{"1.0.0 || 2.0.0", "", false, true},
+		{"file:./local-pkg", "", false, false},
+		{"link:../sibling", "", false, false},
+		{"workspace:*", "", false, false},
+		{"patch:react@npm%3A18.0.0", "", false, false},
+		{"git+https://github.com/foo/bar.git", "", false, false},
+		{"https://example.com/pkg.tgz", "", false, false},
+		{"npm:other-name@1.0.0", "", false, false},
+		// The exact gap found in yarn's own classifyNpmVersionSpec via real testing —
+		// git host shorthand, distinct from the explicit git:/git+ prefixes above.
+		{"github:jonschlinkert/is-thirteen", "", false, false},
+		{"gitlab:owner/repo", "", false, false},
+		{"bitbucket:owner/repo", "", false, false},
+		{"gist:1234567890abcdef", "", false, false},
+		{"", "", false, false},
+		{"   ", "", false, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.spec, func(t *testing.T) {
+			ver, probeable, rangeOrTag := classifyNpmSpecifier(tc.spec)
+			assert.Equal(t, tc.wantVer, ver)
+			assert.Equal(t, tc.wantProbeable, probeable)
+			assert.Equal(t, tc.wantRangeOrTag, rangeOrTag)
+		})
+	}
+}
+
+func TestClassifyBlankVersionEntry(t *testing.T) {
+	blockedPackages := map[string]npmBlockedInfo{"depd": {Policy: "blocks open ssf", Condition: "open ssf"}}
+
+	assert.Equal(t, npmEntryResolved, classifyBlankVersionEntry(
+		npmLogEntry{Name: "accepts", Version: "2.0.0"}, blockedPackages))
+
+	assert.Equal(t, npmEntryWholePackageBlocked, classifyBlankVersionEntry(
+		npmLogEntry{Name: "depd", Version: ""}, blockedPackages))
+
+	// Genuine git URL — non-registry, no probe.
+	assert.Equal(t, npmEntryNonRegistrySpecifier, classifyBlankVersionEntry(
+		npmLogEntry{Name: "is-thirteen", Version: "", Specifier: "github:jonschlinkert/is-thirteen"}, blockedPackages))
+
+	// Local workspace/file/link/patch reference and npm alias — also non-registry, no probe.
+	for _, spec := range []string{"workspace:*", "file:../local-pkg", "link:../sibling", "npm:other-name@^1.0.0", "patch:react@npm%3A18.0.0"} {
+		assert.Equal(t, npmEntryNonRegistrySpecifier, classifyBlankVersionEntry(
+			npmLogEntry{Name: "some-pkg", Version: "", Specifier: spec}, blockedPackages), "specifier %q", spec)
+	}
+
+	// Genuinely bare, exact version — the only case that's safe to probe.
+	assert.Equal(t, npmEntryETARGET, classifyBlankVersionEntry(
+		npmLogEntry{Name: "lodash", Version: "", Specifier: "99.99.99"}, blockedPackages))
+
+	// Never probed, even reduced to a bare number after stripping its operator — a guess, not what was requested.
+	for _, spec := range []string{"^2.0.0", "~1.2.0", ">=1.0.0", "1.x", "*", "latest", "1.0.0 || 2.0.0"} {
+		assert.Equal(t, npmEntryUnresolvableRange, classifyBlankVersionEntry(
+			npmLogEntry{Name: "some-pkg", Version: "", Specifier: spec}, blockedPackages), "specifier %q", spec)
+	}
+}
+
+func TestBuildGraphFromLogEntries(t *testing.T) {
+	entries := []npmLogEntry{
+		{Name: "express", Version: "5.2.1", ParentName: "myproj", ParentVersion: "1.0.0"},
+		{Name: "accepts", Version: "2.0.0", ParentName: "express", ParentVersion: "5.2.1"},
+		{Name: "depd", Version: "", ParentName: "express", ParentVersion: "5.2.1"},
+	}
+	graph := buildGraphFromLogEntries(entries, "myproj", "1.0.0", map[string]npmBlockedInfo{})
+	require.NotNil(t, graph)
+	assert.Equal(t, npmNodeId("myproj", "1.0.0"), graph.Id)
+	require.Len(t, graph.Nodes, 1)
+	assert.Equal(t, npmNodeId("express", "5.2.1"), graph.Nodes[0].Id)
+
+	childIds := map[string]bool{}
+	for _, child := range graph.Nodes[0].Nodes {
+		childIds[child.Id] = true
+	}
+	assert.True(t, childIds[npmNodeId("accepts", "2.0.0")])
+	assert.True(t, childIds[npmNodeId("depd", "")])
+}
+
+func TestNpmPackageKey_ConsistentWithGetUrlNameAndVersionByTech(t *testing.T) {
+	// The key runNpmLogFallback stores under must be exactly what fillGraphRelations
+	// derives when it later walks the reconstructed tree and looks the node up —
+	// both must go through the same getUrlNameAndVersionByTech call.
+	key, err := npmPackageKey(techutils.Npm, "https://example.jfrog.io/artifactory", "npm-remote", "depd", "")
+	require.NoError(t, err)
+
+	node := npmSyntheticNodeForKey("depd", "")
+	urls, name, _, version := getUrlNameAndVersionByTech(techutils.Npm, node, nil, "https://example.jfrog.io/artifactory", "npm-remote")
+	require.Len(t, urls, 1)
+	assert.Equal(t, urls[0], key)
+	assert.Equal(t, "depd", name)
+	assert.Empty(t, version)
+}
+
+func TestReadNpmProjectNameVersion(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "package.json"), []byte(`{"name":"myproj","version":"2.0.0"}`), 0644))
+
+	name, version, err := readNpmProjectNameVersion(dir)
+	require.NoError(t, err)
+	assert.Equal(t, "myproj", name)
+	assert.Equal(t, "2.0.0", version)
+}
+
+func TestFindNewestNpmDebugLog_PicksFilenameNewestOnModTimeTie(t *testing.T) {
+	dir := t.TempDir()
+	logsDir := filepath.Join(dir, "_logs")
+	require.NoError(t, os.MkdirAll(logsDir, 0755))
+
+	olderName := "2026-01-01T00_00_00_000Z-debug-0.log"
+	newerName := "2026-01-01T00_00_01_000Z-debug-0.log"
+	require.NoError(t, os.WriteFile(filepath.Join(logsDir, olderName), []byte("older"), 0644))
+	require.NoError(t, os.WriteFile(filepath.Join(logsDir, newerName), []byte("newer"), 0644))
+
+	// Force an exact ModTime tie so only the filename timestamp can disambiguate.
+	tie := time.Date(2026, 1, 1, 12, 0, 0, 0, time.UTC)
+	require.NoError(t, os.Chtimes(filepath.Join(logsDir, olderName), tie, tie))
+	require.NoError(t, os.Chtimes(filepath.Join(logsDir, newerName), tie, tie))
+
+	newest, err := findNewestNpmDebugLogChunksAfter(logsDir, 0)
+	require.NoError(t, err)
+	require.Len(t, newest, 1)
+	assert.Equal(t, newerName, filepath.Base(newest[0]))
+}

--- a/sca/bom/buildinfo/technologies/common.go
+++ b/sca/bom/buildinfo/technologies/common.go
@@ -67,6 +67,9 @@ type BuildInfoBomGeneratorParams struct {
 	NpmOverwritePackageLock bool
 	NpmRunNative            bool
 	NpmLegacyPeerDeps       bool
+	// NpmForceLogsMax, when non-empty, is appended as --logs-max <value> to the install command.
+	// Leave empty unless ambient logs-max is known to be 0 — never override a nonzero setting.
+	NpmForceLogsMax string
 	// Yarn params
 	// YarnOverwriteYarnLock refreshes yarn.lock when older than package.json (mirrors NpmOverwritePackageLock).
 	// Curation sets this to true; audit/scan leave it false to trust the existing lockfile.

--- a/sca/bom/buildinfo/technologies/npm/npm.go
+++ b/sca/bom/buildinfo/technologies/npm/npm.go
@@ -126,6 +126,21 @@ func GetNativeNpmRegistryConfig() (*NpmrcRegistryConfig, error) {
 	}, nil
 }
 
+// GetNpmConfigValue runs 'npm config get <key>' from workingDir, respecting the same
+// .npmrc/env resolution a real npm command from that directory would see.
+func GetNpmConfigValue(workingDir, key string) (string, error) {
+	npmVersion, npmExecPath, err := biutils.GetNpmVersionAndExecPath(log.Logger)
+	if err != nil {
+		return "", fmt.Errorf("failed to locate npm executable: %w", err)
+	}
+	disableWorkspaces := npmVersion.AtLeast("7.0.0")
+	data, _, err := biutils.RunNpmCmd(npmExecPath, workingDir, npmConfigGetArgs(key, disableWorkspaces), log.Logger)
+	if err != nil {
+		return "", fmt.Errorf("failed to run 'npm config get %s': %w", key, err)
+	}
+	return strings.TrimSpace(string(data)), nil
+}
+
 func npmConfigGetArgs(key string, disableWorkspaces bool) []string {
 	args := []string{"config", "get", key}
 	if disableWorkspaces {
@@ -188,6 +203,10 @@ func createTreeDepsParam(params *technologies.BuildInfoBomGeneratorParams) biuti
 	installCommandArgs := params.InstallCommandArgs
 	if params.NpmLegacyPeerDeps {
 		installCommandArgs = appendUniqueFlag(installCommandArgs, LegacyPeerDepsFlag)
+	}
+	if params.NpmForceLogsMax != "" {
+		// Appended last so this flag can't be shadowed by an earlier one.
+		installCommandArgs = append(installCommandArgs, "--logs-max", params.NpmForceLogsMax)
 	}
 	npmTreeDepParam := biutils.NpmTreeDepListParam{
 		Args:                 addIgnoreScriptsFlag(params.Args),

--- a/sca/bom/buildinfo/technologies/npm/npm_test.go
+++ b/sca/bom/buildinfo/technologies/npm/npm_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/jfrog/jfrog-client-go/utils/io/fileutils"
 	xrayUtils "github.com/jfrog/jfrog-client-go/xray/services/utils"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestParseNpmDependenciesList(t *testing.T) {
@@ -247,6 +248,60 @@ func TestBuildNpmAuthTokenKey(t *testing.T) {
 			}
 			assert.NoError(t, err)
 			assert.Equal(t, tc.expectedKey, authKey)
+		})
+	}
+}
+
+// NpmForceLogsMax, when set, must be appended last so an earlier user-supplied flag can't
+// shadow it — but it must never be forced just because IsCurationCmd is true, since that
+// would override (and prune) a user's own already-nonzero logs-max retention setting.
+func TestCreateTreeDepsParam_ForceLogsMaxOnlyWhenExplicitlySet(t *testing.T) {
+	tests := []struct {
+		name         string
+		params       *technologies.BuildInfoBomGeneratorParams
+		wantLogsMax  string
+		wantArgsTail []string
+	}{
+		{
+			name:        "forced with no other install args",
+			params:      &technologies.BuildInfoBomGeneratorParams{IsCurationCmd: true, NpmForceLogsMax: "1"},
+			wantLogsMax: "1",
+		},
+		{
+			name: "forced with pre-existing install args",
+			params: &technologies.BuildInfoBomGeneratorParams{
+				IsCurationCmd:      true,
+				NpmForceLogsMax:    "1",
+				InstallCommandArgs: []string{"--registry", "https://example.com"},
+			},
+			wantLogsMax:  "1",
+			wantArgsTail: []string{"--registry", "https://example.com"},
+		},
+		{
+			name:        "curation without NpmForceLogsMax does not force logs-max",
+			params:      &technologies.BuildInfoBomGeneratorParams{IsCurationCmd: true},
+			wantLogsMax: "",
+		},
+		{
+			name:        "non-curation does not force logs-max",
+			params:      &technologies.BuildInfoBomGeneratorParams{IsCurationCmd: false},
+			wantLogsMax: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := createTreeDepsParam(tt.params)
+			if tt.wantLogsMax != "" {
+				require.GreaterOrEqual(t, len(got.InstallCommandArgs), 2)
+				last := got.InstallCommandArgs[len(got.InstallCommandArgs)-2:]
+				assert.Equal(t, []string{"--logs-max", tt.wantLogsMax}, last)
+				for i, arg := range tt.wantArgsTail {
+					assert.Equal(t, arg, got.InstallCommandArgs[i])
+				}
+			} else {
+				assert.NotContains(t, got.InstallCommandArgs, "--logs-max")
+			}
 		})
 	}
 }

--- a/tests/testdata/curation/npmlogs/mixed-crash/_logs/2026-01-01T00_00_00_000Z-debug-0.log
+++ b/tests/testdata/curation/npmlogs/mixed-crash/_logs/2026-01-01T00_00_00_000Z-debug-0.log
@@ -1,0 +1,31 @@
+0 verbose cli node npm
+1 info using npm@10.5.0
+2 info using node@v20.12.2
+37 timing idealTree:init Completed in 5ms
+38 silly idealTree buildDeps
+39 silly fetch manifest express@^5.2.1
+40 http fetch GET 200 https://z0test.jfrogdev.org/artifactory/api/npm/my-pnpm-remote/express 700ms (cache revalidated)
+41 silly fetch manifest lodash@99.99.99
+42 http fetch GET 200 https://z0test.jfrogdev.org/artifactory/api/npm/my-pnpm-remote/lodash 201ms (cache revalidated)
+43 silly fetch manifest typescript@5.3.3
+44 http fetch GET 200 https://z0test.jfrogdev.org/artifactory/api/npm/my-pnpm-remote/typescript 216ms (cache revalidated)
+45 silly fetch manifest is-thirteen@github:jonschlinkert/is-thirteen
+46 silly placeDep ROOT express@5.2.1 OK for: mypnpmproject-v11@1.0.0 want: ^5.2.1
+47 silly placeDep ROOT lodash@ OK for: mypnpmproject-v11@1.0.0 want: 99.99.99
+48 silly placeDep ROOT typescript@5.3.3 OK for: mypnpmproject-v11@1.0.0 want: 5.3.3
+49 silly placeDep ROOT is-thirteen@ OK for: mypnpmproject-v11@1.0.0 want: github:jonschlinkert/is-thirteen
+50 silly fetch manifest accepts@^2.0.0
+51 http fetch GET 200 https://z0test.jfrogdev.org/artifactory/api/npm/my-pnpm-remote/accepts 190ms (cache revalidated)
+52 silly fetch manifest depd@^2.0.0
+53 notice All versions blocked - {policy:blocks open ssf,condition:open ssf}
+54 http fetch GET 403 https://z0test.jfrogdev.org/artifactory/api/npm/my-pnpm-remote/depd 196ms (cache skip)
+55 silly placeDep ROOT accepts@2.0.0 OK for: express@5.2.1 want: ^2.0.0
+56 silly placeDep node_modules/express depd@ OK for: express@5.2.1 want: ^2.0.0
+59 silly placeDep node_modules/express some-range-pkg@ OK for: express@5.2.1 want: ^3.0.0
+57 error command git --no-replace-objects ls-remote ssh://git@github.com/jonschlinkert/is-thirteen.git
+58 error git@github.com: Permission denied (publickey).
+293 timing idealTree:buildDeps Completed in 2959ms
+296 timing command:install Completed in 2966ms
+297 verbose stack lodash: No matching version found for lodash@99.99.99.
+303 error code ETARGET
+304 error notarget No matching version found for lodash@99.99.99.


### PR DESCRIPTION


- [ ] The pull request is targeting the `dev` branch.
- [ ] The code has been validated to compile successfully by running `go vet ./...`.
- [ ] The code has been formatted properly using `go fmt ./...`.
- [ ] All [static analysis checks](https://github.com/jfrog/jfrog-cli-security/actions/workflows/analysis.yml) passed.
- [ ] All [tests](https://github.com/jfrog/jfrog-cli-security/actions/workflows/test.yml) have passed. If this feature is not already covered by the tests, new tests have been added.
- [ ] Updated the [Contributing page](https://github.com/jfrog/jfrog-cli-security/blob/main/CONTRIBUTING.md) / [ReadMe page](https://github.com/jfrog/jfrog-cli-security/blob/main/README.md) / [CI Workflow files](https://github.com/jfrog/jfrog-cli-security/tree/main/.github/workflows) if needed.
- [ ] All changes are detailed at the description. if not already covered at [JFrog Documentation](https://github.com/jfrog/documentation), new documentation have been added.

-----

## Summary

Adds a fallback for `jf ca` (npm): when `npm install --package-lock-only` crashes mid-resolution due to a curation-blocked package, this reconstructs a partial report from npm's own debug log instead of aborting with zero findings. Classifies each unresolved entry as whole-package-blocked, non-registry (git URL/local ref/alias — never probed), unresolvable range (advisory only), or genuine ETARGET (still probed). Scoped to npm only — yarn/pnpm untouched.

Before
<img width="1365" height="880" alt="Screenshot 2026-08-03 at 2 21 53 PM" src="https://github.com/user-attachments/assets/57019787-6b62-44a9-8e66-3c5d88eded8f" />

After
<img width="1697" height="959" alt="Screenshot 2026-08-03 at 2 22 02 PM" src="https://github.com/user-attachments/assets/b2957b3e-9c2b-4ef9-8d77-715d2093077f" />
