### PR TITLE
XRAY-159000 - Link the build scan job summary violations to the scanned build

### DIFF
--- a/utils/results/conversion/summaryparser/summaryparser.go
+++ b/utils/results/conversion/summaryparser/summaryparser.go
@@ -90,13 +90,6 @@ func (sc *CmdResultsSummaryConverter) parseScaVulnerabilities(descriptors []stri
 	if sc.currentScan.Vulnerabilities.ScaResults == nil {
 		sc.currentScan.Vulnerabilities.ScaResults = &formats.ScaScanResultSummary{}
 	}
-	// Parse general SCA results
-	if scaResponse.ScanId != "" {
-		sc.currentScan.Vulnerabilities.ScaResults.ScanIds = utils.UniqueUnion(sc.currentScan.Vulnerabilities.ScaResults.ScanIds, scaResponse.ScanId)
-	}
-	if scaResponse.XrayDataUrl != "" {
-		sc.currentScan.Vulnerabilities.ScaResults.MoreInfoUrls = utils.UniqueUnion(sc.currentScan.Vulnerabilities.ScaResults.MoreInfoUrls, scaResponse.XrayDataUrl)
-	}
 	if sc.status.IsScanFailed(results.CmdStepSca) {
 		return
 	}

--- a/utils/results/output/securityJobSummary.go
+++ b/utils/results/output/securityJobSummary.go
@@ -25,6 +25,7 @@ import (
 	"github.com/jfrog/jfrog-cli-security/utils/severityutils"
 	"github.com/jfrog/jfrog-client-go/utils/errorutils"
 	"github.com/jfrog/jfrog-client-go/utils/log"
+	"github.com/jfrog/jfrog-client-go/xray/services"
 	"github.com/owenrumney/go-sarif/v3/pkg/report/v210/sarif"
 )
 
@@ -73,13 +74,52 @@ type SecurityJobSummary struct{}
 func newResultSummary(cmdResults *results.SecurityCommandResults, serverDetails *config.ServerDetails, vulnerabilitiesRequested, violationsRequested bool) (summary ScanCommandResultSummary, err error) {
 	summary.ResultType = cmdResults.CmdType
 	summary.Args = &ResultSummaryArgs{BaseJfrogUrl: serverDetails.Url}
-	summary.Summary, err = conversion.NewCommandResultsConvertor(conversion.ResultConvertParams{
+	if summary.Summary, err = conversion.NewCommandResultsConvertor(conversion.ResultConvertParams{
 		PlatformUrl:            serverDetails.Url,
 		IncludeVulnerabilities: vulnerabilitiesRequested,
 		HasViolationContext:    violationsRequested,
 		Pretty:                 true,
-	}).ConvertToSummary(cmdResults)
+	}).ConvertToSummary(cmdResults); err != nil {
+		return
+	}
+	setScaScanReferences(&summary.Summary, cmdResults)
 	return
+}
+
+// Xray provides the link to the scan results as part of the SCA scan response.
+// It describes the scan and not the issues, so it is attached to every issue type the scan reported.
+func setScaScanReferences(summary *formats.ResultsSummary, cmdResults *results.SecurityCommandResults) {
+	for _, target := range cmdResults.Targets {
+		if target.ScaResults == nil {
+			continue
+		}
+		for i := range summary.Scans {
+			if summary.Scans[i].Target != target.Target || summary.Scans[i].Name != target.Name {
+				continue
+			}
+			for _, scaResponse := range target.ScaResults.DeprecatedXrayResults {
+				addScaScanReference(summary.Scans[i].Vulnerabilities, scaResponse)
+				if summary.Scans[i].Violations != nil {
+					addScaScanReference(&summary.Scans[i].Violations.ScanResultSummary, scaResponse)
+				}
+			}
+		}
+	}
+}
+
+func addScaScanReference(issues *formats.ScanResultSummary, scaResponse services.ScanResponse) {
+	if issues == nil {
+		return
+	}
+	if issues.ScaResults == nil {
+		issues.ScaResults = &formats.ScaScanResultSummary{}
+	}
+	if scaResponse.ScanId != "" {
+		issues.ScaResults.ScanIds = utils.UniqueUnion(issues.ScaResults.ScanIds, scaResponse.ScanId)
+	}
+	if scaResponse.XrayDataUrl != "" {
+		issues.ScaResults.MoreInfoUrls = utils.UniqueUnion(issues.ScaResults.MoreInfoUrls, scaResponse.XrayDataUrl)
+	}
 }
 
 func NewBuildScanSummary(cmdResults *results.SecurityCommandResults, serverDetails *config.ServerDetails, vulnerabilitiesRequested bool, buildName, buildNumber string) (summary ScanCommandResultSummary, err error) {

--- a/utils/results/output/securityJobSummary.go
+++ b/utils/results/output/securityJobSummary.go
@@ -98,7 +98,9 @@ func setScaScanReferences(summary *formats.ResultsSummary, cmdResults *results.S
 				continue
 			}
 			for _, scaResponse := range target.ScaResults.DeprecatedXrayResults {
-				addScaScanReference(summary.Scans[i].Vulnerabilities, scaResponse)
+				if summary.Scans[i].Vulnerabilities != nil {
+					addScaScanReference(summary.Scans[i].Vulnerabilities, scaResponse)
+				}
 				if summary.Scans[i].Violations != nil {
 					addScaScanReference(&summary.Scans[i].Violations.ScanResultSummary, scaResponse)
 				}
@@ -108,9 +110,6 @@ func setScaScanReferences(summary *formats.ResultsSummary, cmdResults *results.S
 }
 
 func addScaScanReference(issues *formats.ScanResultSummary, scaResponse services.ScanResponse) {
-	if issues == nil {
-		return
-	}
 	if issues.ScaResults == nil {
 		issues.ScaResults = &formats.ScaScanResultSummary{}
 	}

--- a/utils/results/output/securityJobSummary_test.go
+++ b/utils/results/output/securityJobSummary_test.go
@@ -14,11 +14,14 @@ import (
 	"github.com/jfrog/jfrog-cli-security/tests/validations"
 	"github.com/jfrog/jfrog-cli-security/utils"
 	"github.com/jfrog/jfrog-cli-security/utils/formats"
+	"github.com/jfrog/jfrog-cli-security/utils/formats/violationutils"
 	"github.com/jfrog/jfrog-cli-security/utils/jasutils"
 	"github.com/jfrog/jfrog-cli-security/utils/results"
+	"github.com/jfrog/jfrog-cli-security/utils/severityutils"
 	"github.com/jfrog/jfrog-client-go/utils/io/fileutils"
 	"github.com/jfrog/jfrog-client-go/utils/log"
 	clientTests "github.com/jfrog/jfrog-client-go/utils/tests"
+	"github.com/jfrog/jfrog-client-go/xray/services"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -549,4 +552,41 @@ func getOutputFromFile(t *testing.T, path string) string {
 	content, err := os.ReadFile(path)
 	assert.NoError(t, err)
 	return strings.ReplaceAll(string(content), "\r\n", "\n")
+}
+
+func TestScaScanReference(t *testing.T) {
+	const xrayDataUrl = "https://myserver.com/ui/scans-list/builds-scans/build-name/scan-descendants/1"
+	testCases := []struct {
+		name                   string
+		includeVulnerabilities bool
+	}{
+		{name: "Violations only"},
+		{name: "Violations and vulnerabilities", includeVulnerabilities: true},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			cmdResults := results.NewCommandResults(utils.Build)
+			cmdResults.Violations = &violationutils.Violations{Sca: []violationutils.CveViolation{{
+				ScaViolation: violationutils.ScaViolation{Violation: violationutils.Violation{
+					ViolationType: violationutils.CveViolationType,
+					Severity:      severityutils.High,
+					Watch:         "watch-name",
+				}},
+			}}}
+			cmdResults.NewScanResults(results.ScanTarget{Name: "build-name (1)"}).ScaScanResults(0, services.ScanResponse{
+				ScanId:      validations.TestScaScanId,
+				XrayDataUrl: xrayDataUrl,
+			})
+
+			summary, err := NewBuildScanSummary(cmdResults, &config.ServerDetails{Url: validations.TestPlatformUrl}, testCase.includeVulnerabilities, "build-name", "1")
+			assert.NoError(t, err)
+			assert.Len(t, summary.Summary.Scans, 1)
+			assert.Equal(t, []string{validations.TestScaScanId}, summary.Summary.Scans[0].Violations.ScaResults.ScanIds)
+			assert.Equal(t, []string{xrayDataUrl}, summary.Summary.Scans[0].Violations.ScaResults.MoreInfoUrls)
+			if testCase.includeVulnerabilities {
+				assert.Equal(t, []string{validations.TestScaScanId}, summary.Summary.Scans[0].Vulnerabilities.ScaResults.ScanIds)
+				assert.Equal(t, []string{xrayDataUrl}, summary.Summary.Scans[0].Vulnerabilities.ScaResults.MoreInfoUrls)
+			}
+		})
+	}
 }


### PR DESCRIPTION
https://jfrog-int.atlassian.net/browse/XRAY-159000

# Background

In the job summary of a published build, the table shows "Security Violations" and "Security Issues", each linking "See the results of the scan in JFrog". The Issues link opens that build's scan results; the Violations link opens the unfiltered list of every build scan on the platform, so users have to search for their own build by hand.

# Description

Xray returns the link to the scan results (`more_details_url`) on the SCA scan response. It was copied to the summary inside `parseScaVulnerabilities`, which the convertor gates behind `IncludeVulnerabilities`, so violations never got it and `getJfrogUrl` fell back to the generic `ui/scans-list/builds-scans`. The job summary now attaches it to every issue type of the scan, next to the target names adjustment it already does (a violations only run, `jf build-scan --violations`, never reaches the vulnerabilities parsing at all, so the reference has to be read outside of it).

# Tests

`TestScaScanReference` covers both modes. Live e2e on a SaaS platform: `jf mvn` -> `jf rt build-publish` -> `jf build-scan` -> `jf gsm`, with and without `--vuln`; both cells deep-link to the scanned build.

<!-- screenshot -->

-----
- [ ] The pull request is targeting the `dev` branch.
- [ ] The code has been validated to compile successfully by running `go vet ./...`.
- [ ] The code has been formatted properly using `go fmt ./...`.
- [ ] All [static analysis checks](https://github.com/jfrog/jfrog-cli-security/actions/workflows/analysis.yml) passed.
- [ ] All [tests](https://github.com/jfrog/jfrog-cli-security/actions/workflows/test.yml) have passed. If this feature is not already covered by the tests, new tests have been added.
- [ ] Updated the [Contributing page](https://github.com/jfrog/jfrog-cli-security/blob/main/CONTRIBUTING.md) / [ReadMe page](https://github.com/jfrog/jfrog-cli-security/blob/main/README.md) / [CI Workflow files](https://github.com/jfrog/jfrog-cli-security/tree/main/.github/workflows) if needed.
- [ ] All changes are detailed at the description. if not already covered at [JFrog Documentation](https://github.com/jfrog/documentation), new documentation have been added.

-----