### PR TITLE
Add risky tech callback guard after techs detection

### DIFF
--- a/commands/audit/audit.go
+++ b/commands/audit/audit.go
@@ -474,6 +474,13 @@ func isEntitledForSnippetDetection(isEntitledForJas bool, xrayManager *xray.Xray
 func populateScanTargets(cmdResults *results.SecurityCommandResults, params *AuditParams) {
 	// Populate x scan targets based on the provided parameters.
 	detectScanTargets(cmdResults, params)
+	if detectedTechsGuardCallback := params.DetectedTechnologiesGuardCallback(); detectedTechsGuardCallback != nil {
+		if err := detectedTechsGuardCallback(collectDetectedTechnologies(cmdResults)); err != nil {
+			// allowSkippingError is hardcoded to false: this check must never be bypassable via AllowPartialResults.
+			cmdResults.AddGeneralError(err, false)
+			return
+		}
+	}
 	// Populate target information for the scans
 	for _, targetResult := range cmdResults.Targets {
 		// Generate SBOM for the target if requested or for SCA scans.
@@ -661,6 +668,16 @@ func createScanTarget(root string, exclude []string, includes ...string) *result
 		log.Debug(fmt.Sprintf("Root directory '%s' is excluded; creating scan target from %d explicit include path(s)", root, len(include)))
 	}
 	return &results.ScanTarget{Target: root, Include: include, Exclude: exclude}
+}
+
+func collectDetectedTechnologies(cmdResults *results.SecurityCommandResults) []techutils.Technology {
+	detected := datastructures.MakeSet[techutils.Technology]()
+	for _, targetResult := range cmdResults.Targets {
+		for _, tech := range targetResult.Technologies {
+			detected.Add(tech)
+		}
+	}
+	return detected.ToSlice()
 }
 
 func detectTechnologiesInTarget(target results.ScanTarget, otherParams *AuditParams) (technologies []techutils.Technology) {

--- a/commands/audit/audit.go
+++ b/commands/audit/audit.go
@@ -475,7 +475,7 @@ func populateScanTargets(cmdResults *results.SecurityCommandResults, params *Aud
 	// Populate x scan targets based on the provided parameters.
 	detectScanTargets(cmdResults, params)
 	if detectedTechsGuardCallback := params.DetectedTechnologiesGuardCallback(); detectedTechsGuardCallback != nil {
-		if err := detectedTechsGuardCallback(collectDetectedTechnologies(cmdResults)); err != nil {
+		if err := detectedTechsGuardCallback(cmdResults.GetTechnologies()); err != nil {
 			// allowSkippingError is hardcoded to false: this check must never be bypassable via AllowPartialResults.
 			cmdResults.AddGeneralError(err, false)
 			return
@@ -668,16 +668,6 @@ func createScanTarget(root string, exclude []string, includes ...string) *result
 		log.Debug(fmt.Sprintf("Root directory '%s' is excluded; creating scan target from %d explicit include path(s)", root, len(include)))
 	}
 	return &results.ScanTarget{Target: root, Include: include, Exclude: exclude}
-}
-
-func collectDetectedTechnologies(cmdResults *results.SecurityCommandResults) []techutils.Technology {
-	detected := datastructures.MakeSet[techutils.Technology]()
-	for _, targetResult := range cmdResults.Targets {
-		for _, tech := range targetResult.Technologies {
-			detected.Add(tech)
-		}
-	}
-	return detected.ToSlice()
 }
 
 func detectTechnologiesInTarget(target results.ScanTarget, otherParams *AuditParams) (technologies []techutils.Technology) {

--- a/commands/audit/audit_test.go
+++ b/commands/audit/audit_test.go
@@ -1,6 +1,7 @@
 package audit
 
 import (
+	"errors"
 	"fmt"
 	"net/http"
 	"os"
@@ -601,6 +602,49 @@ func TestDetectScanTargetsNewFlowCliExcludedCwdWithNonExcludedInclude(t *testing
 		}
 	}
 	assert.True(t, hasNpm, "expected Npm among detected technologies")
+}
+
+func TestPopulateScanTargetsDetectedTechnologiesGuardCallbackIsNotSkippable(t *testing.T) {
+	baseDir, cleanUp := createTestDir(t)
+	defer cleanUp()
+
+	mavenDir := filepath.Join(baseDir, "maven-wd")
+	assert.NoError(t, os.MkdirAll(mavenDir, 0o755))
+	createEmptyFile(t, filepath.Join(mavenDir, "pom.xml"))
+
+	callbackErr := errors.New("environment guard failed")
+
+	tests := []struct {
+		name                string
+		allowPartialResults bool
+	}{
+		{
+			name:                "Partial results disabled - fail upon every error",
+			allowPartialResults: false,
+		},
+		{
+			name:                "allowPartialResults=true - callback error must still propagate",
+			allowPartialResults: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cmdRes := results.NewCommandResults(utils.SourceCode).SetEntitledForJas(true).SetSecretValidation(true).SetAllowPartialResults(tt.allowPartialResults)
+			params := NewAuditParams()
+			params.SetWorkingDirs([]string{mavenDir})
+			params.SetIsRecursiveScan(false)
+			params.SetBomGenerator(xrayplugin.NewXrayLibBomGenerator())
+			params.SetDetectedTechnologiesGuardCallback(func(detected []techutils.Technology) error {
+				return callbackErr
+			})
+
+			populateScanTargets(cmdRes, params)
+
+			// The callback error must surface via GetErrors() regardless of AllowPartialResults
+			assert.ErrorContains(t, cmdRes.GetErrors(), callbackErr.Error())
+		})
+	}
 }
 
 func TestShouldGenerateSbom(t *testing.T) {

--- a/commands/audit/auditparams.go
+++ b/commands/audit/auditparams.go
@@ -24,12 +24,14 @@ type AuditParams struct {
 	appsConfig  *jfrogappsconfig.JFrogAppsConfig
 	workingDirs []string
 	// Common params to all scan routines
-	resultsContext    results.ResultContext
-	gitContext        *xscServices.XscGitInfoContext
-	rootDir           string
-	installFunc       func(tech string) error
-	fixableOnly       bool
-	minSeverityFilter severityutils.Severity
+	resultsContext results.ResultContext
+	gitContext     *xscServices.XscGitInfoContext
+	rootDir        string
+	installFunc    func(tech string) error
+	// Optional hook invoked once technologies are detected for all targets, before any SBOM/dependency-tree generation runs (i.e. before any build-tool plugin executes untrusted code). A non-nil error aborts the scan.
+	detectedTechnologiesGuardCallback func(detectedTechnologies []techutils.Technology) error
+	fixableOnly                       bool
+	minSeverityFilter                 severityutils.Severity
 	*AuditBasicParams
 	multiScanId string
 	// Include third party dependencies source code in the applicability scan.
@@ -161,6 +163,15 @@ func (params *AuditParams) SetWorkingDirs(workingDirs []string) *AuditParams {
 func (params *AuditParams) SetInstallFunc(installFunc func(tech string) error) *AuditParams {
 	params.installFunc = installFunc
 	return params
+}
+
+func (params *AuditParams) SetDetectedTechnologiesGuardCallback(callback func(detectedTechnologies []techutils.Technology) error) *AuditParams {
+	params.detectedTechnologiesGuardCallback = callback
+	return params
+}
+
+func (params *AuditParams) DetectedTechnologiesGuardCallback() func(detectedTechnologies []techutils.Technology) error {
+	return params.detectedTechnologiesGuardCallback
 }
 
 func (params *AuditParams) FixableOnly() bool {


### PR DESCRIPTION
- [ ] The pull request is targeting the `dev` branch.
- [ ] The code has been validated to compile successfully by running `go vet ./...`.
- [ ] The code has been formatted properly using `go fmt ./...`.
- [ ] All [static analysis checks](https://github.com/jfrog/jfrog-cli-security/actions/workflows/analysis.yml) passed.
- [ ] All [tests](https://github.com/jfrog/jfrog-cli-security/actions/workflows/test.yml) have passed. If this feature is not already covered by the tests, new tests have been added.
- [ ] Updated the [Contributing page](https://github.com/jfrog/jfrog-cli-security/blob/main/CONTRIBUTING.md) / [ReadMe page](https://github.com/jfrog/jfrog-cli-security/blob/main/README.md) / [CI Workflow files](https://github.com/jfrog/jfrog-cli-security/tree/main/.github/workflows) if needed.
- [ ] All changes are detailed at the description. if not already covered at [JFrog Documentation](https://github.com/jfrog/documentation), new documentation have been added.

-----
This PR adds ability to accept and execute a function that guards from executing risky technologies without proper validations.
When executing Frogbot we are exposed to untrusted code contributions (through PRs). In Maven and Gradle when we use the dep-tree plugins the tasks being executed are running scripts found in the repo prior to the task itself. In order to prevet malicious code execution we are adding an optional guard function that can be provided to audit. if not provided - no-op