### PR TITLE
XRAY-157605 Use the real package name for aliased pnpm dependencies

### DIFF
--- a/commands/curation/curationaudit.go
+++ b/commands/curation/curationaudit.go
@@ -2175,6 +2175,7 @@ func cleanupForcedNpmDebugLog(logsDir string, logsMaxWasZero bool, baselineKey i
 // rotation manages them like any other run.
 func (ca *CurationAuditCommand) runNpmLogFallback(logsDir string, tech techutils.Technology, results map[string]*CurationReport, originalErr error, logsMaxWasZero bool, baselineKey int64) error {
 	entries, blockedPackages, logFilePaths, parseErr := parseNpmDebugLog(logsDir, baselineKey)
+	entries = resolveNpmAliasEntries(entries)
 	if logsMaxWasZero {
 		defer func() {
 			for _, logFilePath := range logFilePaths {
@@ -2280,7 +2281,7 @@ func (ca *CurationAuditCommand) runNpmLogFallback(logsDir string, tech techutils
 			// "curation never applied" categories, so it can't be mistaken for a real block.
 			advisoryWarnings = append(advisoryWarnings, fmt.Sprintf(
 				"Package '%s' (%s): Not evaluated: This dependency was not evaluated because it is resolved from a source "+
-					"other than an npm registry (such as a Git URL, local path, or npm alias), bypassing Artifactory. "+
+					"other than an npm registry (such as a Git URL or local path), bypassing Artifactory. "+
 					"As a result, curation policies do not apply.",
 				entry.Name, entry.Specifier))
 		case npmEntryETARGET:

--- a/commands/curation/npmlogparser.go
+++ b/commands/curation/npmlogparser.go
@@ -266,6 +266,59 @@ func findNewestNpmDebugLogChunksAfter(logsDir string, afterKey int64) ([]string,
 	return paths, nil
 }
 
+// resolveNpmAliasTarget parses an "npm:<name>@<versionSpec>" alias specifier — how an npm
+// alias ("pkg-cjs": "npm:pkg@6.0.1") is recorded in npm's debug log — into the real registry
+// package name and the version/range it targets. ok=false for anything else, including a
+// malformed alias (no '@' after stripping the prefix) — that's treated as genuinely
+// unresolvable rather than guessed at.
+func resolveNpmAliasTarget(spec string) (name, versionSpec string, ok bool) {
+	const npmAliasPrefix = "npm:"
+	trimmed := strings.TrimSpace(spec)
+	if !strings.HasPrefix(strings.ToLower(trimmed), npmAliasPrefix) {
+		return "", "", false
+	}
+	rest := trimmed[len(npmAliasPrefix):]
+	// LastIndex, not Index: a scoped real name ("@babel/code-frame") contains its own '@', so
+	// the version separator is always the final one.
+	i := strings.LastIndex(rest, "@")
+	if i <= 0 {
+		return "", "", false
+	}
+	return rest[:i], rest[i+1:], true
+}
+
+// resolveNpmAliasEntries rewrites every entry whose Specifier is a resolvable npm alias
+// ("pkg-cjs": "npm:pkg@6.0.1") to the real package it targets — Name becomes the real name and
+// Specifier becomes the inner version/range — then propagates that rename to any other entry's
+// ParentName that referenced the alias, so parent-child edges in the reconstructed tree still
+// line up.
+//
+// npm's debug log always names a placeDep entry after the alias, never the real package.
+// Artifactory's block notices and the registry both know it only by the real name, so every
+// blockedPackages lookup, HEAD-check, and graph edge downstream must see the real name — done
+// once here, at the point the wrong name would otherwise enter the system, so every consumer
+// below (classification, the graph, the report) needs no alias-awareness of its own. See
+// RTECO-1882 / XRAY-157605: the same class of bug this fixes on the non-fallback path.
+func resolveNpmAliasEntries(entries []npmLogEntry) []npmLogEntry {
+	aliasToReal := map[string]string{}
+	for i, entry := range entries {
+		if realName, realSpec, ok := resolveNpmAliasTarget(entry.Specifier); ok {
+			aliasToReal[entry.Name] = realName
+			entries[i].Name = realName
+			entries[i].Specifier = realSpec
+		}
+	}
+	if len(aliasToReal) == 0 {
+		return entries
+	}
+	for i, entry := range entries {
+		if realParent, ok := aliasToReal[entry.ParentName]; ok {
+			entries[i].ParentName = realParent
+		}
+	}
+	return entries
+}
+
 // classifyBlankVersionEntry categorizes an npmLogEntry whose Version is blank (non-blank is
 // always npmEntryResolved). A range/wildcard/dist-tag is never treated as probeable even after
 // stripping its operator (e.g. "^2.0.0" -> "2.0.0") — that stripped value is a guess at what npm

--- a/commands/curation/npmlogparser_test.go
+++ b/commands/curation/npmlogparser_test.go
@@ -305,6 +305,79 @@ func TestClassifyBlankVersionEntry(t *testing.T) {
 	}
 }
 
+func TestResolveNpmAliasTarget(t *testing.T) {
+	tests := []struct {
+		spec        string
+		wantName    string
+		wantVersion string
+		wantOk      bool
+	}{
+		{"npm:strip-ansi@6.0.1", "strip-ansi", "6.0.1", true},
+		{"npm:strip-ansi@^6.0.1", "strip-ansi", "^6.0.1", true},
+		{"NPM:strip-ansi@6.0.1", "strip-ansi", "6.0.1", true}, // prefix match is case-insensitive
+		{"npm:@babel/code-frame@^7.24.7", "@babel/code-frame", "^7.24.7", true},
+		{"npm:strip-ansi", "", "", false},   // no '@' after the prefix at all
+		{"npm:", "", "", false},             // empty remainder
+		{"strip-ansi@6.0.1", "", "", false}, // not an alias at all
+		{"git+https://github.com/chalk/ansi-regex.git", "", "", false},
+	}
+	for _, tc := range tests {
+		name, version, ok := resolveNpmAliasTarget(tc.spec)
+		assert.Equal(t, tc.wantOk, ok, "spec %q", tc.spec)
+		assert.Equal(t, tc.wantName, name, "spec %q", tc.spec)
+		assert.Equal(t, tc.wantVersion, version, "spec %q", tc.spec)
+	}
+}
+
+// TestResolveNpmAliasEntries covers the exact shape of RTECO-1882 / XRAY-157605 reproduced in
+// npm's debug-log fallback: "strip-ansi-cjs": "npm:strip-ansi@6.0.1" is placeDep'd under the
+// alias name, but Artifactory's block notice for the real package can only ever be keyed
+// "strip-ansi" — so the rewrite must happen before classification ever runs.
+func TestResolveNpmAliasEntries(t *testing.T) {
+	entries := []npmLogEntry{
+		{Name: "strip-ansi-cjs", Version: "", ParentName: "myproj", ParentVersion: "1.0.0", Specifier: "npm:strip-ansi@6.0.1"},
+		// A transitive dependency of the aliased package — its ParentName must follow the rename.
+		{Name: "ansi-regex", Version: "5.0.1", ParentName: "strip-ansi-cjs", ParentVersion: "6.0.1"},
+		// Untouched: neither an alias itself nor a child of one.
+		{Name: "strip-ansi", Version: "7.2.0", ParentName: "myproj", ParentVersion: "1.0.0"},
+	}
+
+	resolved := resolveNpmAliasEntries(entries)
+
+	require.Len(t, resolved, 3)
+	assert.Equal(t, "strip-ansi", resolved[0].Name, "alias entry's own Name must become the real name")
+	assert.Equal(t, "6.0.1", resolved[0].Specifier, "alias entry's Specifier must become the inner version")
+	assert.Equal(t, "strip-ansi", resolved[1].ParentName, "a child of the alias must have its ParentName renamed too")
+	assert.Equal(t, "strip-ansi", resolved[2].Name, "an entry unrelated to the alias must be untouched")
+}
+
+// TestResolveNpmAliasEntriesLeavesMalformedAliasUntouched: an unparsable "npm:" specifier
+// (no '@') can't be resolved to a real package, so it must be left as-is — classifyNpmSpecifier
+// will still (correctly) treat it as non-registry rather than guessing at a target.
+func TestResolveNpmAliasEntriesLeavesMalformedAliasUntouched(t *testing.T) {
+	entries := []npmLogEntry{
+		{Name: "weird-cjs", Version: "", Specifier: "npm:strip-ansi"},
+	}
+	resolved := resolveNpmAliasEntries(entries)
+	assert.Equal(t, "weird-cjs", resolved[0].Name)
+	assert.Equal(t, "npm:strip-ansi", resolved[0].Specifier)
+}
+
+// TestClassifyBlankVersionEntryAfterAliasResolution proves the fix end to end at the
+// classification boundary: once resolveNpmAliasEntries has run, an aliased entry whose real
+// target is whole-package-blocked correctly classifies as npmEntryWholePackageBlocked instead
+// of npmEntryNonRegistrySpecifier — the exact misclassification reported live against a
+// "blocks open ssf" policy (RTECO-1882 / XRAY-157605).
+func TestClassifyBlankVersionEntryAfterAliasResolution(t *testing.T) {
+	blockedPackages := map[string]npmBlockedInfo{"strip-ansi": {Policy: "blocks open ssf", Condition: "open ssf"}}
+	entries := resolveNpmAliasEntries([]npmLogEntry{
+		{Name: "strip-ansi-cjs", Version: "", ParentName: "myproj", ParentVersion: "1.0.0", Specifier: "npm:strip-ansi@6.0.1"},
+	})
+	require.Len(t, entries, 1)
+	assert.Equal(t, npmEntryWholePackageBlocked, classifyBlankVersionEntry(entries[0], blockedPackages),
+		"an alias to a whole-package-blocked real package must not be reported as merely non-registry/not-evaluated")
+}
+
 func TestBuildGraphFromLogEntries(t *testing.T) {
 	entries := []npmLogEntry{
 		{Name: "express", Version: "5.2.1", ParentName: "myproj", ParentVersion: "1.0.0"},

--- a/sca/bom/buildinfo/technologies/pnpm/pnpm.go
+++ b/sca/bom/buildinfo/technologies/pnpm/pnpm.go
@@ -463,7 +463,7 @@ func parsePnpmLSContent(projectInfo []pnpmLsProject) (dependencyTrees []*xrayUti
 		// query Artifactory for a package that doesn't exist (404).
 		for name, dependency := range project.Dependencies {
 			if dependency.Local {
-				_ = uniqueDepsSet.Remove(getDependencyId(name, dependency.Version))
+				_ = uniqueDepsSet.Remove(getDependencyId(dependencyName(name, dependency), dependency.Version))
 			}
 		}
 	}
@@ -475,13 +475,13 @@ func createProjectDependenciesTree(project pnpmLsProject) map[string]xray.DepTre
 	treeMap := make(map[string]xray.DepTreeNode)
 	var directDependencies []string
 	for depName, dependency := range project.Dependencies {
-		directDependency := getDependencyId(depName, dependency.Version)
-		directDependencies = append(directDependencies, directDependency)
+		directDependency := getDependencyId(dependencyName(depName, dependency), dependency.Version)
+		directDependencies = appendUniqueChild(directDependencies, directDependency)
 		appendTransitiveDependencies(directDependency, dependency.Dependencies, &treeMap)
 	}
 	for depName, dependency := range project.DevDependencies {
-		directDependency := getDependencyId(depName, dependency.Version)
-		directDependencies = append(directDependencies, directDependency)
+		directDependency := getDependencyId(dependencyName(depName, dependency), dependency.Version)
+		directDependencies = appendUniqueChild(directDependencies, directDependency)
 		appendTransitiveDependencies(directDependency, dependency.Dependencies, &treeMap)
 	}
 	if len(directDependencies) > 0 {
@@ -494,11 +494,37 @@ func getDependencyId(depName, version string) string {
 	return techutils.Npm.GetXrayPackageTypeId() + depName + ":" + version
 }
 
+// appendUniqueChild appends candidateDependency unless it is already present. Two dependency
+// map keys can resolve to the same real name+version — e.g. a CJS/ESM alias pair both pointing
+// at "npm:strip-ansi@6.0.1" — and without this guard the duplicate ID is appended twice,
+// producing two identical sibling GraphNodes for what is really one installed package.
+func appendUniqueChild(children []string, candidateDependency string) []string {
+	for _, existingChild := range children {
+		if existingChild == candidateDependency {
+			return children
+		}
+	}
+	return append(children, candidateDependency)
+}
+
+// dependencyName returns the real registry package name for a dependency. Dependency maps
+// are keyed by the name the package is installed under, which for an aliased dependency
+// (e.g. "strip-ansi-cjs": "npm:strip-ansi@^6.0.1") is the alias rather than a package that
+// exists in the registry. Both sources report the real name in From — 'pnpm ls --json'
+// emits it as "from", and the lockfile parser resolves it from the ref — so From wins
+// whenever it is set.
+func dependencyName(key string, dep pnpmLsDependency) string {
+	if dep.From != "" {
+		return dep.From
+	}
+	return key
+}
+
 func appendTransitiveDependencies(parent string, dependencies map[string]pnpmLsDependency, result *map[string]xray.DepTreeNode) {
 	for depName, dependency := range dependencies {
-		dependencyId := getDependencyId(depName, dependency.Version)
+		dependencyId := getDependencyId(dependencyName(depName, dependency), dependency.Version)
 		if node, ok := (*result)[parent]; ok {
-			node.Children = append(node.Children, dependencyId)
+			node.Children = appendUniqueChild(node.Children, dependencyId)
 			(*result)[parent] = node
 		} else {
 			(*result)[parent] = xray.DepTreeNode{Children: []string{dependencyId}}

--- a/sca/bom/buildinfo/technologies/pnpm/pnpm_test.go
+++ b/sca/bom/buildinfo/technologies/pnpm/pnpm_test.go
@@ -1,6 +1,7 @@
 package pnpm
 
 import (
+	"encoding/json"
 	"errors"
 	"os"
 	"path/filepath"
@@ -289,6 +290,227 @@ func TestParsePnpmLSContentNestsWorkspaceMembers(t *testing.T) {
 	assert.NotContains(t, uniqueDeps, getDependencyId("packages/create-vite", "0.0.0"))
 	assert.Contains(t, uniqueDeps, getDependencyId("rolldown", "1.0.3"))
 	assert.Contains(t, uniqueDeps, getDependencyId("cross-spawn", "7.0.6"))
+}
+
+// TestParsePnpmLSContentUsesRealNameForAliases asserts that an aliased dependency is
+// identified by its real registry package name rather than the alias. 'pnpm ls --json'
+// reports the real name in "from" while keying the map by the alias, and the lockfile
+// parser resolves it the same way. Using the alias produces a component ID for a package
+// that does not exist, which 404s the curation HEAD-check and makes Xray find no
+// vulnerabilities for it.
+func TestParsePnpmLSContentUsesRealNameForAliases(t *testing.T) {
+	project := pnpmLsProject{
+		Name:    "alias-project",
+		Version: "1.0.0",
+		Dependencies: map[string]pnpmLsDependency{
+			"strip-ansi-cjs": {From: "strip-ansi", Version: "6.0.1"},
+			"my-babel":       {From: "@babel/code-frame", Version: "7.29.7"},
+			"strip-ansi":     {From: "strip-ansi", Version: "7.2.0"},
+		},
+		DevDependencies: map[string]pnpmLsDependency{
+			"wrap-ansi-cjs": {From: "wrap-ansi", Version: "7.0.0"},
+		},
+	}
+	trees, uniqueDeps := parsePnpmLSContent([]pnpmLsProject{project})
+	require.Len(t, trees, 1)
+
+	assert.Contains(t, uniqueDeps, getDependencyId("strip-ansi", "6.0.1"))
+	assert.Contains(t, uniqueDeps, getDependencyId("@babel/code-frame", "7.29.7"))
+	assert.Contains(t, uniqueDeps, getDependencyId("wrap-ansi", "7.0.0"))
+	assert.Contains(t, uniqueDeps, getDependencyId("strip-ansi", "7.2.0"))
+
+	// The alias itself must never reach Artifactory or Xray.
+	assert.NotContains(t, uniqueDeps, getDependencyId("strip-ansi-cjs", "6.0.1"))
+	assert.NotContains(t, uniqueDeps, getDependencyId("my-babel", "7.29.7"))
+	assert.NotContains(t, uniqueDeps, getDependencyId("wrap-ansi-cjs", "7.0.0"))
+
+	assert.NotNil(t, findNodeByID(trees[0], getDependencyId("strip-ansi", "6.0.1")),
+		"the aliased package must appear in the tree under its real name")
+}
+
+// TestParsePnpmLSContentAliasedTransitive asserts the real name is also used for
+// transitive dependencies, which are attached through a separate code path.
+func TestParsePnpmLSContentAliasedTransitive(t *testing.T) {
+	project := pnpmLsProject{
+		Name:    "alias-project",
+		Version: "1.0.0",
+		Dependencies: map[string]pnpmLsDependency{
+			"parent": {From: "parent", Version: "1.0.0", Dependencies: map[string]pnpmLsDependency{
+				"strip-ansi-cjs": {From: "strip-ansi", Version: "6.0.1"},
+			}},
+		},
+	}
+	trees, uniqueDeps := parsePnpmLSContent([]pnpmLsProject{project})
+	require.Len(t, trees, 1)
+
+	assert.Contains(t, uniqueDeps, getDependencyId("strip-ansi", "6.0.1"))
+	assert.NotContains(t, uniqueDeps, getDependencyId("strip-ansi-cjs", "6.0.1"))
+
+	parent := findNodeByID(trees[0], getDependencyId("parent", "1.0.0"))
+	require.NotNil(t, parent)
+	assert.NotNil(t, findNodeByID(parent, getDependencyId("strip-ansi", "6.0.1")),
+		"the aliased transitive must be nested under its parent under the real name")
+}
+
+// TestPnpmLockfileAliasEndToEnd exercises the full curation pipeline for an aliased dependency —
+// pnpm-lock.yaml -> parsePnpmLockFile -> parsePnpmLSContent -> uniqueDeps — using the exact
+// lockfile shape pnpm 10 writes for "strip-ansi-cjs": "npm:strip-ansi@^6.0.1" (verified against a
+// real `pnpm install`). The two stages are covered individually elsewhere (pnpmlock_test.go
+// asserts From is set; pnpm_test.go asserts IDs from a hand-built pnpmLsProject), but neither
+// proves the two are actually wired together. A regression here — e.g. resolveRefName stops
+// setting From, or dependencyName stops reading it — would silently reintroduce the alias bug
+// this pipeline exists to fix, without failing either narrower test.
+func TestPnpmLockfileAliasEndToEnd(t *testing.T) {
+	dir := t.TempDir()
+	lock := "lockfileVersion: '9.0'\n" +
+		"importers:\n" +
+		"  .:\n" +
+		"    dependencies:\n" +
+		"      strip-ansi:\n" +
+		"        specifier: ^7.0.1\n" +
+		"        version: 7.2.0\n" +
+		"      strip-ansi-cjs:\n" +
+		"        specifier: npm:strip-ansi@^6.0.1\n" +
+		"        version: strip-ansi@6.0.1\n" +
+		"snapshots:\n" +
+		"  strip-ansi@7.2.0:\n" +
+		"    dependencies:\n" +
+		"      ansi-regex: 6.2.2\n" +
+		"  strip-ansi@6.0.1:\n" +
+		"    dependencies:\n" +
+		"      ansi-regex: 5.0.1\n" +
+		"  ansi-regex@6.2.2: {}\n" +
+		"  ansi-regex@5.0.1: {}\n"
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "pnpm-lock.yaml"), []byte(lock), 0o644))
+
+	projects, err := parsePnpmLockFile(dir, ".")
+	require.NoError(t, err)
+	require.Len(t, projects, 1)
+
+	trees, uniqueDeps := parsePnpmLSContent(projects)
+	require.Len(t, trees, 1)
+
+	assert.Contains(t, uniqueDeps, getDependencyId("strip-ansi", "6.0.1"),
+		"the aliased direct dependency must reach uniqueDeps under its real name")
+	assert.Contains(t, uniqueDeps, getDependencyId("ansi-regex", "5.0.1"),
+		"the aliased dependency's own transitive must reach uniqueDeps")
+	assert.NotContains(t, uniqueDeps, getDependencyId("strip-ansi-cjs", "6.0.1"),
+		"the alias itself must never reach Artifactory or Xray")
+
+	aliasedNode := findNodeByID(trees[0], getDependencyId("strip-ansi", "6.0.1"))
+	require.NotNil(t, aliasedNode, "the aliased package must appear in the tree under its real name")
+	assert.NotNil(t, findNodeByID(aliasedNode, getDependencyId("ansi-regex", "5.0.1")),
+		"the aliased transitive must be nested under the aliased package's real-name node")
+}
+
+// TestPnpmLsJSONAliasEndToEnd exercises the JSON half of the curation pipeline for an aliased
+// dependency — a literal `pnpm ls --json` payload -> json.Unmarshal into []pnpmLsProject ->
+// parsePnpmLSContent -> uniqueDeps — using the same field shape calculateDependencies unmarshals
+// in production (pnpm.go:161-163). TestPnpmLockfileAliasEndToEnd covers the equivalent YAML/
+// lockfile boundary via a real yaml.Unmarshal; this is its JSON counterpart. The fix hinges on
+// the `json:"from"` struct tag on pnpmLsDependency — a test that builds pnpmLsProject/
+// pnpmLsDependency directly in Go, as the narrower alias tests do, would keep passing even if
+// that tag were wrong, since it never exercises encoding/json at all.
+func TestPnpmLsJSONAliasEndToEnd(t *testing.T) {
+	// Field names and nesting match real `pnpm ls --depth Infinity --json --long` output,
+	// captured against pnpm 10 for "strip-ansi-cjs": "npm:strip-ansi@^6.0.1". Extra fields
+	// pnpm emits (resolved, path, ...) are included to prove they don't interfere with
+	// unmarshalling into the narrower pnpmLsProject/pnpmLsDependency shape.
+	lsJSON := `[
+	  {
+	    "name": "alias-json-project",
+	    "version": "1.0.0",
+	    "dependencies": {
+	      "strip-ansi": {
+	        "from": "strip-ansi",
+	        "version": "7.2.0",
+	        "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+	        "dependencies": {
+	          "ansi-regex": {"from": "ansi-regex", "version": "6.2.2"}
+	        }
+	      },
+	      "strip-ansi-cjs": {
+	        "from": "strip-ansi",
+	        "version": "6.0.1",
+	        "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+	        "dependencies": {
+	          "ansi-regex": {"from": "ansi-regex", "version": "5.0.1"}
+	        }
+	      }
+	    }
+	  }
+	]`
+
+	var projects []pnpmLsProject
+	require.NoError(t, json.Unmarshal([]byte(lsJSON), &projects))
+	require.Len(t, projects, 1)
+	require.Contains(t, projects[0].Dependencies, "strip-ansi-cjs")
+	assert.Equal(t, "strip-ansi", projects[0].Dependencies["strip-ansi-cjs"].From,
+		"json:\"from\" must unmarshal into the From field")
+
+	trees, uniqueDeps := parsePnpmLSContent(projects)
+	require.Len(t, trees, 1)
+
+	assert.Contains(t, uniqueDeps, getDependencyId("strip-ansi", "6.0.1"),
+		"the aliased direct dependency must reach uniqueDeps under its real name")
+	assert.Contains(t, uniqueDeps, getDependencyId("ansi-regex", "5.0.1"),
+		"the aliased dependency's own transitive must reach uniqueDeps")
+	assert.NotContains(t, uniqueDeps, getDependencyId("strip-ansi-cjs", "6.0.1"),
+		"the alias itself must never reach Artifactory or Xray")
+
+	aliasedNode := findNodeByID(trees[0], getDependencyId("strip-ansi", "6.0.1"))
+	require.NotNil(t, aliasedNode, "the aliased package must appear in the tree under its real name")
+	assert.NotNil(t, findNodeByID(aliasedNode, getDependencyId("ansi-regex", "5.0.1")),
+		"the aliased transitive must be nested under the aliased package's real-name node")
+}
+
+// TestParsePnpmLSContentDuplicateSiblingOnAliasCollision covers two aliases resolving to the
+// same real name+version (e.g. a CJS/ESM split like "strip-ansi-cjs"/"strip-ansi-esm" both
+// pointing at "npm:strip-ansi@6.0.1"). Both keys survive dependencyName resolution as the same
+// dependency ID, so appending both unconditionally produces two identical sibling GraphNodes
+// under the same parent — the tree misrepresents the package as installed twice.
+func TestParsePnpmLSContentDuplicateSiblingOnAliasCollision(t *testing.T) {
+	project := pnpmLsProject{
+		Name:    "alias-collision-project",
+		Version: "1.0.0",
+		Dependencies: map[string]pnpmLsDependency{
+			"strip-ansi-cjs": {From: "strip-ansi", Version: "6.0.1"},
+			"strip-ansi-esm": {From: "strip-ansi", Version: "6.0.1"},
+		},
+	}
+	trees, uniqueDeps := parsePnpmLSContent([]pnpmLsProject{project})
+	require.Len(t, trees, 1)
+
+	realID := getDependencyId("strip-ansi", "6.0.1")
+	assert.Contains(t, uniqueDeps, realID)
+
+	var childIDs []string
+	for _, c := range trees[0].Nodes {
+		childIDs = append(childIDs, c.Id)
+	}
+	assert.Len(t, childIDs, 1, "expected one deduped sibling, got: %v", childIDs)
+}
+
+// TestAppendTransitiveDependenciesDuplicateSiblingOnAliasCollision covers the same collision
+// one level down: two aliased transitives of the same parent resolving to the same real
+// name+version must not produce duplicate sibling nodes under that parent either.
+func TestAppendTransitiveDependenciesDuplicateSiblingOnAliasCollision(t *testing.T) {
+	project := pnpmLsProject{
+		Name:    "alias-collision-transitive",
+		Version: "1.0.0",
+		Dependencies: map[string]pnpmLsDependency{
+			"parent": {From: "parent", Version: "1.0.0", Dependencies: map[string]pnpmLsDependency{
+				"strip-ansi-cjs": {From: "strip-ansi", Version: "6.0.1"},
+				"strip-ansi-esm": {From: "strip-ansi", Version: "6.0.1"},
+			}},
+		},
+	}
+	trees, _ := parsePnpmLSContent([]pnpmLsProject{project})
+	require.Len(t, trees, 1)
+
+	parent := findNodeByID(trees[0], getDependencyId("parent", "1.0.0"))
+	require.NotNil(t, parent)
+	assert.Len(t, parent.Nodes, 1, "expected one deduped sibling under parent, got: %v", parent.Nodes)
 }
 
 // TestResolveWorkspaceRoot covers the three cases: a standalone project (no marker),

--- a/sca/bom/buildinfo/technologies/pnpm/pnpmlock.go
+++ b/sca/bom/buildinfo/technologies/pnpm/pnpmlock.go
@@ -151,11 +151,11 @@ func buildDepsMap(deps map[string]pnpmLockDep, snapshots map[string]pnpmLockSnap
 		// dep.Version may contain a peer-dep suffix: "2.0.0(@peer/dep@1.0.0)"
 		// Strip it for the Xray ID; keep the raw form for snapshot lookup.
 		rawRef := dep.Version
-		_, cleanVersion := splitPnpmRef(rawRef)
+		realName, cleanVersion := resolveRefName(name, rawRef)
 		depKey := buildSnapshotKey(name, rawRef)
 
 		entry := pnpmLsDependency{
-			From:    name,
+			From:    realName,
 			Version: cleanVersion,
 		}
 		if !visited[depKey] {
@@ -176,10 +176,10 @@ func walkSnapshot(snapshotKey string, snapshots map[string]pnpmLockSnapshot, vis
 	}
 	result := make(map[string]pnpmLsDependency)
 	for name, rawRef := range snap.Dependencies {
-		_, cleanVersion := splitPnpmRef(rawRef)
+		realName, cleanVersion := resolveRefName(name, rawRef)
 		childKey := buildSnapshotKey(name, rawRef)
 		entry := pnpmLsDependency{
-			From:    name,
+			From:    realName,
 			Version: cleanVersion,
 		}
 		if !visited[childKey] {
@@ -190,6 +190,20 @@ func walkSnapshot(snapshotKey string, snapshots map[string]pnpmLockSnapshot, vis
 		result[name] = entry
 	}
 	return result
+}
+
+// resolveRefName returns the real registry package name and version for a dependency.
+// An aliased dependency ("strip-ansi-cjs": "npm:strip-ansi@^6.0.1") is recorded with the
+// alias as the map key and the real package in the ref ("strip-ansi@6.0.1"), so the ref
+// wins. A plain version ref carries no name, in which case the key is already the real
+// name. Getting this wrong yields a component ID for a package that does not exist, which
+// 404s the curation HEAD-check and leaves Xray with nothing to match.
+func resolveRefName(key, rawRef string) (name, version string) {
+	name, version = splitPnpmRef(rawRef)
+	if name == "" {
+		name = key
+	}
+	return
 }
 
 // splitPnpmRef splits a pnpm ref into (name, version), stripping any peer-dep suffix.

--- a/sca/bom/buildinfo/technologies/pnpm/pnpmlock_test.go
+++ b/sca/bom/buildinfo/technologies/pnpm/pnpmlock_test.go
@@ -184,6 +184,54 @@ func TestSplitPnpmRef(t *testing.T) {
 	}
 }
 
+// TestBuildDepsMapResolvesAliases covers aliased dependencies
+// (e.g. "strip-ansi-cjs": "npm:strip-ansi@^6.0.1"), where the importers-block key is the
+// alias while the ref carries the real registry package. The map stays keyed by the alias
+// (that is the node_modules identity), but From must hold the real name so the Xray
+// component ID and the Artifactory download URL point at a package that actually exists.
+func TestBuildDepsMapResolvesAliases(t *testing.T) {
+	deps := map[string]pnpmLockDep{
+		"strip-ansi-cjs": {Specifier: "npm:strip-ansi@^6.0.1", Version: "strip-ansi@6.0.1"},
+		"my-babel":       {Specifier: "npm:@babel/code-frame@^7.24.7", Version: "@babel/code-frame@7.29.7"},
+		"strip-ansi":     {Specifier: "^7.0.1", Version: "7.2.0"},
+	}
+	got := buildDepsMap(deps, nil, map[string]bool{})
+
+	require.Contains(t, got, "strip-ansi-cjs")
+	assert.Equal(t, "strip-ansi", got["strip-ansi-cjs"].From, "alias must resolve to the real package name")
+	assert.Equal(t, "6.0.1", got["strip-ansi-cjs"].Version)
+
+	// An alias whose target is scoped must keep its scope.
+	require.Contains(t, got, "my-babel")
+	assert.Equal(t, "@babel/code-frame", got["my-babel"].From)
+	assert.Equal(t, "7.29.7", got["my-babel"].Version)
+
+	// A regular dependency is unaffected: the key is already the real name.
+	require.Contains(t, got, "strip-ansi")
+	assert.Equal(t, "strip-ansi", got["strip-ansi"].From)
+	assert.Equal(t, "7.2.0", got["strip-ansi"].Version)
+}
+
+// TestWalkSnapshotResolvesAliases covers the same aliasing, one level down: a package
+// may itself depend on an aliased package, recorded in the snapshots block.
+func TestWalkSnapshotResolvesAliases(t *testing.T) {
+	snapshots := map[string]pnpmLockSnapshot{
+		"parent@1.0.0": {Dependencies: map[string]string{
+			"strip-ansi-cjs": "strip-ansi@6.0.1",
+			"ansi-regex":     "5.0.1",
+		}},
+	}
+	got := walkSnapshot("parent@1.0.0", snapshots, map[string]bool{})
+
+	require.Contains(t, got, "strip-ansi-cjs")
+	assert.Equal(t, "strip-ansi", got["strip-ansi-cjs"].From, "transitive alias must resolve to the real package name")
+	assert.Equal(t, "6.0.1", got["strip-ansi-cjs"].Version)
+
+	require.Contains(t, got, "ansi-regex")
+	assert.Equal(t, "ansi-regex", got["ansi-regex"].From)
+	assert.Equal(t, "5.0.1", got["ansi-regex"].Version)
+}
+
 // TestValidateLockfileVersion ensures only lockfileVersion 9.0+ (the 'snapshots'
 // format this parser understands) is accepted, and older formats are rejected
 // rather than silently yielding an incomplete dependency tree.


### PR DESCRIPTION
- [ ] The pull request is targeting the `dev` branch.
- [ ] The code has been validated to compile successfully by running `go vet ./...`.
- [ ] The code has been formatted properly using `go fmt ./...`.
- [ ] All [static analysis checks](https://github.com/jfrog/jfrog-cli-security/actions/workflows/analysis.yml) passed.
- [ ] All [tests](https://github.com/jfrog/jfrog-cli-security/actions/workflows/test.yml) have passed. If this feature is not already covered by the tests, new tests have been added.
- [ ] Updated the [Contributing page](https://github.com/jfrog/jfrog-cli-security/blob/main/CONTRIBUTING.md) / [ReadMe page](https://github.com/jfrog/jfrog-cli-security/blob/main/README.md) / [CI Workflow files](https://github.com/jfrog/jfrog-cli-security/tree/main/.github/workflows) if needed.
- [ ] All changes are detailed at the description. if not already covered at [JFrog Documentation](https://github.com/jfrog/documentation), new documentation have been added.

-----

pnpm aliases install a package under a different local name:

"strip-ansi-cjs": "npm:strip-ansi@^6.0.1"
Both pnpm tree builders used the map key — the alias — as the package name, producing a component ID for a package that exists in no registry.

The real name was already available in both paths and simply unused:

curation parses pnpm-lock.yaml, where the ref held the real name and it was discarded audit runs pnpm ls --json, which reports it as "from" — a field read nowhere in the repo. Both now resolve it into From, and the tree builders prefer it, so one change fixes both paths.

Before:
<img width="1624" height="222" alt="Screenshot 2026-08-10 at 12 36 44 PM" src="https://github.com/user-attachments/assets/f8e30c24-c276-4b38-9ac4-b19684165521" />

After:
<img width="1175" height="299" alt="Screenshot 2026-08-10 at 12 37 41 PM" src="https://github.com/user-attachments/assets/841d0913-a582-4ecf-926d-94adc7d1af81" />
