### PR TITLE
Fix CVE-less SCA violations dropped under a Watch

### DIFF
--- a/policy/enforcer/policyenforcer.go
+++ b/policy/enforcer/policyenforcer.go
@@ -460,31 +460,43 @@ func convertToBasicViolation(violationType violationutils.ViolationIssueType, vi
 
 func convertToCveViolations(cmdResults *results.SecurityCommandResults, violation services.XrayViolation) (cveViolations []violationutils.CveViolation) {
 	resolved, unresolvedCount := resolveInfectedComponents(cmdResults, violation)
-	for _, cve := range violation.Cves {
-		if cve.Id == "" {
-			log.Warn(fmt.Sprintf("Skipping CVE violation with empty CVE ID for violation ID %s", violation.Id))
-			continue
-		}
+	for _, cveId := range getCveIds(violation) {
 		if len(resolved) == 0 {
 			logComponentLessFallback(violation, unresolvedCount)
-			cveViolation := createCveViolation(cmdResults, "", cve.Id, violation, nil)
+			cveViolation := createCveViolation(cmdResults, "", cveId, violation, nil)
 			if cveViolation == nil {
-				log.Warn(fmt.Sprintf("CVE (%s) violation with no located affected components for violation ID %s", cve.Id, violation.Id))
+				log.Warn(fmt.Sprintf("CVE (%s) violation with no located affected components for violation ID %s", cveId, violation.Id))
 				continue
 			}
 			cveViolations = append(cveViolations, *cveViolation)
 			continue
 		}
 		for i := range resolved {
-			cveViolation := createCveViolation(cmdResults, resolved[i].xrayId, cve.Id, violation, &resolved[i])
+			cveViolation := createCveViolation(cmdResults, resolved[i].xrayId, cveId, violation, &resolved[i])
 			if cveViolation == nil {
-				log.Warn(fmt.Sprintf("CVE (%s) violation for component (%s) with no located affected components for violation ID %s", cve.Id, resolved[i].xrayId, violation.Id))
+				log.Warn(fmt.Sprintf("CVE (%s) violation for component (%s) with no located affected components for violation ID %s", cveId, resolved[i].xrayId, violation.Id))
 				continue
 			}
 			cveViolations = append(cveViolations, *cveViolation)
 		}
 	}
 	return cveViolations
+}
+
+// getCveIds returns the identifiers to convert for a Security violation. Xray-native vulnerabilities
+// with no assigned CVE (e.g. XRAY-XXXXX) still report through the CVE-keyed Security violation type,
+// with a CveDetails entry whose Id is empty. Fall back to the violation's own issue ID for those,
+// mirroring the fallback already used when building the SBOM (see ExtractIssuesInfoForCdx).
+func getCveIds(violation services.XrayViolation) (cveIds []string) {
+	for _, cve := range violation.Cves {
+		if cve.Id != "" {
+			cveIds = append(cveIds, cve.Id)
+		}
+	}
+	if len(cveIds) == 0 && violation.IssueId != "" {
+		cveIds = append(cveIds, violation.IssueId)
+	}
+	return
 }
 
 func createCveViolation(cmdResults *results.SecurityCommandResults, impactedComponentXrayId, cveId string, violation services.XrayViolation, preResolved *bomResolvedComponent) *violationutils.CveViolation {


### PR DESCRIPTION
## Problem

Any Xray SCA "Security" violation for a vulnerability that has no assigned CVE (only a native `XRAY-XXXXX` issue ID) is silently dropped when a Watch is used — with Frogbot V3 / `jf audit --static-sca`, the vulnerability never shows up in output, regardless of severity or policy match.

`convertToCveViolations` only builds output for entries in `violation.Cves`. Xray still returns a `CveDetails` entry for these vulnerabilities (CVSS/CWE populated), but with an empty `cve` field — which hits the `cve.Id == ""` guard and skips the violation entirely, with no fallback to the violation's own `IssueId`.

This is not a regression — the CVE-only assumption has been present since this converter was introduced (#543, 2025-11-23); CVE-less SCA vulnerabilities have never worked under a Watch.

## Fix

Fall back to `violation.IssueId` when no `Cves` entry has a usable ID, mirroring the same fallback already used when building the SBOM (`ExtractIssuesInfoForCdx`) — so the pattern is already precedented elsewhere in this codebase, just not applied here.

## Verification

Verified live against a real local Xray (not a unit test): a real Watch + Security policy (min severity Low) bound to a real indexed NuGet artifact carrying a real High-severity CVE-less vulnerability (`XRAY-1034038`, `OpenTelemetry.Resources.Host`).

Before this fix, calling the unmodified `GenerateViolations` against the real persisted violation:
```
[Info] Fetching violations from Xray...
[Warn] Skipping CVE violation with empty CVE ID for violation ID 2085062705793982464
=== SCA (CVE) violations returned: 0 ===
```

After the fix, same real Xray, same real violation:
```
=== SCA (CVE) violations returned: 1 ===
```
with correct severity (`High`), matched policy/watch, resolved impacted component, and fix version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
