### PR TITLE
Update expected violation counts for new jackson-databind advisories

### DIFF
--- a/git_test.go
+++ b/git_test.go
@@ -308,8 +308,8 @@ func TestGitAuditJasSkipNotApplicableCvesViolations(t *testing.T) {
 		xrayVersion, xscVersion, "",
 		validations.ValidationParams{
 			Violations: &validations.ViolationCount{
-				ValidateScan:                &validations.ScanCount{Sca: 70, Sast: 5, Secrets: 2},
-				ValidateApplicabilityStatus: &validations.ApplicabilityStatusCount{NotApplicable: 61, NotCovered: 8, MissingContext: 1, Inactive: 1},
+				ValidateScan:                &validations.ScanCount{Sca: 72, Sast: 5, Secrets: 2},
+				ValidateApplicabilityStatus: &validations.ApplicabilityStatusCount{NotApplicable: 61, NotCovered: 10, MissingContext: 1, Inactive: 1},
 			},
 			ExactResultsMatch: true,
 		},
@@ -343,8 +343,8 @@ func TestGitAuditJasSkipNotApplicableCvesViolations(t *testing.T) {
 		xrayVersion, xscVersion, "",
 		validations.ValidationParams{
 			Violations: &validations.ViolationCount{
-				ValidateScan:                &validations.ScanCount{Sca: 9, Sast: 5, Secrets: 2},
-				ValidateApplicabilityStatus: &validations.ApplicabilityStatusCount{NotCovered: 8, MissingContext: 1, Inactive: 1},
+				ValidateScan:                &validations.ScanCount{Sca: 11, Sast: 5, Secrets: 2},
+				ValidateApplicabilityStatus: &validations.ApplicabilityStatusCount{NotCovered: 10, MissingContext: 1, Inactive: 1},
 			},
 			ExactResultsMatch: true,
 		},


### PR DESCRIPTION
# Background

The Git Commands integration suite has been failing on `dev` and on every open PR since Aug 24, on all three OSes, blocking the security CLI release. A single test is responsible; re-runs don't help.

# Description

`TestGitAuditJasSkipNotApplicableCvesViolations` asserts exact totals (`ExactResultsMatch: true`) against the live Xray DB. Two new `com.fasterxml.jackson.core:jackson-databind:2.9.8` advisories were published — `CVE-2026-77310` (`XRAY-1059207`) and `XRAY-1059208`, both `Not Covered` — so `issues-mvn` now reports 72 SCA violations instead of 70. Bumped `Sca` 70→72 / 9→11 and `NotCovered` 8→10 in both halves of the test.

# Tests

Diffed the reported violations of the last green run (job `96340748454`) against the current failing one (job `97708691683`): exactly those two added, none removed. CI on this PR is the verification.

-----
- [ ] The pull request is targeting the `dev` branch.
- [ ] The code has been validated to compile successfully by running `go vet ./...`.
- [ ] The code has been formatted properly using `go fmt ./...`.
- [ ] All [static analysis checks](https://github.com/jfrog/jfrog-cli-security/actions/workflows/analysis.yml) passed.
- [ ] All [tests](https://github.com/jfrog/jfrog-cli-security/actions/workflows/test.yml) have passed. If this feature is not already covered by the tests, new tests have been added.
- [ ] Updated the [Contributing page](https://github.com/jfrog/jfrog-cli-security/blob/main/CONTRIBUTING.md) / [ReadMe page](https://github.com/jfrog/jfrog-cli-security/blob/main/README.md) / [CI Workflow files](https://github.com/jfrog/jfrog-cli-security/tree/main/.github/workflows) if needed.
- [ ] All changes are detailed at the description. if not already covered at [JFrog Documentation](https://github.com/jfrog/documentation), new documentation have been added.

-----