### PR TITLE
Adds GeneralEvent call in jf scan to enable external analytics

### DIFF
--- a/commands/scan/scan.go
+++ b/commands/scan/scan.go
@@ -234,16 +234,12 @@ func (scanCmd *ScanCommand) Run() (err error) {
 	})
 }
 
-// Returns a single descriptive string of the scan's targets. Multiple targets are joined since jf scan may have multiple working-directory
 func (scanCmd *ScanCommand) getAnalyticsProjectPath() string {
-	if scanCmd.spec == nil {
+	currentDir, err := coreutils.GetWorkingDirectory()
+	if err != nil {
 		return ""
 	}
-	patterns := make([]string, 0, len(scanCmd.spec.Files))
-	for _, file := range scanCmd.spec.Files {
-		patterns = append(patterns, file.Pattern)
-	}
-	return strings.Join(patterns, ", ")
+	return currentDir
 }
 
 func (scanCmd *ScanCommand) recordResults(scanResults *results.SecurityCommandResults) (err error) {

--- a/commands/scan/scan.go
+++ b/commands/scan/scan.go
@@ -46,6 +46,7 @@ import (
 	xrayClient "github.com/jfrog/jfrog-client-go/xray"
 	"github.com/jfrog/jfrog-client-go/xray/services"
 	xrayClientUtils "github.com/jfrog/jfrog-client-go/xray/services/utils"
+	xscservices "github.com/jfrog/jfrog-client-go/xsc/services"
 )
 
 type FileContext func(string) parallel.TaskFunc
@@ -217,7 +218,32 @@ func (scanCmd *ScanCommand) SetScansToPerform(scansToPerform []utils.SubScanType
 }
 
 func (scanCmd *ScanCommand) Run() (err error) {
-	return scanCmd.RunAndRecordResults(utils.Binary, scanCmd.recordResults)
+	scanCmd.multiScanId, scanCmd.startTime = xsc.SendNewScanEvent(
+		scanCmd.xrayVersion,
+		scanCmd.xscVersion,
+		scanCmd.serverDetails,
+		xsc.CreateAnalyticsEvent(xscservices.CliProduct, xscservices.CliEventType, scanCmd.serverDetails, scanCmd.getAnalyticsProjectPath()),
+		scanCmd.resultsContext.ProjectKey,
+	)
+	return scanCmd.RunAndRecordResults(utils.Binary, func(scanResults *results.SecurityCommandResults) (err error) {
+		if scanResults == nil {
+			return
+		}
+		xsc.SendScanEndedWithResults(scanCmd.serverDetails, scanResults)
+		return scanCmd.recordResults(scanResults)
+	})
+}
+
+// Returns a single descriptive string of the scan's targets. Multiple targets are joined since jf scan may have multiple working-directory
+func (scanCmd *ScanCommand) getAnalyticsProjectPath() string {
+	if scanCmd.spec == nil {
+		return ""
+	}
+	patterns := make([]string, 0, len(scanCmd.spec.Files))
+	for _, file := range scanCmd.spec.Files {
+		patterns = append(patterns, file.Pattern)
+	}
+	return strings.Join(patterns, ", ")
 }
 
 func (scanCmd *ScanCommand) recordResults(scanResults *results.SecurityCommandResults) (err error) {


### PR DESCRIPTION
- [ ] The pull request is targeting the `dev` branch.
- [ ] The code has been validated to compile successfully by running `go vet ./...`.
- [ ] The code has been formatted properly using `go fmt ./...`.
- [ ] All [static analysis checks](https://github.com/jfrog/jfrog-cli-security/actions/workflows/analysis.yml) passed.
- [ ] All [tests](https://github.com/jfrog/jfrog-cli-security/actions/workflows/test.yml) have passed. If this feature is not already covered by the tests, new tests have been added.
- [ ] Updated the [Contributing page](https://github.com/jfrog/jfrog-cli-security/blob/main/CONTRIBUTING.md) / [ReadMe page](https://github.com/jfrog/jfrog-cli-security/blob/main/README.md) / [CI Workflow files](https://github.com/jfrog/jfrog-cli-security/tree/main/.github/workflows) if needed.
- [ ] All changes are detailed at the description. if not already covered at [JFrog Documentation](https://github.com/jfrog/documentation), new documentation have been added.

-----