### PR TITLE
Fix incorrect WD in rollback mechanism for npm and pnpm

### DIFF
--- a/remediation/sca/packageupdaters/commonpackageupdater_test.go
+++ b/remediation/sca/packageupdaters/commonpackageupdater_test.go
@@ -28,6 +28,8 @@ type dependencyFixTest struct {
 	lockFileToVerifyItsChange string
 	// Verifies descriptor content is unchanged after error (for rollback testing)
 	descriptorToVerifyNoChange string
+	// Overrides the default "remediation"/"indirect-project" subdirectory picked by projectSubdir
+	projectSubDir string
 }
 
 const (
@@ -124,10 +126,18 @@ func TestUpdateDependency(t *testing.T) {
 			{
 				testcaseInfo:               "rollback-on-npm-install-failure",
 				fixDetails:                 createFixDetails(techutils.Npm, "minimist", "1.2.5", "1.2.6", true, "package.json", "package-lock.json"),
-				testDirName:                "npm-rollback",
+				projectSubDir:              "remediation-rollback",
 				fixSupported:               true,
 				errorExpected:              true,
 				descriptorToVerifyNoChange: "package.json",
+			},
+			{
+				testcaseInfo:               "rollback-on-npm-install-failure-nested-descriptor",
+				fixDetails:                 createFixDetails(techutils.Npm, "minimist", "1.2.5", "1.2.6", true, filepath.Join("app", "package.json"), filepath.Join("app", "package-lock.json")),
+				projectSubDir:              "remediation-rollback-nested",
+				fixSupported:               true,
+				errorExpected:              true,
+				descriptorToVerifyNoChange: filepath.Join("app", "package.json"),
 			},
 		},
 
@@ -169,7 +179,7 @@ func TestUpdateDependency(t *testing.T) {
 					if test.testDirName != "" {
 						testDirName = test.testDirName
 					}
-					cleanup := createTempDirAndChdir(t, testDirName+test.specificTechVersion, test.fixDetails.IsDirectDependency)
+					cleanup := createTempDirAndChdir(t, testDirName+test.specificTechVersion, test.fixDetails.IsDirectDependency, test.projectSubDir)
 					defer cleanup()
 
 					var lockFileContentBeforeUpdate []byte
@@ -224,8 +234,11 @@ func projectSubdir(directDependency bool) string {
 	return "indirect-project"
 }
 
-func createTempDirAndChdir(t *testing.T, tech string, directDependency bool) func() {
+func createTempDirAndChdir(t *testing.T, tech string, directDependency bool, subDirOverride string) func() {
 	subdir := projectSubdir(directDependency)
+	if subDirOverride != "" {
+		subdir = subDirOverride
+	}
 	projectPath := filepath.Join("..", "..", "..", "tests", "testdata", "projects", "package-managers", tech, subdir)
 	tmpProjectPath, cleanup := tests.CreateTestProject(t, projectPath)
 	currDir, err := os.Getwd()

--- a/remediation/sca/packageupdaters/npmpackageupdater.go
+++ b/remediation/sca/packageupdaters/npmpackageupdater.go
@@ -112,7 +112,7 @@ func (npm *NpmPackageUpdater) regenerateLockfile(fixDetails *FixDetails, descrip
 		if err := npm.regenerateLockFileWithRetry(); err != nil {
 			log.Warn(fmt.Sprintf("Failed to regenerate lock file after updating '%s' to version '%s': %s. Rolling back...", fixDetails.ImpactedDependencyName, fixDetails.SuggestedFixedVersion, err.Error()))
 			//#nosec G306 -- 0644 is correct for a checked-out source file.
-			if rollbackErr := os.WriteFile(descriptorPath, backupContent, 0644); rollbackErr != nil {
+			if rollbackErr := os.WriteFile(filepath.Base(descriptorPath), backupContent, 0644); rollbackErr != nil {
 				return fmt.Errorf("failed to rollback descriptor after lock file regeneration failure: %w (original error: %v)", rollbackErr, err)
 			}
 			return err

--- a/remediation/sca/packageupdaters/pnpmpackageupdater.go
+++ b/remediation/sca/packageupdaters/pnpmpackageupdater.go
@@ -115,7 +115,7 @@ func (pnpm *PnpmPackageUpdater) regenerateLockfile(fixDetails *FixDetails, descr
 		if err := pnpm.runPnpmInstallLockOnly(); err != nil {
 			log.Warn(fmt.Sprintf("Failed to regenerate lock file after updating '%s' to version '%s': %s. Rolling back...", fixDetails.ImpactedDependencyName, fixDetails.SuggestedFixedVersion, err.Error()))
 			//#nosec G306 -- 0644 is correct for a checked-out source file.
-			if rollbackErr := os.WriteFile(descriptorPath, backupContent, 0644); rollbackErr != nil {
+			if rollbackErr := os.WriteFile(filepath.Base(descriptorPath), backupContent, 0644); rollbackErr != nil {
 				return fmt.Errorf("failed to rollback descriptor after lock file regeneration failure: %w (original error: %v)", rollbackErr, err)
 			}
 			return err

--- a/tests/testdata/projects/package-managers/npm/remediation-rollback-nested/app/package-lock.json
+++ b/tests/testdata/projects/package-managers/npm/remediation-rollback-nested/app/package-lock.json
@@ -1,0 +1,23 @@
+{
+  "name": "npm-rollback-nested-test",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "npm-rollback-nested-test",
+      "version": "1.0.0",
+      "license": "ISC",
+      "dependencies": {
+        "minimist": "1.2.5",
+        "this-package-does-not-exist-frogbot-test": "1.0.0"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+      "license": "MIT"
+    }
+  }
+}

--- a/tests/testdata/projects/package-managers/npm/remediation-rollback-nested/app/package.json
+++ b/tests/testdata/projects/package-managers/npm/remediation-rollback-nested/app/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "npm-rollback-nested-test",
+  "version": "1.0.0",
+  "description": "Test project for rollback functionality when the descriptor lives in a subdirectory relative to the working root",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "minimist": "1.2.5",
+    "this-package-does-not-exist-frogbot-test": "1.0.0"
+  }
+}


### PR DESCRIPTION
- [ ] The pull request is targeting the `dev` branch.
- [ ] The code has been validated to compile successfully by running `go vet ./...`.
- [ ] The code has been formatted properly using `go fmt ./...`.
- [ ] All [static analysis checks](https://github.com/jfrog/jfrog-cli-security/actions/workflows/analysis.yml) passed.
- [ ] All [tests](https://github.com/jfrog/jfrog-cli-security/actions/workflows/test.yml) have passed. If this feature is not already covered by the tests, new tests have been added.
- [ ] Updated the [Contributing page](https://github.com/jfrog/jfrog-cli-security/blob/main/CONTRIBUTING.md) / [ReadMe page](https://github.com/jfrog/jfrog-cli-security/blob/main/README.md) / [CI Workflow files](https://github.com/jfrog/jfrog-cli-security/tree/main/.github/workflows) if needed.
- [ ] All changes are detailed at the description. if not already covered at [JFrog Documentation](https://github.com/jfrog/documentation), new documentation have been added.

-----
This PR corrects the rollback mechanism for npm and pnpm. Before we attempt to even regenerate the lock file we cd to the descriptor's dir in withDescriptorWorkingDir, and we cd back only after the rollback attempt (if exists).
So far the code tried to write the backup content to the descriptors root-relative path when we are already in dir where the lock file exists, which caused an error (file not found).
The fix simply fixes the path so the backup will be written to a correct path, and adds a test that can catch this scenario