### PR TITLE
XRAY-157127 - Keep each package manager resolving against its own Artifactory repo

### DIFF
--- a/sca/bom/buildinfo/buildinfobom.go
+++ b/sca/bom/buildinfo/buildinfobom.go
@@ -157,12 +157,12 @@ func (b *BuildInfoBomGenerator) buildDependencyTree(scan results.ScanTarget) (*D
 	hasAnyTree := false
 	for _, tech := range techs {
 		log.Debug(fmt.Sprintf("Generating '%s' dependency tree for '%s'...", tech.ToFormal(), scan.Target))
-		serverDetails, err := SetResolutionRepoInParamsIfExists(&b.params, tech)
+		techParams, serverDetails, err := b.resolveTechParams(tech)
 		if err != nil {
 			buildErr = errors.Join(buildErr, fmt.Errorf("failed to set resolution repo in params: %w", err))
 			continue
 		}
-		treeResult, err := GetTechDependencyTree(b.params, serverDetails, tech)
+		treeResult, err := GetTechDependencyTree(techParams, serverDetails, tech)
 		if err != nil {
 			buildErr = errors.Join(buildErr, fmt.Errorf("failed while building '%s' dependency tree: %w", tech, err))
 			continue
@@ -181,6 +181,12 @@ func (b *BuildInfoBomGenerator) buildDependencyTree(scan results.ScanTarget) (*D
 		return nil, errorutils.CheckErrorf("no dependencies were found. Please try to build your project and re-run the audit command")
 	}
 	return merged, buildErr
+}
+
+func (b *BuildInfoBomGenerator) resolveTechParams(tech techutils.Technology) (techParams technologies.BuildInfoBomGeneratorParams, serverDetails *config.ServerDetails, err error) {
+	techParams = b.params
+	serverDetails, err = SetResolutionRepoInParamsIfExists(&techParams, tech)
+	return
 }
 
 func mergeResults(existing, additional *DependencyTreeResult) *DependencyTreeResult {

--- a/sca/bom/buildinfo/buildinfobom.go
+++ b/sca/bom/buildinfo/buildinfobom.go
@@ -185,6 +185,10 @@ func (b *BuildInfoBomGenerator) buildDependencyTree(scan results.ScanTarget) (*D
 
 func (b *BuildInfoBomGenerator) resolveTechParams(tech techutils.Technology) (techParams technologies.BuildInfoBomGeneratorParams, serverDetails *config.ServerDetails, err error) {
 	techParams = b.params
+	if b.params.ServerDetails != nil {
+		copied := *b.params.ServerDetails
+		techParams.ServerDetails = &copied
+	}
 	serverDetails, err = SetResolutionRepoInParamsIfExists(&techParams, tech)
 	return
 }

--- a/sca/bom/buildinfo/buildinfobom_test.go
+++ b/sca/bom/buildinfo/buildinfobom_test.go
@@ -2,15 +2,115 @@ package buildinfo
 
 import (
 	"fmt"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/CycloneDX/cyclonedx-go"
+	"github.com/jfrog/jfrog-cli-core/v2/utils/config"
+	coreutils "github.com/jfrog/jfrog-cli-core/v2/utils/coreutils"
+	"github.com/jfrog/jfrog-cli-security/sca/bom/buildinfo/technologies"
 	"github.com/jfrog/jfrog-cli-security/utils/results"
+	"github.com/jfrog/jfrog-cli-security/utils/techutils"
 
 	xrayUtils "github.com/jfrog/jfrog-client-go/xray/services/utils"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func isolateResolverConfig(t *testing.T) string {
+	t.Helper()
+	t.Setenv(coreutils.HomeDir, t.TempDir())
+	dummyHome := t.TempDir()
+	t.Setenv("HOME", dummyHome)
+	t.Setenv("USERPROFILE", dummyHome)
+	require.NoError(t, config.SaveServersConf([]*config.ServerDetails{{
+		ServerId:       "test",
+		Url:            "http://localhost/",
+		ArtifactoryUrl: "http://localhost/artifactory/",
+	}}))
+	projectRoot := t.TempDir()
+	originalCwd, err := os.Getwd()
+	require.NoError(t, err)
+	require.NoError(t, os.Chdir(projectRoot))
+	t.Cleanup(func() { require.NoError(t, os.Chdir(originalCwd)) })
+	return projectRoot
+}
+
+func TestResolveTechParamsIsolation(t *testing.T) {
+	projectRoot := isolateResolverConfig(t)
+	projectsDir := filepath.Join(projectRoot, ".jfrog", "projects")
+	require.NoError(t, os.MkdirAll(projectsDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(projectsDir, "go.yaml"),
+		[]byte("version: 1\ntype: go\nresolver:\n  serverId: test\n  repo: go-vir\n"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(projectsDir, "npm.yaml"),
+		[]byte("version: 1\ntype: npm\nresolver:\n  serverId: test\n  repo: npm-remote\n"), 0o644))
+
+	generator := NewBuildInfoBomGenerator()
+
+	goParams, _, err := generator.resolveTechParams(techutils.Go)
+	require.NoError(t, err)
+	assert.Equal(t, "go-vir", goParams.DependenciesRepository, "Go must resolve against its own go.yaml")
+
+	npmParams, _, err := generator.resolveTechParams(techutils.Npm)
+	require.NoError(t, err)
+	assert.Equal(t, "npm-remote", npmParams.DependenciesRepository,
+		"npm must resolve against npm.yaml even after Go resolved first (no shared-state leak)")
+
+	assert.Empty(t, generator.params.DependenciesRepository,
+		"resolving a technology must not mutate the generator's shared params")
+}
+
+func TestResolveTechParamsSkipsConfigLookup(t *testing.T) {
+	projectRoot := isolateResolverConfig(t)
+	projectsDir := filepath.Join(projectRoot, ".jfrog", "projects")
+	require.NoError(t, os.MkdirAll(projectsDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(projectsDir, "npm.yaml"),
+		[]byte("version: 1\ntype: npm\nresolver:\n  serverId: test\n  repo: npm-remote\n"), 0o644))
+
+	testCases := []struct {
+		name     string
+		params   technologies.BuildInfoBomGeneratorParams
+		expected string
+	}{
+		{
+			name:     "explicit deps repo",
+			params:   technologies.BuildInfoBomGeneratorParams{DependenciesRepository: "cli-deps-repo"},
+			expected: "cli-deps-repo",
+		},
+		{
+			name:   "ignore config file",
+			params: technologies.BuildInfoBomGeneratorParams{IgnoreConfigFile: true},
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			generator := NewBuildInfoBomGenerator()
+			generator.params = testCase.params
+
+			npmParams, _, err := generator.resolveTechParams(techutils.Npm)
+			require.NoError(t, err)
+			assert.Equal(t, testCase.expected, npmParams.DependenciesRepository)
+		})
+	}
+}
+
+func TestBuildDependencyTreeDoesNotMutateGeneratorParams(t *testing.T) {
+	projectRoot := isolateResolverConfig(t)
+	projectsDir := filepath.Join(projectRoot, ".jfrog", "projects")
+	require.NoError(t, os.MkdirAll(projectsDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(projectsDir, "go.yaml"),
+		[]byte("version: 1\ntype: go\nresolver:\n  serverId: test\n  repo: go-vir\n"), 0o644))
+
+	generator := NewBuildInfoBomGenerator()
+	_, _ = generator.buildDependencyTree(results.ScanTarget{
+		Target:       projectRoot,
+		Technologies: []techutils.Technology{techutils.Go},
+	})
+
+	assert.Empty(t, generator.params.DependenciesRepository)
+}
 
 func TestMergeResults(t *testing.T) {
 	nodeA := &xrayUtils.GraphNode{Id: "npm://a:1"}

--- a/sca/bom/buildinfo/buildinfobom_test.go
+++ b/sca/bom/buildinfo/buildinfobom_test.go
@@ -37,79 +37,49 @@ func isolateResolverConfig(t *testing.T) string {
 	return projectRoot
 }
 
-func TestResolveTechParamsIsolation(t *testing.T) {
-	projectRoot := isolateResolverConfig(t)
-	projectsDir := filepath.Join(projectRoot, ".jfrog", "projects")
-	require.NoError(t, os.MkdirAll(projectsDir, 0o755))
-	require.NoError(t, os.WriteFile(filepath.Join(projectsDir, "go.yaml"),
-		[]byte("version: 1\ntype: go\nresolver:\n  serverId: test\n  repo: go-vir\n"), 0o644))
-	require.NoError(t, os.WriteFile(filepath.Join(projectsDir, "npm.yaml"),
-		[]byte("version: 1\ntype: npm\nresolver:\n  serverId: test\n  repo: npm-remote\n"), 0o644))
+func TestResolveTechParams(t *testing.T) {
+	t.Run("isolates DependenciesRepository per technology", func(t *testing.T) {
+		projectRoot := isolateResolverConfig(t)
+		projectsDir := filepath.Join(projectRoot, ".jfrog", "projects")
+		require.NoError(t, os.MkdirAll(projectsDir, 0o755))
+		require.NoError(t, os.WriteFile(filepath.Join(projectsDir, "go.yaml"),
+			[]byte("version: 1\ntype: go\nresolver:\n  serverId: test\n  repo: go-vir\n"), 0o644))
+		require.NoError(t, os.WriteFile(filepath.Join(projectsDir, "npm.yaml"),
+			[]byte("version: 1\ntype: npm\nresolver:\n  serverId: test\n  repo: npm-remote\n"), 0o644))
 
-	generator := NewBuildInfoBomGenerator()
+		generator := NewBuildInfoBomGenerator()
 
-	goParams, _, err := generator.resolveTechParams(techutils.Go)
-	require.NoError(t, err)
-	assert.Equal(t, "go-vir", goParams.DependenciesRepository, "Go must resolve against its own go.yaml")
+		goParams, _, err := generator.resolveTechParams(techutils.Go)
+		require.NoError(t, err)
+		assert.Equal(t, "go-vir", goParams.DependenciesRepository)
 
-	npmParams, _, err := generator.resolveTechParams(techutils.Npm)
-	require.NoError(t, err)
-	assert.Equal(t, "npm-remote", npmParams.DependenciesRepository,
-		"npm must resolve against npm.yaml even after Go resolved first (no shared-state leak)")
-
-	assert.Empty(t, generator.params.DependenciesRepository,
-		"resolving a technology must not mutate the generator's shared params")
-}
-
-func TestResolveTechParamsSkipsConfigLookup(t *testing.T) {
-	projectRoot := isolateResolverConfig(t)
-	projectsDir := filepath.Join(projectRoot, ".jfrog", "projects")
-	require.NoError(t, os.MkdirAll(projectsDir, 0o755))
-	require.NoError(t, os.WriteFile(filepath.Join(projectsDir, "npm.yaml"),
-		[]byte("version: 1\ntype: npm\nresolver:\n  serverId: test\n  repo: npm-remote\n"), 0o644))
-
-	testCases := []struct {
-		name     string
-		params   technologies.BuildInfoBomGeneratorParams
-		expected string
-	}{
-		{
-			name:     "explicit deps repo",
-			params:   technologies.BuildInfoBomGeneratorParams{DependenciesRepository: "cli-deps-repo"},
-			expected: "cli-deps-repo",
-		},
-		{
-			name:   "ignore config file",
-			params: technologies.BuildInfoBomGeneratorParams{IgnoreConfigFile: true},
-		},
-	}
-
-	for _, testCase := range testCases {
-		t.Run(testCase.name, func(t *testing.T) {
-			generator := NewBuildInfoBomGenerator()
-			generator.params = testCase.params
-
-			npmParams, _, err := generator.resolveTechParams(techutils.Npm)
-			require.NoError(t, err)
-			assert.Equal(t, testCase.expected, npmParams.DependenciesRepository)
-		})
-	}
-}
-
-func TestBuildDependencyTreeDoesNotMutateGeneratorParams(t *testing.T) {
-	projectRoot := isolateResolverConfig(t)
-	projectsDir := filepath.Join(projectRoot, ".jfrog", "projects")
-	require.NoError(t, os.MkdirAll(projectsDir, 0o755))
-	require.NoError(t, os.WriteFile(filepath.Join(projectsDir, "go.yaml"),
-		[]byte("version: 1\ntype: go\nresolver:\n  serverId: test\n  repo: go-vir\n"), 0o644))
-
-	generator := NewBuildInfoBomGenerator()
-	_, _ = generator.buildDependencyTree(results.ScanTarget{
-		Target:       projectRoot,
-		Technologies: []techutils.Technology{techutils.Go},
+		npmParams, _, err := generator.resolveTechParams(techutils.Npm)
+		require.NoError(t, err)
+		assert.Equal(t, "npm-remote", npmParams.DependenciesRepository)
+		assert.Empty(t, generator.params.DependenciesRepository)
 	})
 
-	assert.Empty(t, generator.params.DependenciesRepository)
+	t.Run("isolates ServerDetails from in-place mutation", func(t *testing.T) {
+		shared := &config.ServerDetails{
+			ServerId:       "test",
+			Url:            "http://localhost/",
+			ArtifactoryUrl: "http://localhost/artifactory/",
+		}
+		generator := NewBuildInfoBomGenerator()
+		generator.params = technologies.BuildInfoBomGeneratorParams{
+			ServerDetails:          shared,
+			DependenciesRepository: "cli-deps-repo",
+		}
+
+		techParams, _, err := generator.resolveTechParams(techutils.Nuget)
+		require.NoError(t, err)
+		require.NotNil(t, techParams.ServerDetails)
+		assert.NotSame(t, shared, techParams.ServerDetails)
+
+		techParams.ServerDetails.ArtifactoryUrl += "api/curation/audit"
+		assert.Equal(t, "http://localhost/artifactory/", shared.ArtifactoryUrl)
+		assert.Equal(t, "http://localhost/artifactory/", generator.params.ServerDetails.ArtifactoryUrl)
+	})
 }
 
 func TestMergeResults(t *testing.T) {


### PR DESCRIPTION
https://jfrog-int.atlassian.net/browse/XRAY-157127

# Background
Polyglot CI audits with distinct Go/npm (and other) resolver configs intermittently resolved one technology against another's Artifactory repository, producing flaky 404s depending on which technology ran first in the same `jf audit` process.

# Description
`BuildInfoBomGenerator` reused one shared `params` across technologies; `SetResolutionRepoInParamsIfExists` wrote the first tech's repo into that field, so later techs skipped their `projects/<tech>.yaml`. Each tech now resolves through `resolveTechParams` against a per-call copy, leaving the generator params clean while `--deps-repo` / `IgnoreConfigFile` still short-circuit the lookup.

# Tests
Reproduced and verified locally before and after the fix.

-----

Made with [Cursor](https://cursor.com)