### PR TITLE
XRAY-156537 - Keep sbom-enrich running when a vulnerability has no CVE

### DIFF
--- a/commands/enrich/enrich.go
+++ b/commands/enrich/enrich.go
@@ -71,6 +71,13 @@ func getScaScanFileName(cmdResults *results.SecurityCommandResults) string {
 	return ""
 }
 
+func vulnerabilityId(vuln services.Vulnerability) string {
+	if len(vuln.Cves) > 0 && vuln.Cves[0].Id != "" {
+		return vuln.Cves[0].Id
+	}
+	return vuln.IssueId
+}
+
 func AppendVulnsToJson(cmdResults *results.SecurityCommandResults) error {
 	fileName := getScaScanFileName(cmdResults)
 	fileContent, err := os.ReadFile(fileName)
@@ -91,7 +98,7 @@ func AppendVulnsToJson(cmdResults *results.SecurityCommandResults) error {
 	}
 	for _, vuln := range xrayResults[0].Vulnerabilities {
 		for component := range vuln.Components {
-			vulnerability := map[string]string{"bom-ref": component, "id": vuln.Cves[0].Id}
+			vulnerability := map[string]string{"bom-ref": component, "id": vulnerabilityId(vuln)}
 			vulnerabilities = append(vulnerabilities, vulnerability)
 		}
 	}
@@ -119,7 +126,7 @@ func AppendVulnsToXML(cmdResults *results.SecurityCommandResults) error {
 			addVuln := vulns.CreateElement("vulnerability")
 			addVuln.CreateAttr("bom-ref", component)
 			id := addVuln.CreateElement("id")
-			id.CreateText(vuln.Cves[0].Id)
+			id.CreateText(vulnerabilityId(vuln))
 		}
 	}
 	result.IndentTabs()

--- a/commands/enrich/enrich_test.go
+++ b/commands/enrich/enrich_test.go
@@ -56,7 +56,7 @@ const componentRef = "pkg:maven/xerces/xercesImpl@2.11.0"
 
 // resultsWithNonCveVuln builds a scan result carrying a single vulnerability that has no CVE,
 // only an Xray issue id - the shape that used to crash AppendVulnsToJson/AppendVulnsToXML.
