### PR TITLE
XRAY-157176 - Honor SAST changed files mode in the config profile scan flow

### DIFF
--- a/jas/runner/jasrunner.go
+++ b/jas/runner/jasrunner.go
@@ -172,6 +172,15 @@ func runIacScan(params *JasRunnerParams) parallel.TaskFunc {
 	}
 }
 
+// The config profile enables changed files mode through the SAST differential scanning option.
+func (params JasRunnerParams) sastChangedFilesMode() bool {
+	if params.SastChangedFilesMode {
+		return true
+	}
+	return params.ConfigProfile != nil && len(params.ConfigProfile.Modules) > 0 &&
+		params.ConfigProfile.Modules[0].ScanConfig.SastScannerConfig.EnableFastDiffMode
+}
+
 func runSastScan(params *JasRunnerParams) parallel.TaskFunc {
 	return func(threadId int) (err error) {
 		defer func() {
@@ -185,7 +194,7 @@ func runSastScan(params *JasRunnerParams) parallel.TaskFunc {
 				TargetCount:        params.TargetCount,
 				ThreadId:           threadId,
 				SastChangedFiles:   params.ChangedFiles,
-				ChangedFilesMode:   params.SastChangedFilesMode || (params.ConfigProfile != nil && params.ConfigProfile.Modules[0].ScanConfig.SastScannerConfig.EnableFastDiffMode),
+				ChangedFilesMode:   params.sastChangedFilesMode(),
 				ResultsToCompare:   getSourceRunsToCompare(params, jasutils.Sast),
 			},
 			params.Scanner,

--- a/jas/runner/jasrunner_test.go
+++ b/jas/runner/jasrunner_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/jfrog/jfrog-cli-security/utils/results"
 	"github.com/jfrog/jfrog-cli-security/utils/techutils"
 	"github.com/jfrog/jfrog-client-go/utils/io/fileutils"
+	"github.com/jfrog/jfrog-client-go/xsc/services"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -100,4 +101,30 @@ func TestJasRunner_Target_AnalyzerManagerReturnsError(t *testing.T) {
 	)
 	// Expect error:
 	assert.ErrorContains(t, jas.ParseAnalyzerManagerError(jasutils.Applicability, err), "failed to run Applicability scan")
+}
+
+func TestSastChangedFilesMode(t *testing.T) {
+	profileWithDiffMode := &services.ConfigProfile{Modules: []services.Module{{
+		ScanConfig: services.ScanConfig{SastScannerConfig: services.SastScannerConfig{EnableFastDiffMode: true}},
+	}}}
+	profileWithoutDiffMode := &services.ConfigProfile{Modules: []services.Module{{
+		ScanConfig: services.ScanConfig{SastScannerConfig: services.SastScannerConfig{EnableSastScan: true}},
+	}}}
+
+	tests := []struct {
+		name     string
+		params   JasRunnerParams
+		expected bool
+	}{
+		{name: "no profile and no flag", params: JasRunnerParams{}},
+		{name: "flag only", params: JasRunnerParams{SastChangedFilesMode: true}, expected: true},
+		{name: "profile differential scanning enabled", params: JasRunnerParams{ConfigProfile: profileWithDiffMode}, expected: true},
+		{name: "profile differential scanning disabled", params: JasRunnerParams{ConfigProfile: profileWithoutDiffMode}},
+		{name: "profile without modules", params: JasRunnerParams{ConfigProfile: &services.ConfigProfile{}}},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			assert.Equal(t, test.expected, test.params.sastChangedFilesMode())
+		})
+	}
 }

