### PR TITLE
Fix Audit SCA parallel runs

### DIFF
--- a/sca/scan/scangraph/runner.go
+++ b/sca/scan/scangraph/runner.go
@@ -68,14 +68,16 @@ func (sg *ScanGraphStrategy) DeprecatedScanTask(target *cyclonedx.BOM) (techResu
 		// If there is no tree, or a tree without any non-root dependencies - we don't need to scan it
 		return services.ScanResponse{}, nil
 	}
-	sg.XrayGraphScanParams().DependenciesGraph = flatTree
+	// Copy params so concurrent SCA tasks do not overwrite each other's graph or technology.
+	scanParams := sg.ScanGraphParams.Clone()
+	scanParams.XrayGraphScanParams().DependenciesGraph = flatTree
 	if targetTechnology := resolveTechnologyFromBOM(target); targetTechnology != techutils.NoTech {
 		// Report the technology to Xray.
-		sg.SetTechnology(targetTechnology)
-		sg.XrayGraphScanParams().Technology = targetTechnology.String()
+		scanParams.SetTechnology(targetTechnology)
+		scanParams.XrayGraphScanParams().Technology = targetTechnology.String()
 	}
 	// Send the scan graph params to run the scan.
-	return runXrayDependenciesTreeScanGraph(&sg.ScanGraphParams, fullTree)
+	return runXrayDependenciesTreeScanGraph(&scanParams, fullTree)
 }
 
 func resolveTechnologyFromBOM(target *cyclonedx.BOM) (tech techutils.Technology) {

--- a/sca/scan/scangraph/runner.go
+++ b/sca/scan/scangraph/runner.go
@@ -69,7 +69,7 @@ func (sg *ScanGraphStrategy) DeprecatedScanTask(target *cyclonedx.BOM) (techResu
 		return services.ScanResponse{}, nil
 	}
 	// Copy params so concurrent SCA tasks do not overwrite each other's graph or technology.
-	scanParams := sg.ScanGraphParams.Clone()
+	scanParams := sg.Clone()
 	scanParams.XrayGraphScanParams().DependenciesGraph = flatTree
 	if targetTechnology := resolveTechnologyFromBOM(target); targetTechnology != techutils.NoTech {
 		// Report the technology to Xray.

--- a/sca/scan/scascan.go
+++ b/sca/scan/scascan.go
@@ -90,10 +90,16 @@ func createScaScanTaskWithRunner(auditParallelRunner *utils.SecurityParallelRunn
 	return func(threadId int) (err error) {
 		defer auditParallelRunner.ScaScansWg.Done()
 		params.ThreadId = threadId
-		auditParallelRunner.ResultsMu.Lock()
-		defer auditParallelRunner.ResultsMu.Unlock()
 		return scaScanTask(strategy, params)
 	}
+}
+
+func (params ScaScanParams) withResultsLock(write func()) {
+	if params.Runner != nil {
+		params.Runner.ResultsMu.Lock()
+		defer params.Runner.ResultsMu.Unlock()
+	}
+	write()
 }
 
 func shouldRunScan(params ScaScanParams) (bool, error) {
@@ -152,7 +158,9 @@ func scaScanTask(strategy SbomScanStrategy, params ScaScanParams) (err error) {
 	if !params.IsNewFlow {
 		scanResults, err := strategy.DeprecatedScanTask(params.ScanResults.ScaResults.Sbom)
 		// We add the results before checking for errors, so we can display the results even if an error occurred.
-		params.ScanResults.ScaScanResults(GetScaScansStatusCode(err, scanResults), scanResults)
+		params.withResultsLock(func() {
+			params.ScanResults.ScaScanResults(GetScaScansStatusCode(err, scanResults), scanResults)
+		})
 		if err != nil {
 			return err
 		}
@@ -162,7 +170,9 @@ func scaScanTask(strategy SbomScanStrategy, params ScaScanParams) (err error) {
 	// New flow: we scan the SBOM and enrich it with CVE vulnerabilities and calculate violations.
 	bomWithVulnerabilities, err := strategy.SbomEnrichTask(params.ScanResults.ScaResults.Sbom)
 	// We add the results before checking for errors, so we can display the results even if an error occurred.
-	params.ScanResults.EnrichedSbomScanResults(GetScaScansStatusCode(err), bomWithVulnerabilities)
+	params.withResultsLock(func() {
+		params.ScanResults.EnrichedSbomScanResults(GetScaScansStatusCode(err), bomWithVulnerabilities)
+	})
 	if err != nil {
 		return fmt.Errorf("failed to enrich SBOM for %s: %w", params.ScanResults.Target, err)
 	}

--- a/sca/scan/scascan_test.go
+++ b/sca/scan/scascan_test.go
@@ -1,0 +1,100 @@
+package scan
+
+import (
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/CycloneDX/cyclonedx-go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/jfrog/jfrog-cli-security/utils"
+	"github.com/jfrog/jfrog-cli-security/utils/results"
+	"github.com/jfrog/jfrog-client-go/xray/services"
+)
+
+type barrierScanStrategy struct {
+	ready *sync.WaitGroup
+	start chan struct{}
+}
+
+func (s *barrierScanStrategy) WithOptions(...SbomScanOption) SbomScanStrategy { return s }
+func (s *barrierScanStrategy) PrepareStrategy() error                         { return nil }
+
+func (s *barrierScanStrategy) SbomEnrichTask(target *cyclonedx.BOM) (*cyclonedx.BOM, error) {
+	_, err := s.DeprecatedScanTask(target)
+	return target, err
+}
+
+func (s *barrierScanStrategy) DeprecatedScanTask(*cyclonedx.BOM) (services.ScanResponse, error) {
+	s.ready.Done()
+	select {
+	case <-s.start:
+		return services.ScanResponse{ScanId: "parallel-sca"}, nil
+	case <-time.After(2 * time.Second):
+		return services.ScanResponse{}, errScaTasksDidNotOverlap
+	}
+}
+
+var errScaTasksDidNotOverlap = errors.New("SCA tasks did not overlap; ResultsMu likely serializes the scan")
+
+func TestRunScaScanWithRunnerRunsTargetsInParallel(t *testing.T) {
+	for _, tc := range []struct {
+		name      string
+		isNewFlow bool
+	}{
+		{name: "deprecated scan graph", isNewFlow: false},
+		{name: "sbom enrich", isNewFlow: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			const targetCount = 2
+			var ready sync.WaitGroup
+			ready.Add(targetCount)
+			start := make(chan struct{})
+			strategy := &barrierScanStrategy{ready: &ready, start: start}
+
+			cmdResults := results.NewCommandResults(utils.SourceCode)
+			runner := utils.CreateSecurityParallelRunner(targetCount)
+			for i := 0; i < targetCount; i++ {
+				target := cmdResults.NewScanResults(results.ScanTarget{Target: t.Name() + string(rune('a'+i))})
+				target.SetSbom(librarySbom())
+				require.NoError(t, RunScaScan(strategy, ScaScanParams{
+					ScanResults: target,
+					TargetCount: targetCount,
+					Runner:      runner,
+					IsNewFlow:   tc.isNewFlow,
+				}))
+			}
+
+			go func() {
+				ready.Wait()
+				close(start)
+			}()
+			runner.Start()
+
+			for _, target := range cmdResults.Targets {
+				require.Empty(t, target.GetNotSkippedErrors())
+				require.NotNil(t, target.ScaResults)
+				if tc.isNewFlow {
+					require.NotNil(t, target.ScaResults.Sbom)
+					continue
+				}
+				require.Len(t, target.ScaResults.DeprecatedXrayResults, 1)
+				assert.Equal(t, "parallel-sca", target.ScaResults.DeprecatedXrayResults[0].ScanId)
+			}
+		})
+	}
+}
+
+func librarySbom() *cyclonedx.BOM {
+	sbom := cyclonedx.NewBOM()
+	components := []cyclonedx.Component{{
+		BOMRef: "pkg:npm/example@1.0.0",
+		Name:   "example",
+		Type:   cyclonedx.ComponentTypeLibrary,
+	}}
+	sbom.Components = &components
+	return sbom
+}

--- a/utils/xray/scangraph/params.go
+++ b/utils/xray/scangraph/params.go
@@ -59,8 +59,6 @@ func (sgp *ScanGraphParams) Technology() techutils.Technology {
 	return sgp.technology
 }
 
-// Clone returns a copy that can be mutated per scan without racing other concurrent scans
-// that share the original params (DependenciesGraph and Technology are set per target).
 func (sgp ScanGraphParams) Clone() ScanGraphParams {
 	cloned := sgp
 	if sgp.xrayGraphScanParams != nil {

--- a/utils/xray/scangraph/params.go
+++ b/utils/xray/scangraph/params.go
@@ -58,3 +58,14 @@ func (sgp *ScanGraphParams) SetTechnology(technology techutils.Technology) *Scan
 func (sgp *ScanGraphParams) Technology() techutils.Technology {
 	return sgp.technology
 }
+
+// Clone returns a copy that can be mutated per scan without racing other concurrent scans
+// that share the original params (DependenciesGraph and Technology are set per target).
+func (sgp ScanGraphParams) Clone() ScanGraphParams {
+	cloned := sgp
+	if sgp.xrayGraphScanParams != nil {
+		paramsCopy := *sgp.xrayGraphScanParams
+		cloned.xrayGraphScanParams = &paramsCopy
+	}
+	return cloned
+}

--- a/utils/xray/scangraph/scangraph_test.go
+++ b/utils/xray/scangraph/scangraph_test.go
@@ -4,9 +4,31 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/jfrog/jfrog-cli-security/utils/techutils"
 	"github.com/jfrog/jfrog-client-go/xray/services"
+	xrayUtils "github.com/jfrog/jfrog-client-go/xray/services/utils"
 	"github.com/stretchr/testify/assert"
 )
+
+func TestScanGraphParamsCloneDoesNotShareMutableGraph(t *testing.T) {
+	original := NewScanGraphParams().
+		SetXrayGraphScanParams(&services.XrayGraphScanParams{
+			ProjectKey: "proj",
+			Technology: "npm",
+		}).
+		SetTechnology(techutils.Npm)
+	cloned := original.Clone()
+
+	cloned.XrayGraphScanParams().DependenciesGraph = &xrayUtils.GraphNode{Id: "cloned-root"}
+	cloned.XrayGraphScanParams().Technology = techutils.Yarn.String()
+	cloned.SetTechnology(techutils.Yarn)
+
+	assert.Nil(t, original.XrayGraphScanParams().DependenciesGraph)
+	assert.Equal(t, techutils.Npm, original.Technology())
+	assert.Equal(t, "npm", original.XrayGraphScanParams().Technology)
+	assert.Equal(t, "proj", cloned.XrayGraphScanParams().ProjectKey)
+	assert.Equal(t, "cloned-root", cloned.XrayGraphScanParams().DependenciesGraph.Id)
+}
 
 func TestFilterResultIfNeeded(t *testing.T) {
 	// Define test cases


### PR DESCRIPTION
## Summary
`--threads` was supposed to run SCA per target in parallel, but `ResultsMu` was held for the entire scan-graph/enrich call. Threads were created, yet SCA work stayed sequential (JAS already scaled because it only locks when writing results).

This PR:
- Locks `ResultsMu` only while attaching SCA results, matching JAS.
- Clones scan-graph params per target so concurrent scans do not share `DependenciesGraph` / technology.
- Adds tests that overlapping SCA tasks actually run together (`-race` clean).

Dependency-tree / SBOM generation is still sequential (`os.Chdir` per target). That is out of scope here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved scan isolation to prevent concurrent SCA scans from overwriting each other’s dependency or technology data.
  - Ensured scan results are written safely when multiple targets are processed at the same time.
  - Improved consistency of results across both legacy scan-graph and newer SBOM enrichment flows.

- **Performance**
  - SCA scans now process multiple targets in parallel, reducing overall scan completion time.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->