-func resultsWithNonCveVuln(t *testing.T, inputFile string) *results.SecurityCommandResults {
+func resultsWithNonCveVuln(inputFile string) *results.SecurityCommandResults {
 	cmdResults := results.NewCommandResults(utils.SBOM)
 	cmdResults.NewScanResults(results.ScanTarget{Target: inputFile}).ScaScanResults(0, services.ScanResponse{
 		Vulnerabilities: []services.Vulnerability{{
@@ -80,7 +80,7 @@ func TestAppendVulnsToJsonNonCveVuln(t *testing.T) {
 	require.NoError(t, os.WriteFile(inputFile, []byte(`{"bomFormat":"CycloneDX"}`), 0644))
 
 	buf := captureOutput(t)
-	require.NoError(t, AppendVulnsToJson(resultsWithNonCveVuln(t, inputFile)))
+	require.NoError(t, AppendVulnsToJson(resultsWithNonCveVuln(inputFile)))
 
 	output := buf.String()
 	assert.Contains(t, output, "XRAY-87173")
@@ -92,7 +92,7 @@ func TestAppendVulnsToXMLNonCveVuln(t *testing.T) {
 	require.NoError(t, os.WriteFile(inputFile, []byte(`<?xml version="1.0" encoding="UTF-8"?><bom></bom>`), 0644))
 
 	buf := captureOutput(t)
-	require.NoError(t, AppendVulnsToXML(resultsWithNonCveVuln(t, inputFile)))
+	require.NoError(t, AppendVulnsToXML(resultsWithNonCveVuln(inputFile)))
 
 	output := buf.String()
 	assert.Contains(t, output, "XRAY-87173")

--- a/commands/enrich/enrich_test.go
+++ b/commands/enrich/enrich_test.go
@@ -1,0 +1,100 @@
+package enrich
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/jfrog/jfrog-cli-security/utils"
+	"github.com/jfrog/jfrog-cli-security/utils/results"
+	"github.com/jfrog/jfrog-client-go/utils/log"
+	"github.com/jfrog/jfrog-client-go/xray/services"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestVulnerabilityId(t *testing.T) {
+	testCases := []struct {
+		name     string
+		vuln     services.Vulnerability
+		expected string
+	}{
+		{
+			name: "prefers first CVE when present",
+			vuln: services.Vulnerability{
+				IssueId: "XRAY-1",
+				Cves:    []services.Cve{{Id: "CVE-2020-1"}, {Id: "CVE-2020-2"}},
+			},
+			expected: "CVE-2020-1",
+		},
+		{
+			name: "falls back to IssueId when Cves empty",
+			vuln: services.Vulnerability{
+				IssueId: "XRAY-87173",
+				Cves:    nil,
+			},
+			expected: "XRAY-87173",
+		},
+		{
+			name: "falls back to IssueId when first CVE id empty",
+			vuln: services.Vulnerability{
+				IssueId: "XRAY-2",
+				Cves:    []services.Cve{{Id: ""}},
+			},
+			expected: "XRAY-2",
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.expected, vulnerabilityId(tc.vuln))
+		})
+	}
+}
+
+const componentRef = "pkg:maven/xerces/xercesImpl@2.11.0"
+
+// resultsWithNonCveVuln builds a scan result carrying a single vulnerability that has no CVE,
+// only an Xray issue id - the shape that used to crash AppendVulnsToJson/AppendVulnsToXML.
+func resultsWithNonCveVuln(t *testing.T, inputFile string) *results.SecurityCommandResults {
+	cmdResults := results.NewCommandResults(utils.SBOM)
+	cmdResults.NewScanResults(results.ScanTarget{Target: inputFile}).ScaScanResults(0, services.ScanResponse{
+		Vulnerabilities: []services.Vulnerability{{
+			IssueId:    "XRAY-87173",
+			Components: map[string]services.Component{componentRef: {}},
+		}},
+	})
+	return cmdResults
+}
+
+func captureOutput(t *testing.T) *bytes.Buffer {
+	var buf bytes.Buffer
+	origLogger := log.Logger
+	log.SetLogger(log.NewLogger(log.INFO, &buf))
+	t.Cleanup(func() { log.SetLogger(origLogger) })
+	return &buf
+}
+
+func TestAppendVulnsToJsonNonCveVuln(t *testing.T) {
+	inputFile := filepath.Join(t.TempDir(), "sbom.json")
+	require.NoError(t, os.WriteFile(inputFile, []byte(`{"bomFormat":"CycloneDX"}`), 0644))
+
+	buf := captureOutput(t)
+	require.NoError(t, AppendVulnsToJson(resultsWithNonCveVuln(t, inputFile)))
+
+	output := buf.String()
+	assert.Contains(t, output, "XRAY-87173")
+	assert.Contains(t, output, componentRef)
+}
+
+func TestAppendVulnsToXMLNonCveVuln(t *testing.T) {
+	inputFile := filepath.Join(t.TempDir(), "sbom.xml")
+	require.NoError(t, os.WriteFile(inputFile, []byte(`<?xml version="1.0" encoding="UTF-8"?><bom></bom>`), 0644))
+
+	buf := captureOutput(t)
+	require.NoError(t, AppendVulnsToXML(resultsWithNonCveVuln(t, inputFile)))
+
+	output := buf.String()
+	assert.Contains(t, output, "XRAY-87173")
+	assert.Contains(t, output, componentRef)
+}


### PR DESCRIPTION
https://jfrog-int.atlassian.net/browse/XRAY-156537

# Background

Customers pipe `jf audit --format cyclonedx` into `jf se` (`sbom-enrich`) in CI to produce an enriched CycloneDX SBOM. When Xray returns a High+ advisory that has only an Xray ID and no CVE, the enrich step panics and aborts the whole pipeline with no partial output.

# Description

`AppendVulnsToJson` / `AppendVulnsToXML` assumed every vulnerability had a non-empty `Cves` slice. A shared `vulnerabilityId` helper now prefers the first CVE id and falls back to `IssueId` when `Cves` is empty, so Xray-only advisories are written into the SBOM instead of crashing the command.

# Tests

- Unit: `TestVulnerabilityId`, `TestAppendVulnsToJsonNonCveVuln`, `TestAppendVulnsToXMLNonCveVuln` — empty-`Cves` / `IssueId`-only input, the shape that used to panic.
- Live A/B of a locally built CLI against the released one, on a `xercesImpl@2.11.0` SBOM (JSON and XML): released panics at `enrich.go:94`, fixed exits 0 and emits `XRAY-87173` alongside the CVE-mapped ids.

- [x] The pull request is targeting the `dev` branch.
- [x] The code has been validated to compile successfully by running `go vet ./...`.
- [x] The code has been formatted properly using `go fmt ./...`.
- [ ] All [static analysis checks](https://github.com/jfrog/jfrog-cli-security/actions/workflows/analysis.yml) passed.
- [x] All [tests](https://github.com/jfrog/jfrog-cli-security/actions/workflows/test.yml) have passed. If this feature is not already covered by the tests, new tests have been added.
- [ ] Updated the [Contributing page](https://github.com/jfrog/jfrog-cli-security/blob/main/CONTRIBUTING.md) / [ReadMe page](https://github.com/jfrog/jfrog-cli-security/blob/main/README.md) / [CI Workflow files](https://github.com/jfrog/jfrog-cli-security/tree/main/.github/workflows) if needed.
- [x] All changes are detailed at the description. if not already covered at [JFrog Documentation](https://github.com/jfrog/documentation), new documentation have been added.

Made with [Cursor](https://cursor.com)