--- a/jas/sast/sastscanner.go
+++ b/jas/sast/sastscanner.go
@@ -104,7 +104,7 @@ func newSastScanManager(scanner *jas.JasScanner, scannerTempDir string, signedDe
 }
 
 func (ssm *SastScanManager) DeprecatedRun(module jfrogappsconfig.Module, centralConfigExclusions []string) (vulnerabilitiesSarifRuns []*sarif.Run, violationsSarifRuns []*sarif.Run, err error) {
-	if err = ssm.deprecatedCreateConfigFile(module, ssm.signedDescriptions, ssm.sastChangedFiles, centralConfigExclusions, ssm.scanner.Exclusions...); err != nil {
+	if err = ssm.deprecatedCreateConfigFile(module, ssm.signedDescriptions, centralConfigExclusions, ssm.scanner.Exclusions...); err != nil {
 		return
 	}
 	if err = ssm.runAnalyzerManager(filepath.Dir(ssm.scanner.AnalyzerManager.AnalyzerManagerFullPath)); err != nil {
@@ -155,7 +155,7 @@ type sastParameters struct {
 	SignedDescriptions bool `yaml:"signed_descriptions,omitempty"`
 }
 
-func (ssm *SastScanManager) deprecatedCreateConfigFile(module jfrogappsconfig.Module, signedDescriptions bool, sastChangedFiles []string, centralConfigExclusions []string, exclusions ...string) error {
+func (ssm *SastScanManager) deprecatedCreateConfigFile(module jfrogappsconfig.Module, signedDescriptions bool, centralConfigExclusions []string, exclusions ...string) error {
 	sastScanner := module.Scanners.Sast
 	if sastScanner == nil {
 		sastScanner = &jfrogappsconfig.SastScanner{}
@@ -164,15 +164,11 @@ func (ssm *SastScanManager) deprecatedCreateConfigFile(module jfrogappsconfig.Mo
 	if err != nil {
 		return err
 	}
-	if ssm.changedFilesMode {
-		log.Debug(fmt.Sprintf("SAST changed files mode: using %d paths as scan roots", len(sastChangedFiles)))
-		roots = sastChangedFiles
-	}
 	configFileContent := sastScanConfig{
 		Scans: []scanConfiguration{
 			{
 				Type:                   sastScannerType,
-				Roots:                  roots,
+				Roots:                  ssm.getScanRoots(roots),
 				Output:                 ssm.resultsFileName,
 				PathToResultsToCompare: ssm.resultsToCompareFileName,
 				Language:               sastScanner.Language,
@@ -188,12 +184,21 @@ func (ssm *SastScanManager) deprecatedCreateConfigFile(module jfrogappsconfig.Mo
 	return jas.CreateScannersConfigFile(ssm.configFileName, configFileContent, jasutils.Sast)
 }
 
+// In changed files mode only the files affected by the diff are analyzed, instead of the entire scanned tree.
+func (ssm *SastScanManager) getScanRoots(defaultRoots []string) []string {
+	if !ssm.changedFilesMode {
+		return defaultRoots
+	}
+	log.Debug(fmt.Sprintf("SAST changed files mode: using %d paths as scan roots", len(ssm.sastChangedFiles)))
+	return ssm.sastChangedFiles
+}
+
 func (ssm *SastScanManager) createConfigFileForTarget(target results.ScanTarget) error {
 	configFileContent := sastScanConfig{
 		Scans: []scanConfiguration{
 			{
 				Type:                   sastScannerType,
-				Roots:                  jas.GetRootsFromTarget(target),
+				Roots:                  ssm.getScanRoots(jas.GetRootsFromTarget(target)),
 				Output:                 ssm.resultsFileName,
 				PathToResultsToCompare: ssm.resultsToCompareFileName,
 				SastParameters: sastParameters{

--- a/jas/sast/sastscanner_test.go
+++ b/jas/sast/sastscanner_test.go
@@ -296,6 +296,20 @@ func TestSastChangedFilesForTarget(t *testing.T) {
 	}
 }
 
+func readConfigRoots(t *testing.T, configFileName string) []string {
+	t.Helper()
+	data, err := os.ReadFile(configFileName)
+	require.NoError(t, err)
+	var cfg struct {
+		Scans []struct {
+			Roots []string `yaml:"roots,omitempty"`
+		} `yaml:"scans,omitempty"`
+	}
+	require.NoError(t, yaml.Unmarshal(data, &cfg))
+	require.Len(t, cfg.Scans, 1)
+	return cfg.Scans[0].Roots
+}
+
 func TestCreateConfigFile_ChangedFilesModeRoots(t *testing.T) {
 	scanner, cleanUp := jas.InitJasTest(t)
 	defer cleanUp()
@@ -318,21 +332,6 @@ func TestCreateConfigFile_ChangedFilesModeRoots(t *testing.T) {
 	changed := []string{"src/a.go", "src/b.go"}
 	ssm, err := newSastScanManager(scanner, scannerTempDir, false, false, "", nil)
 	require.NoError(t, err)
-
-	type yamlCfg struct {
-		Scans []struct {
-			Roots []string `yaml:"roots,omitempty"`
-		} `yaml:"scans,omitempty"`
-	}
-	readConfigRoots := func(t *testing.T) []string {
-		t.Helper()
-		data, err := os.ReadFile(ssm.configFileName)
-		require.NoError(t, err)
-		var cfg yamlCfg
-		require.NoError(t, yaml.Unmarshal(data, &cfg))
-		require.Len(t, cfg.Scans, 1)
-		return cfg.Scans[0].Roots
-	}
 
 	for _, tc := range []struct {
 		name             string
@@ -372,7 +371,7 @@ func TestCreateConfigFile_ChangedFilesModeRoots(t *testing.T) {
 			ssm.changedFilesMode = tc.changedFilesMode
 			ssm.sastChangedFiles = tc.sastForCall
 			require.NoError(t, ssm.deprecatedCreateConfigFile(module, false, nil))
-			got := readConfigRoots(t)
+			got := readConfigRoots(t, ssm.configFileName)
 			if tc.emptyRoots {
 				assert.Empty(t, got, "with changed-files mode on and no per-target list, roots should be nil/empty in YAML, not the default module source roots")
 			} else {
@@ -399,6 +398,7 @@ func TestCreateConfigFileForTarget_ChangedFilesModeRoots(t *testing.T) {
 		changedFilesMode bool
 		changedFiles     []string
 		want             []string
+		emptyRoots       bool
 	}{
 		{
 			name:             "changed_files_mode_uses_changed_files_as_roots",
@@ -411,21 +411,23 @@ func TestCreateConfigFileForTarget_ChangedFilesModeRoots(t *testing.T) {
 			changedFiles: changed,
 			want:         []string{target.Target},
 		},
+		{
+			// RunSastScan skips the analyzer in this case, so the target must not fall back to the whole tree.
+			name:             "changed_files_mode_without_changed_files_uses_no_roots",
+			changedFilesMode: true,
+			emptyRoots:       true,
+		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			ssm, err := newSastScanManager(scanner, scannerTempDir, false, tc.changedFilesMode, "", tc.changedFiles)
 			require.NoError(t, err)
 			require.NoError(t, ssm.createConfigFileForTarget(target))
-			data, err := os.ReadFile(ssm.configFileName)
-			require.NoError(t, err)
-			var cfg struct {
-				Scans []struct {
-					Roots []string `yaml:"roots,omitempty"`
-				} `yaml:"scans,omitempty"`
+			got := readConfigRoots(t, ssm.configFileName)
+			if tc.emptyRoots {
+				assert.Empty(t, got, "with changed-files mode on and no changed files, roots should be empty, not the scan target")
+			} else {
+				assert.ElementsMatch(t, tc.want, got)
 			}
-			require.NoError(t, yaml.Unmarshal(data, &cfg))
-			require.Len(t, cfg.Scans, 1)
-			assert.ElementsMatch(t, tc.want, cfg.Scans[0].Roots)
 		})
 	}
 }

--- a/jas/sast/sastscanner_test.go
+++ b/jas/sast/sastscanner_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/jfrog/jfrog-cli-security/jas"
 	"github.com/jfrog/jfrog-cli-security/utils/formats/sarifutils"
 	"github.com/jfrog/jfrog-cli-security/utils/jasutils"
+	"github.com/jfrog/jfrog-cli-security/utils/results"
 )
 
 func TestNewSastScanManager(t *testing.T) {
@@ -369,13 +370,62 @@ func TestCreateConfigFile_ChangedFilesModeRoots(t *testing.T) {
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			ssm.changedFilesMode = tc.changedFilesMode
-			require.NoError(t, ssm.deprecatedCreateConfigFile(module, false, tc.sastForCall, nil))
+			ssm.sastChangedFiles = tc.sastForCall
+			require.NoError(t, ssm.deprecatedCreateConfigFile(module, false, nil))
 			got := readConfigRoots(t)
 			if tc.emptyRoots {
 				assert.Empty(t, got, "with changed-files mode on and no per-target list, roots should be nil/empty in YAML, not the default module source roots")
 			} else {
 				assert.ElementsMatch(t, tc.want, got)
 			}
+		})
+	}
+}
+
+func TestCreateConfigFileForTarget_ChangedFilesModeRoots(t *testing.T) {
+	scanner, cleanUp := jas.InitJasTest(t)
+	defer cleanUp()
+	tempDir, cleanUpTempDir := coreTests.CreateTempDirWithCallbackAndAssert(t)
+	defer cleanUpTempDir()
+	scanner.TempDir = tempDir
+	scannerTempDir, err := jas.CreateScannerTempDirectory(scanner, jasutils.Sast.String(), 0)
+	require.NoError(t, err)
+
+	target := results.ScanTarget{Target: filepath.Join("root", "repository")}
+	changed := []string{filepath.Join("root", "repository", "src", "a.go")}
+
+	for _, tc := range []struct {
+		name             string
+		changedFilesMode bool
+		changedFiles     []string
+		want             []string
+	}{
+		{
+			name:             "changed_files_mode_uses_changed_files_as_roots",
+			changedFilesMode: true,
+			changedFiles:     changed,
+			want:             changed,
+		},
+		{
+			name:         "mode_off_uses_target_roots",
+			changedFiles: changed,
+			want:         []string{target.Target},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ssm, err := newSastScanManager(scanner, scannerTempDir, false, tc.changedFilesMode, "", tc.changedFiles)
+			require.NoError(t, err)
+			require.NoError(t, ssm.createConfigFileForTarget(target))
+			data, err := os.ReadFile(ssm.configFileName)
+			require.NoError(t, err)
+			var cfg struct {
+				Scans []struct {
+					Roots []string `yaml:"roots,omitempty"`
+				} `yaml:"scans,omitempty"`
+			}
+			require.NoError(t, yaml.Unmarshal(data, &cfg))
+			require.Len(t, cfg.Scans, 1)
+			assert.ElementsMatch(t, tc.want, cfg.Scans[0].Roots)
 		})
 	}
 }

--- a/jas/sast/sastscanner_test.go
+++ b/jas/sast/sastscanner_test.go
@@ -342,26 +342,20 @@ func TestCreateConfigFile_ChangedFilesModeRoots(t *testing.T) {
 		emptyRoots  bool
 	}{
 		{
-			name:             "env_true_uses_changed_files_as_roots",
+			name:             "changed_files_mode_uses_changed_files_as_roots",
 			changedFilesMode: true,
 			sastForCall:      changed,
 			want:             changed,
 		},
 		{
-			name:             "env_1_uses_changed_files_as_roots",
-			changedFilesMode: true,
-			sastForCall:      changed,
-			want:             changed,
-		},
-		{
-			name:             "env_false_ignores_changed_files",
+			name:             "changed_files_mode_off_ignores_changed_files",
 			changedFilesMode: false,
 			sastForCall:      changed,
 			want:             expectedDefaultRoots,
 		},
 		{
 			// In changed-files mode, do not use full module roots; RunSastScan skips the analyzer with no diff baseline.
-			name:             "env_true_no_changed_file_list_uses_no_module_roots",
+			name:             "changed_files_mode_no_changed_file_list_uses_no_module_roots",
 			changedFilesMode: true,
 			sastForCall:      nil,
 			emptyRoots:       true,


### PR DESCRIPTION
## What

`enable_differential_scanning` (SAST fast diff mode) has been a no-op in the config-profile / Frogbot V3 flow. The flag reaches `SastScanManager` correctly, but the config file handed to the analyzer manager is built with the **full scan target as roots**, so the whole branch tree is analyzed on every PR scan.

`createConfigFileForTarget` never read `changedFilesMode` — only `deprecatedCreateConfigFile` did. Since the V3 flow leaves `DeprecatedAppsConfigModule` nil (it is only populated by `detectScaTargetsFromTechnologies`, the old flow), every config-profile scan took the builder that ignores the mode.

Introduced in #670, which split the single `createConfigFile` into a deprecated and a target-based copy and carried the changed-files branch over to the deprecated one only. The feature itself landed just before it in #739 / #743 / #745.

## Effect on a real customer (XRAY-157176, blocker)

Two runs on the same PR (one changed `.java` file), differential on vs off, produced a **byte-identical** SAST scanner input:

```yaml
scans:
    - roots:
        - /tmp/jfrog.cli.temp.-1785224331-234849826   # whole checkout, both runs
      type: sast
```

2 x ~17m SAST with the flag on vs 2 x ~18m with it off — a ~5% delta that is just noise. What made this hard to spot from logs is that the analyzer manager reports `running diff scan mode; first_scan/second_scan` in **both** cases: Frogbot PR scans always pass `target-result-file` for the post-scan sarif comparison, independently of the profile flag.

## Fix

Both builders now resolve roots through one `getScanRoots`, so the two paths cannot drift apart again. Behavior in changed-files mode is unchanged from the deprecated path: roots become the changed files, and `RunSastScan` still skips the scanner entirely when nothing changed under the target.

## Verified end to end

Reproduction, with both runtimes wired to the same JPD, config profile and PR:
**https://github.com/Jordanh1996/frogbot-sast-differential-repro** ([PR #1](https://github.com/Jordanh1996/frogbot-sast-differential-repro/pull/1))

Same one-file PR, same profile (`enable_sast_scan: true, enable_differential_scanning: true`), 150-class Java corpus:

| | `jfrog/frogbot@v3` (released) | Frogbot v3 built with this branch |
|---|---|---|
| `SAST changed files mode` log | absent | `using 1 paths as scan roots` |
| Scan roots | whole checkout | `.../ReportBuilder.java` |
| Files parsed per scan | `Generated IR for 151 files` | `Generated IR for 1 files` |
| SAST duration per scan | 25.9s / 25.2s | 18.2s / 18.4s |
| New issues reported on the PR | 1 | 1 |

Identical PR verdict for 1/151 of the parsing. On a customer-scale corpus the released runtime took 23m13s where the patched one took 2m24s.

Worth noting for the SAST team: with per-file roots the engine does **not** do full-repository preprocessing — it reports `Generated IR for 1 files` and the fixed scanner startup (~16s) then dominates. So the scoping does what it was designed to do.

## Tests

- `TestCreateConfigFileForTarget_ChangedFilesModeRoots` covers the previously untested target-based builder, including that changed-files mode with nothing changed yields no roots rather than falling back to the whole tree. It fails on `dev` and passes here.
- `TestSastChangedFilesMode` covers the other half of the chain — that a config profile with `enable_differential_scanning` actually turns changed-files mode on. That link was correct but untested, which is why the drop downstream went unnoticed. The derivation moved into `JasRunnerParams.sastChangedFilesMode()` to make it testable, and it now guards against a profile with no modules instead of indexing `Modules[0]` blindly.
- `TestCreateConfigFile_ChangedFilesModeRoots` drives the changed files through the manager field instead of the removed parameter, and both tests share one `readConfigRoots` helper.

## Out of scope, filed separately

`createConfigFileForTarget` also omits `ExcludedRules`, and nothing reads `SastScannerConfig.ExcludeRules` from the config profile at all — so SAST exclude-rules set in Centralized Config are silently ignored. Unlike the bug fixed here that one is not a #670 regression: the `excluded-rules` key has only ever been fed from a `jfrog-apps-config` module, so the profile field appears to have never been wired. Tracked separately in [XRAY-157301](https://jfrog-int.atlassian.net/browse/XRAY-157301) to keep this PR scoped to the blocker.

---

- [x] The pull request is targeting the `dev` branch.
- [x] The code has been validated to compile successfully by running `go vet ./...`.
- [x] The code has been formatted properly using `go fmt ./...`.
- [x] All [static analysis checks](https://github.com/jfrog/jfrog-cli-security/actions/workflows/analysis.yml) passed.
- [x] All [tests](https://github.com/jfrog/jfrog-cli-security/actions/workflows/test.yml) have passed. If this feature is not already covered by the tests, new tests have been added.
- [ ] Updated the Contributing page / ReadMe page / CI Workflow files if needed.
- [x] All changes are detailed at the description.
