### PR TITLE
fix(sca): 0644 for maven/gradle dep-tree helper writes

### DIFF
--- a/sca/bom/buildinfo/technologies/java/gradle.go
+++ b/sca/bom/buildinfo/technologies/java/gradle.go
@@ -118,7 +118,7 @@ func (gdt *gradleDepTreeManager) createDepTreeScriptAndGetDir() (tmpDir string, 
 	gradleDepTreeJarPath = ioutils.DoubleWinPathSeparator(gradleDepTreeJarPath)
 
 	depTreeInitScript := fmt.Sprintf(gradleDepTreeInitScript, releasesRepo, gradleDepTreeJarPath, gdt.depsRepo)
-	return tmpDir, errorutils.CheckError(os.WriteFile(filepath.Join(tmpDir, gradleDepTreeInitFile), []byte(depTreeInitScript), 0666))
+	return tmpDir, errorutils.CheckError(os.WriteFile(filepath.Join(tmpDir, gradleDepTreeInitFile), []byte(depTreeInitScript), 0644))
 }
 
 // getRemoteRepos constructs the sections of Artifactory's remote repositories in the gradle-dep-tree init script.

--- a/sca/bom/buildinfo/technologies/java/mvn.go
+++ b/sca/bom/buildinfo/technologies/java/mvn.go
@@ -155,7 +155,7 @@ func (mdt *MavenDepTreeManager) installMavenDepTreePlugin(depTreeExecDir string)
 		return nil
 	}
 	mavenDepTreeJarPath := filepath.Join(depTreeExecDir, mavenDepTreeJarFile)
-	if err := errorutils.CheckError(os.WriteFile(mavenDepTreeJarPath, mavenDepTreeJar, 0666)); err != nil {
+	if err := errorutils.CheckError(os.WriteFile(mavenDepTreeJarPath, mavenDepTreeJar, 0644)); err != nil {
 		return err
 	}
 	goals := GetMavenPluginInstallationGoals(mavenDepTreeJarPath)


### PR DESCRIPTION
## Summary
- Change `os.WriteFile(..., 0666)` → `0644` for embedded maven-dep-tree jar and gradle-dep-tree init script.
- Clears Soft-FP `go-weak-file-permissions` on those two sites (modes need not be world-writable).
- Intentional `0777` MkdirAll temp/offline-update dirs unchanged (permanent leave).

## Test plan
- [ ] maven/gradle dep-tree helper install still works
- [ ] Re-scan: weak-perms residual = `0777`×3 only

Refs: usaf-rules Soft-FP tip https://github.com/jfrog/usaf-rules/pull/3389 · EPIC https://github.com/jfrog/usaf-rules/issues/3403

Made with [Cursor](https://cursor.com)