### PR TITLE
XRAY-157581 - Stop reporting pre-existing SAST findings on every pull request

### DIFF
--- a/jas/sast/sastscanner.go
+++ b/jas/sast/sastscanner.go
@@ -19,7 +19,6 @@ import (
 	"github.com/jfrog/jfrog-client-go/utils/log"
 	xscservices "github.com/jfrog/jfrog-client-go/xsc/services"
 	"github.com/owenrumney/go-sarif/v3/pkg/report/v210/sarif"
-	"golang.org/x/exp/maps"
 )
 
 const (
@@ -71,7 +70,7 @@ func RunSastScan(params SastScanParams, scanner *jas.JasScanner) (vulnerabilitie
 	if vulnerabilitiesResults, violationsResults, err = sastScanManager.runSastScan(params); err != nil {
 		return
 	}
-	log.Info(utils.GetScanFindingsLog(utils.SastScan, sarifutils.GetResultsLocationCount(vulnerabilitiesResults...), startTime, params.ThreadId))
+	log.Info(utils.GetScanFindingsLog(utils.SastScan, sarifutils.GetResultsLocationCount(sarifutils.GroupResultsByLocation(vulnerabilitiesResults)...), startTime, params.ThreadId))
 	return
 }
 
@@ -114,8 +113,6 @@ func (ssm *SastScanManager) DeprecatedRun(module jfrogappsconfig.Module, central
 	if err != nil {
 		return
 	}
-	groupResultsByLocation(vulnerabilitiesSarifRuns)
-	groupResultsByLocation(violationsSarifRuns)
 	return
 }
 
@@ -130,8 +127,6 @@ func (ssm *SastScanManager) Run(target results.ScanTarget) (vulnerabilitiesSarif
 	if err != nil {
 		return
 	}
-	groupResultsByLocation(vulnerabilitiesSarifRuns)
-	groupResultsByLocation(violationsSarifRuns)
 	return
 }
 
@@ -219,38 +214,6 @@ func (ssm *SastScanManager) runAnalyzerManager(wd string) error {
 // In the Sast scanner, there can be multiple results with the same location.
 // The only difference is that their CodeFlow values are different.
 // We combine those under the same result location value
-func groupResultsByLocation(sarifRuns []*sarif.Run) {
-	for _, sastRun := range sarifRuns {
-		locationToResult := map[string]*sarif.Result{}
-		for _, sastResult := range sastRun.Results {
-			resultID := getResultId(sastResult)
-			if result, exists := locationToResult[resultID]; exists {
-				result.CodeFlows = append(result.CodeFlows, sastResult.CodeFlows...)
-			} else {
-				locationToResult[resultID] = sastResult
-			}
-		}
-		sastRun.Results = maps.Values(locationToResult)
-	}
-}
-
-func getResultLocationStr(result *sarif.Result) string {
-	if len(result.Locations) == 0 {
-		return ""
-	}
-	location := result.Locations[0]
-	return fmt.Sprintf("%s%d%d%d%d",
-		sarifutils.GetLocationFileName(location),
-		sarifutils.GetLocationStartLine(location),
-		sarifutils.GetLocationStartColumn(location),
-		sarifutils.GetLocationEndLine(location),
-		sarifutils.GetLocationEndColumn(location))
-}
-
-func getResultId(result *sarif.Result) string {
-	return sarifutils.GetResultRuleId(result) + result.Level + sarifutils.GetResultMsgText(result) + getResultLocationStr(result)
-}
-
 // sastChangedFileDropStats counts reasons entries from git were not used as SAST roots.
 type sastChangedFileDropStats struct {
 	invalidPath   int

--- a/jas/sast/sastscanner_test.go
+++ b/jas/sast/sastscanner_test.go
@@ -10,8 +10,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/owenrumney/go-sarif/v3/pkg/report/v210/sarif"
-
 	coreTests "github.com/jfrog/jfrog-cli-core/v2/utils/tests"
 	"github.com/jfrog/jfrog-client-go/utils/io/fileutils"
 	xscservices "github.com/jfrog/jfrog-client-go/xsc/services"
@@ -78,9 +76,9 @@ func TestSastParseResults_EmptyResults(t *testing.T) {
 	if assert.NoError(t, err) && assert.NotNil(t, vulnerabilitiesResults) {
 		assert.Len(t, vulnerabilitiesResults, 1)
 		assert.Empty(t, vulnerabilitiesResults[0].Results)
-		groupResultsByLocation(vulnerabilitiesResults)
-		assert.Len(t, vulnerabilitiesResults, 1)
-		assert.Empty(t, vulnerabilitiesResults[0].Results)
+		grouped := sarifutils.GroupResultsByLocation(vulnerabilitiesResults)
+		assert.Len(t, grouped, 1)
+		assert.Empty(t, grouped[0].Results)
 	}
 }
 
@@ -101,95 +99,9 @@ func TestSastParseResults_ResultsContainIacViolations(t *testing.T) {
 	if assert.NoError(t, err) && assert.NotNil(t, vulnerabilitiesResults) {
 		assert.Len(t, vulnerabilitiesResults, 1)
 		assert.NotEmpty(t, vulnerabilitiesResults[0].Results)
-		groupResultsByLocation(vulnerabilitiesResults)
+		grouped := sarifutils.GroupResultsByLocation(vulnerabilitiesResults)
 		// File has 4 results, 2 of them at the same location different codeFlow
-		assert.Len(t, vulnerabilitiesResults[0].Results, 3)
-	}
-}
-
-func TestGroupResultsByLocation(t *testing.T) {
-	tests := []struct {
-		run            *sarif.Run
-		expectedOutput *sarif.Run
-	}{
-		{
-			run:            sarifutils.CreateRunWithDummyResults(),
-			expectedOutput: sarifutils.CreateRunWithDummyResults(),
-		},
-		{
-			// No similar groups at all
-			run: sarifutils.CreateRunWithDummyResults(
-				sarifutils.CreateResultWithOneLocation("file", 1, 2, 3, 4, "snippet", "rule1", "info"),
-				sarifutils.CreateResultWithOneLocation("file", 1, 2, 3, 4, "snippet", "rule1", "note"),
-				sarifutils.CreateResultWithOneLocation("file", 5, 6, 7, 8, "snippet", "rule1", "info"),
-				sarifutils.CreateResultWithOneLocation("file2", 1, 2, 3, 4, "snippet", "rule1", "info").WithCodeFlows([]*sarif.CodeFlow{
-					sarifutils.CreateCodeFlow(sarifutils.CreateThreadFlow(
-						sarifutils.CreateLocation("other", 0, 0, 0, 0, "other-snippet"),
-						sarifutils.CreateLocation("file2", 1, 2, 3, 4, "snippet"),
-					)),
-				}),
-				sarifutils.CreateResultWithOneLocation("file2", 1, 2, 3, 4, "snippet", "rule2", "info").WithCodeFlows([]*sarif.CodeFlow{
-					sarifutils.CreateCodeFlow(sarifutils.CreateThreadFlow(
-						sarifutils.CreateLocation("other2", 1, 1, 1, 1, "other-snippet2"),
-						sarifutils.CreateLocation("file2", 1, 2, 3, 4, "snippet"),
-					)),
-				}),
-			),
-			expectedOutput: sarifutils.CreateRunWithDummyResults(
-				sarifutils.CreateResultWithOneLocation("file", 1, 2, 3, 4, "snippet", "rule1", "info"),
-				sarifutils.CreateResultWithOneLocation("file", 1, 2, 3, 4, "snippet", "rule1", "note"),
-				sarifutils.CreateResultWithOneLocation("file", 5, 6, 7, 8, "snippet", "rule1", "info"),
-				sarifutils.CreateResultWithOneLocation("file2", 1, 2, 3, 4, "snippet", "rule1", "info").WithCodeFlows([]*sarif.CodeFlow{
-					sarifutils.CreateCodeFlow(sarifutils.CreateThreadFlow(
-						sarifutils.CreateLocation("other", 0, 0, 0, 0, "other-snippet"),
-						sarifutils.CreateLocation("file2", 1, 2, 3, 4, "snippet"),
-					)),
-				}),
-				sarifutils.CreateResultWithOneLocation("file2", 1, 2, 3, 4, "snippet", "rule2", "info").WithCodeFlows([]*sarif.CodeFlow{
-					sarifutils.CreateCodeFlow(sarifutils.CreateThreadFlow(
-						sarifutils.CreateLocation("other2", 1, 1, 1, 1, "other-snippet2"),
-						sarifutils.CreateLocation("file2", 1, 2, 3, 4, "snippet"),
-					)),
-				}),
-			),
-		},
-		{
-			// With similar groups
-			run: sarifutils.CreateRunWithDummyResults(
-				sarifutils.CreateResultWithOneLocation("file", 1, 2, 3, 4, "snippet", "rule1", "info").WithCodeFlows([]*sarif.CodeFlow{
-					sarifutils.CreateCodeFlow(sarifutils.CreateThreadFlow(
-						sarifutils.CreateLocation("other", 0, 0, 0, 0, "other-snippet"),
-						sarifutils.CreateLocation("file", 1, 2, 3, 4, "snippet"),
-					)),
-				}),
-				sarifutils.CreateResultWithOneLocation("file", 1, 2, 3, 4, "snippet", "rule1", "info").WithCodeFlows([]*sarif.CodeFlow{
-					sarifutils.CreateCodeFlow(sarifutils.CreateThreadFlow(
-						sarifutils.CreateLocation("other2", 1, 1, 1, 1, "other-snippet"),
-						sarifutils.CreateLocation("file", 1, 2, 3, 4, "snippet"),
-					)),
-				}),
-				sarifutils.CreateResultWithOneLocation("file", 5, 6, 7, 8, "snippet", "rule1", "info"),
-				sarifutils.CreateResultWithOneLocation("file", 1, 2, 3, 4, "snippet", "rule1", "info"),
-			),
-			expectedOutput: sarifutils.CreateRunWithDummyResults(
-				sarifutils.CreateResultWithOneLocation("file", 1, 2, 3, 4, "snippet", "rule1", "info").WithCodeFlows([]*sarif.CodeFlow{
-					sarifutils.CreateCodeFlow(sarifutils.CreateThreadFlow(
-						sarifutils.CreateLocation("other", 0, 0, 0, 0, "other-snippet"),
-						sarifutils.CreateLocation("file", 1, 2, 3, 4, "snippet"),
-					)),
-					sarifutils.CreateCodeFlow(sarifutils.CreateThreadFlow(
-						sarifutils.CreateLocation("other2", 1, 1, 1, 1, "other-snippet"),
-						sarifutils.CreateLocation("file", 1, 2, 3, 4, "snippet"),
-					)),
-				}),
-				sarifutils.CreateResultWithOneLocation("file", 5, 6, 7, 8, "snippet", "rule1", "info"),
-			),
-		},
-	}
-
-	for _, test := range tests {
-		groupResultsByLocation([]*sarif.Run{test.run})
-		assert.ElementsMatch(t, test.expectedOutput.Results, test.run.Results)
+		assert.Len(t, grouped[0].Results, 3)
 	}
 }
 

--- a/policy/enforcer/policyenforcer.go
+++ b/policy/enforcer/policyenforcer.go
@@ -362,6 +362,13 @@ type matchedJsaVulnerability struct {
 	location *sarif.Location
 }
 
+func jasResultsForReport(jasType jasutils.JasScanType, runs []*sarif.Run) []*sarif.Run {
+	if jasType != jasutils.Sast {
+		return runs
+	}
+	return sarifutils.GroupResultsByLocation(runs)
+}
+
 func locateJasVulnerabilityInfo(cmdResults *results.SecurityCommandResults, jasType jasutils.JasScanType, violation services.XrayViolation) (match matchedJsaVulnerability) {
 	id := getJasVulnerabilityId(violation, jasType)
 	if id == "" {
@@ -374,7 +381,7 @@ func locateJasVulnerabilityInfo(cmdResults *results.SecurityCommandResults, jasT
 			log.Debug(fmt.Sprintf("Skipping %s violation search for target %s with no Jas results", jasType, target.ScanTarget))
 			continue
 		}
-		if err := results.ForEachJasIssue(target.JasResults.GetVulnerabilitiesResults(jasType), cmdResults.Entitlements.Jas,
+		if err := results.ForEachJasIssue(jasResultsForReport(jasType, target.JasResults.GetVulnerabilitiesResults(jasType)), cmdResults.Entitlements.Jas,
 			func(run *sarif.Run, rule *sarif.ReportingDescriptor, severity severityutils.Severity, result *sarif.Result, location *sarif.Location) error {
 				if !found && isMatchingJasViolation(id, jasType, rule, location, run.Invocations, violation) {
 					// Found a relevant issue (JAS Violations only provide abbreviation and file name, no region so we match only by those)

--- a/policy/local/localconvertor.go
+++ b/policy/local/localconvertor.go
@@ -67,7 +67,7 @@ func (d *DeprecatedViolationGenerator) GenerateViolations(cmdResults *results.Se
 				}
 			}
 			if len(target.JasResults.JasViolations.SastScanResults) > 0 {
-				if e := results.ForEachJasIssue(target.JasResults.JasViolations.SastScanResults, cmdResults.Entitlements.Jas, convertJasViolationsToPolicyViolations(&convertedViolations, jasutils.Sast)); e != nil {
+				if e := results.ForEachJasIssue(sarifutils.GroupResultsByLocation(target.JasResults.JasViolations.SastScanResults), cmdResults.Entitlements.Jas, convertJasViolationsToPolicyViolations(&convertedViolations, jasutils.Sast)); e != nil {
 					err = errors.Join(err, fmt.Errorf("failed to convert JAS SAST violations for target %s: %w", target.Target, e))
 				}
 			}

--- a/utils/formats/sarifutils/sarifutils.go
+++ b/utils/formats/sarifutils/sarifutils.go
@@ -934,3 +934,34 @@ func GetResultsByRuleId(ruleId string, runs ...*sarif.Run) (results []*sarif.Res
 	}
 	return
 }
+
+// A SAST scanner reports one result per data-flow path, so a single location can carry several results that
+// differ only by their code flow. Reports show one item per location, with every path that reaches it.
+func GroupResultsByLocation(runs []*sarif.Run) (grouped []*sarif.Run) {
+	for _, run := range runs {
+		groupedResults := []*sarif.Result{}
+		locationToResult := map[string]*sarif.Result{}
+		for _, result := range run.Results {
+			resultId := getResultIdByLocation(result)
+			existing, exists := locationToResult[resultId]
+			if !exists {
+				groupedResult := CopyResult(result)
+				locationToResult[resultId] = groupedResult
+				groupedResults = append(groupedResults, groupedResult)
+				continue
+			}
+			existing.CodeFlows = append(existing.CodeFlows, result.CodeFlows...)
+		}
+		groupedRun := *run
+		groupedRun.Results = groupedResults
+		grouped = append(grouped, &groupedRun)
+	}
+	return
+}
+
+func getResultIdByLocation(result *sarif.Result) string {
+	if len(result.Locations) == 0 {
+		return GetResultRuleId(result) + result.Level + GetResultMsgText(result)
+	}
+	return GetResultRuleId(result) + result.Level + GetResultMsgText(result) + GetLocationId(result.Locations[0])
+}

--- a/utils/formats/sarifutils/sarifutils_test.go
+++ b/utils/formats/sarifutils/sarifutils_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/jfrog/jfrog-cli-security/utils/severityutils"
 	"github.com/owenrumney/go-sarif/v3/pkg/report/v210/sarif"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestAggregateMultipleRunsIntoSingle(t *testing.T) {
@@ -618,5 +619,92 @@ func TestGetResultFingerprint(t *testing.T) {
 	}
 	for _, test := range tests {
 		assert.Equal(t, test.expectedOutput, GetResultFingerprint(test.result))
+	}
+}
+
+func TestGroupResultsByLocation(t *testing.T) {
+	tests := []struct {
+		run            *sarif.Run
+		expectedOutput *sarif.Run
+	}{
+		{
+			run:            CreateRunWithDummyResults(),
+			expectedOutput: CreateRunWithDummyResults(),
+		},
+		{
+			// No similar groups at all
+			run: CreateRunWithDummyResults(
+				CreateResultWithOneLocation("file", 1, 2, 3, 4, "snippet", "rule1", "info"),
+				CreateResultWithOneLocation("file", 1, 2, 3, 4, "snippet", "rule1", "note"),
+				CreateResultWithOneLocation("file", 5, 6, 7, 8, "snippet", "rule1", "info"),
+				CreateResultWithOneLocation("file2", 1, 2, 3, 4, "snippet", "rule1", "info").WithCodeFlows([]*sarif.CodeFlow{
+					CreateCodeFlow(CreateThreadFlow(
+						CreateLocation("other", 0, 0, 0, 0, "other-snippet"),
+						CreateLocation("file2", 1, 2, 3, 4, "snippet"),
+					)),
+				}),
+				CreateResultWithOneLocation("file2", 1, 2, 3, 4, "snippet", "rule2", "info").WithCodeFlows([]*sarif.CodeFlow{
+					CreateCodeFlow(CreateThreadFlow(
+						CreateLocation("other2", 1, 1, 1, 1, "other-snippet2"),
+						CreateLocation("file2", 1, 2, 3, 4, "snippet"),
+					)),
+				}),
+			),
+			expectedOutput: CreateRunWithDummyResults(
+				CreateResultWithOneLocation("file", 1, 2, 3, 4, "snippet", "rule1", "info"),
+				CreateResultWithOneLocation("file", 1, 2, 3, 4, "snippet", "rule1", "note"),
+				CreateResultWithOneLocation("file", 5, 6, 7, 8, "snippet", "rule1", "info"),
+				CreateResultWithOneLocation("file2", 1, 2, 3, 4, "snippet", "rule1", "info").WithCodeFlows([]*sarif.CodeFlow{
+					CreateCodeFlow(CreateThreadFlow(
+						CreateLocation("other", 0, 0, 0, 0, "other-snippet"),
+						CreateLocation("file2", 1, 2, 3, 4, "snippet"),
+					)),
+				}),
+				CreateResultWithOneLocation("file2", 1, 2, 3, 4, "snippet", "rule2", "info").WithCodeFlows([]*sarif.CodeFlow{
+					CreateCodeFlow(CreateThreadFlow(
+						CreateLocation("other2", 1, 1, 1, 1, "other-snippet2"),
+						CreateLocation("file2", 1, 2, 3, 4, "snippet"),
+					)),
+				}),
+			),
+		},
+		{
+			// With similar groups
+			run: CreateRunWithDummyResults(
+				CreateResultWithOneLocation("file", 1, 2, 3, 4, "snippet", "rule1", "info").WithCodeFlows([]*sarif.CodeFlow{
+					CreateCodeFlow(CreateThreadFlow(
+						CreateLocation("other", 0, 0, 0, 0, "other-snippet"),
+						CreateLocation("file", 1, 2, 3, 4, "snippet"),
+					)),
+				}),
+				CreateResultWithOneLocation("file", 1, 2, 3, 4, "snippet", "rule1", "info").WithCodeFlows([]*sarif.CodeFlow{
+					CreateCodeFlow(CreateThreadFlow(
+						CreateLocation("other2", 1, 1, 1, 1, "other-snippet"),
+						CreateLocation("file", 1, 2, 3, 4, "snippet"),
+					)),
+				}),
+				CreateResultWithOneLocation("file", 5, 6, 7, 8, "snippet", "rule1", "info"),
+				CreateResultWithOneLocation("file", 1, 2, 3, 4, "snippet", "rule1", "info"),
+			),
+			expectedOutput: CreateRunWithDummyResults(
+				CreateResultWithOneLocation("file", 1, 2, 3, 4, "snippet", "rule1", "info").WithCodeFlows([]*sarif.CodeFlow{
+					CreateCodeFlow(CreateThreadFlow(
+						CreateLocation("other", 0, 0, 0, 0, "other-snippet"),
+						CreateLocation("file", 1, 2, 3, 4, "snippet"),
+					)),
+					CreateCodeFlow(CreateThreadFlow(
+						CreateLocation("other2", 1, 1, 1, 1, "other-snippet"),
+						CreateLocation("file", 1, 2, 3, 4, "snippet"),
+					)),
+				}),
+				CreateResultWithOneLocation("file", 5, 6, 7, 8, "snippet", "rule1", "info"),
+			),
+		},
+	}
+
+	for _, test := range tests {
+		grouped := GroupResultsByLocation([]*sarif.Run{test.run})
+		require.Len(t, grouped, 1)
+		assert.ElementsMatch(t, test.expectedOutput.Results, grouped[0].Results)
 	}
 }

--- a/utils/results/conversion/convertor.go
+++ b/utils/results/conversion/convertor.go
@@ -7,6 +7,7 @@ import (
 	"github.com/jfrog/jfrog-cli-security/utils"
 	"github.com/jfrog/jfrog-cli-security/utils/formats"
 	"github.com/jfrog/jfrog-cli-security/utils/formats/cdxutils"
+	"github.com/jfrog/jfrog-cli-security/utils/formats/sarifutils"
 	"github.com/jfrog/jfrog-cli-security/utils/formats/violationutils"
 	"github.com/jfrog/jfrog-cli-security/utils/results"
 	"github.com/jfrog/jfrog-cli-security/utils/results/conversion/cyclonedxparser"
@@ -222,7 +223,7 @@ func parseJasResults[T interface{}](params ResultConvertParams, parser ResultsSt
 		return
 	}
 	// Parsing JAS SAST results
-	if err = parser.ParseSast(targetResults.JasResults.JasVulnerabilities.SastScanResults); err != nil {
+	if err = parser.ParseSast(sarifutils.GroupResultsByLocation(targetResults.JasResults.JasVulnerabilities.SastScanResults)); err != nil {
 		return
 	}
 	// Parsing JAS Malicious Code results


### PR DESCRIPTION
https://jfrog-int.atlassian.net/browse/XRAY-157581

Cherry-pick of #840 onto `main`.

# Background

Frogbot pull-request scans report SAST findings that already exist on the target branch, on every pull request, even when the file was never touched. It happens on any line reached by more than one data-flow path.

# Description

A SAST scanner reports one result per data-flow path, each with its own `significant_full_path` fingerprint, and the diff scan matches on those fingerprints. Results sharing a location were merged into one before being stored, keeping a single fingerprint and discarding the rest, so every discarded one looked new against the target scan.

The scan results are now stored as the scanner produced them, and `sarifutils.GroupResultsByLocation` is applied where results are reported: the output convertor, the SAST violations convertor, the policy enforcer lookup and the findings count. It returns grouped runs rather than mutating the ones it is given, so the stored results stay the single source of truth (a per-consumer call rather than a stored second copy — a display concern should not be able to leak back into the data).

# Tests

Unit: grouping moved to `sarifutils` with its existing cases; the SAST fixture with two results at one location still reports three findings.
Live `frogbot scan-pull-request` against a reproduction repository: a pull request touching an unrelated file goes from one reported SAST finding to none; one adding a new data-flow path into the same sink is still reported, as a single comment carrying all of its flows.

-----

- [x] The pull request is targeting the `main` branch (cherry-pick of #840 from `dev`).
- [x] The code has been validated to compile successfully by running `go vet ./...`.
- [x] The code has been formatted properly using `go fmt ./...`.
- [ ] All static analysis checks passed.
- [ ] All tests have passed. If this feature is not already covered by the tests, new tests have been added.
- [ ] Updated the Contributing page / ReadMe page / CI Workflow files if needed.
- [x] All changes are detailed at the description. if not already covered at JFrog Documentation, new documentation have been added.
