### PR TITLE
XRAY-159447 - cvs fallback for pypi

### DIFF
--- a/commands/curation/curationaudit.go
+++ b/commands/curation/curationaudit.go
@@ -84,6 +84,11 @@ const (
 
 	extractPoliciesRegexTemplate = "({.*?})"
 
+	// allVersionsBlockedMsgPattern matches Artifactory's whole-package-block message, e.g.
+	// "All versions blocked - {policy:openssf-jfca,condition:openssf}". Unlike the per-version
+	// download-block message (gated by BlockMessageKey), it only carries policy + condition.
+	allVersionsBlockedMsgPattern = `(?i)all versions blocked\s*-\s*\{\s*policy\s*:\s*([^,}]+?)\s*,\s*condition\s*:\s*([^}]+?)\s*\}`
+
 	errorTemplateHeadRequest = "failed sending HEAD request to %s for package '%s:%s'. Status-code: %v. Cause: %v"
 
 	errorTemplateUnsupportedTech = "It looks like this project uses '%s' to download its dependencies. " +
@@ -102,13 +107,12 @@ const (
 	MinXrayPassThroughSupport = "3.92.0"
 	MinArtiGradleGemSupport   = "7.63.5"
 
-	// cvsPartialReportWarning is shown when pip or poetry resolution failed because CVS
-	// stripped a required version from the simple index, but the metadata-API
-	// fallback succeeded in recovering at least one policy violation.
-	cvsPartialReportWarning = "The curation audit was unable to fully resolve the dependency tree because one or more pinned package versions " +
-		"are blocked by the curation policy. Details of the policy violations are shown in the table below.\n" +
-		"Dependency analysis cannot proceed until these issues are addressed.\n" +
-		"Once you switch to an approved version and re-run the audit, additional results will be available."
+	// cvsPartialReportWarningTemplate is shown when a Python package manager's resolution
+	// failed due to a curation block, but the fallback still recovered a partial report.
+	// %s is the technology name (pip/poetry/pipenv/uv), filled in at print time.
+	cvsPartialReportWarningTemplate = "%s could not fully resolve the dependency tree because one or more packages " +
+		"are blocked by the curation policy, so this report may be incomplete. Dependencies of blocked packages " +
+		"could not be analyzed because their metadata was unavailable."
 
 	// hfUnresolvedReportKey is used when an HF scan found only dynamic references — no table, just warnings.
 	hfUnresolvedReportKey = "huggingface (unresolved references)"
@@ -126,6 +130,7 @@ const (
 var CurationOutputFormats = []string{string(outFormat.Table), string(outFormat.Json)}
 var osGetwd = os.Getwd
 var npmGetConfigValue = npmtech.GetNpmConfigValue
+var allVersionsBlockedMsgRegex = regexp.MustCompile(allVersionsBlockedMsgPattern)
 
 var supportedTech = map[techutils.Technology]func(ca *CurationAuditCommand) (bool, error){
 	techutils.Npm:  func(ca *CurationAuditCommand) (bool, error) { return true, nil },
@@ -483,7 +488,7 @@ func (ca *CurationAuditCommand) Run() (err error) {
 	}
 	for projectPath, report := range results {
 		if report.isPartial {
-			warningText := cvsPartialReportWarning
+			warningText := fmt.Sprintf(cvsPartialReportWarningTemplate, cvsFallbackTechName(report))
 			if report.npmLogPartial {
 				warningText = npmLogPartialReportWarning
 				log.Debug(fmt.Sprintf("[%s] underlying npm error: %s", projectPath, report.npmLogOriginalErr))
@@ -2474,6 +2479,15 @@ func (ca *CurationAuditCommand) runCvsFallback(cvsErr *python.CvsBlockedError, t
 	return nil
 }
 
+// cvsFallbackTechName returns the package-manager name to show in
+// cvsPartialReportWarningTemplate, taken from the first row's PkgType.
+func cvsFallbackTechName(report *CurationReport) string {
+	if len(report.packagesStatus) > 0 && report.packagesStatus[0].PkgType != "" {
+		return report.packagesStatus[0].PkgType
+	}
+	return "the package manager"
+}
+
 // cleanupForcedNpmDebugLog removes the log our forced --logs-max override caused npm to write,
 // when logs-max=0. Success-path counterpart to runNpmLogFallback's cleanup; baselineKey (see
 // npmDebugLogNewestKey) ensures a stale pre-existing log is never removed by mistake.
@@ -2683,61 +2697,105 @@ func wholePackageBlockedStatus(entry npmLogEntry, info npmBlockedInfo, tech tech
 	}
 }
 
-// applyTransitiveAwareRecommendation: "remove and replace" is only actionable when the
-// blocked package is itself a direct dependency; otherwise name the real direct dependency.
-// ps.Policy is reassigned, not mutated in place — fillGraphRelations clones *PackageStatus
-// per edge via a shallow copy, so edges sharing a preProcessMap entry share the same array.
+// applyTransitiveAwareRecommendation normalizes Explanation/Recommendation to generic,
+// direct/transitive-aware text for a whole-package block (matches npm's behavior).
+// Rewrites every entry in ps.Policy — only safe to call when every entry is already known
+// to be a whole-package condition (e.g. Step 0's own aggregate result). For a per-version
+// probe result, use normalizeMatchingWholePackagePolicies instead, so a genuinely different
+// second policy isn't clobbered. Policy is reassigned, not mutated in place, since
+// PackageStatus copies can share it.
 func applyTransitiveAwareRecommendation(ps *PackageStatus, isDirectDependency bool) {
 	policies := make([]Policy, len(ps.Policy))
 	copy(policies, ps.Policy)
 	for i := range policies {
-		if isDirectDependency {
-			policies[i].Recommendation = "Remove this package from your project and replace with an alternate package"
-		} else {
-			policies[i].Recommendation = fmt.Sprintf(
-				"%s is a transitive dependency of %s and cannot be removed directly. Apply a waiver if acceptable, or replace %s with an alternative that doesn't depend on %s.",
-				ps.PackageName, ps.ParentName, ps.ParentName, ps.PackageName)
-		}
+		normalizeWholePackagePolicy(&policies[i], ps, isDirectDependency)
 	}
 	ps.Policy = policies
 }
 
-// lookupPypiAllVersions calls the Artifactory PyPI metadata API for a package
-// name (no version — returns all releases) and returns all available version
-// strings. This endpoint is NOT filtered by CVS, so it includes versions that
-// have been stripped from the simple index.
-func (nc *treeAnalyzer) lookupPypiAllVersions(name string) ([]string, error) {
-	metadataURL := fmt.Sprintf("%s/api/pypi/%s/pypi/%s/json",
-		strings.TrimSuffix(nc.url, "/"), nc.repo, name)
+// normalizeMatchingWholePackagePolicies rewrites Explanation/Recommendation to the generic,
+// direct/transitive-aware text only for the entries in ps.Policy that match one of
+// aggregatePolicies by Policy+Condition — i.e. the SAME whole-package condition Step 0
+// already confirmed. Any other entry (a genuinely distinct, real per-version policy) is left
+// untouched. Policy is reassigned, not mutated in place, since PackageStatus copies can share it.
+func normalizeMatchingWholePackagePolicies(ps *PackageStatus, aggregatePolicies []Policy, isDirectDependency bool) {
+	policies := make([]Policy, len(ps.Policy))
+	copy(policies, ps.Policy)
+	for i := range policies {
+		if !matchesAnyPolicy(policies[i], aggregatePolicies) {
+			continue
+		}
+		normalizeWholePackagePolicy(&policies[i], ps, isDirectDependency)
+	}
+	ps.Policy = policies
+}
+
+// matchesAnyPolicy reports whether p shares the same Policy+Condition as any of candidates.
+func matchesAnyPolicy(p Policy, candidates []Policy) bool {
+	for _, c := range candidates {
+		if p.Policy == c.Policy && p.Condition == c.Condition {
+			return true
+		}
+	}
+	return false
+}
+
+// normalizeWholePackagePolicy rewrites a single Policy entry's Explanation/Recommendation
+// to the generic, direct/transitive-aware text for a whole-package block.
+func normalizeWholePackagePolicy(p *Policy, ps *PackageStatus, isDirectDependency bool) {
+	p.Explanation = allVersionsBlockedText
+	if isDirectDependency {
+		p.Recommendation = "Remove this package from your project and replace with an alternate package"
+	} else {
+		p.Recommendation = fmt.Sprintf(
+			"%s is a transitive dependency of %s and cannot be removed directly. Apply a waiver if acceptable, or replace %s with an alternative that doesn't depend on %s.",
+			ps.PackageName, ps.ParentName, ps.ParentName, ps.PackageName)
+	}
+}
+
+// pypiAllVersionsMetadataURL is the single source of truth for the package-level
+// (all-versions) PyPI metadata URL — shared by lookupPypiAllVersions and the
+// whole-package-block policy recovery in fetchCvsBlockedStatus, so the two never drift apart.
+func pypiAllVersionsMetadataURL(artiUrl, repo, name string) string {
+	return fmt.Sprintf("%s/api/pypi/%s/pypi/%s/json", strings.TrimSuffix(artiUrl, "/"), repo, name)
+}
+
+// lookupPypiAllVersions fetches all available version strings for a package from
+// Artifactory's PyPI metadata API. If every version is blocked, this endpoint returns 403;
+// allBlocked flags that case so callers can distinguish it from a generic fetch failure.
+func (nc *treeAnalyzer) lookupPypiAllVersions(name string) (versions []string, allBlocked bool, err error) {
+	metadataURL := pypiAllVersionsMetadataURL(nc.url, nc.repo, name)
 
 	requestDetails := nc.httpClientDetails.Clone()
 	var resp *http.Response
 	var body []byte
-	var err error
 	if nc.tech == techutils.Pip || nc.tech == techutils.Poetry || nc.tech == techutils.Pipenv || nc.tech == techutils.Uv {
 		resp, body, err = nc.sendBoundedRequest(http.MethodGet, metadataURL, requestDetails)
 	} else {
 		resp, body, _, err = nc.rtManager.Client().SendGet(metadataURL, true, requestDetails)
 	}
 	if err != nil {
-		return nil, fmt.Errorf("all-versions metadata API request failed for %s: %w", name, err)
+		return nil, false, fmt.Errorf("all-versions metadata API request failed for %s: %w", name, err)
+	}
+	if resp.StatusCode == http.StatusForbidden {
+		return nil, true, nil
 	}
 	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("all-versions metadata API returned HTTP %d for %s", resp.StatusCode, name)
+		return nil, false, fmt.Errorf("all-versions metadata API returned HTTP %d for %s", resp.StatusCode, name)
 	}
 
 	var meta struct {
 		Releases map[string]json.RawMessage `json:"releases"`
 	}
 	if err := json.Unmarshal(body, &meta); err != nil {
-		return nil, fmt.Errorf("failed to parse all-versions metadata for %s: %w", name, err)
+		return nil, false, fmt.Errorf("failed to parse all-versions metadata for %s: %w", name, err)
 	}
 
-	versions := make([]string, 0, len(meta.Releases))
+	versions = make([]string, 0, len(meta.Releases))
 	for v := range meta.Releases {
 		versions = append(versions, v)
 	}
-	return versions, nil
+	return versions, false, nil
 }
 
 // lookupPypiNormalDownloadURL calls the Artifactory PyPI metadata API for
@@ -2796,8 +2854,12 @@ func (nc *treeAnalyzer) lookupPypiNormalDownloadURL(name, ver string) (string, e
 
 // fetchCvsBlockedStatus recovers the curation policy for each CVS-blocked package:
 //
-//  1. For range-based blockers (PinnedRequirement.VersionRange set): resolve the
-//     newest version satisfying the range via the unfiltered all-versions metadata API.
+//  0. Whole-package check (every pin — pinned, ranged, or transitive): query the
+//     all-versions metadata API. If every version is blocked, there's no concrete
+//     version to probe further, so render the row directly as "All versions blocked"
+//     (mirrors npm's wholePackageBlockedStatus). Takes priority over steps 1-3.
+//  1. Otherwise, for range-based or version-less blockers: resolve the newest
+//     version satisfying the range from the all-versions list fetched in step 0.
 //  2. Call the version-specific metadata API to get the normal download URL.
 //  3. Probe the normal (non-audit) download URL via getBlockedPackageDetails.
 //
@@ -2812,15 +2874,59 @@ func (nc *treeAnalyzer) lookupPypiNormalDownloadURL(name, ver string) (string, e
 func (nc *treeAnalyzer) fetchCvsBlockedStatus(pins []python.PinnedRequirement) []*PackageStatus {
 	var statuses []*PackageStatus
 	for _, pin := range pins {
+		depRelation := directRelation
+		if effectiveParent(pin) != pin.Name {
+			depRelation = indirectRelation
+		} else if pin.Version == "" && pin.VersionRange == "" && !pin.ConfirmedDirect {
+			depRelation = indirectRelation
+		}
+
+		allVersions, allBlocked, avErr := nc.lookupPypiAllVersions(pin.Name)
+		wholePackageBlocked := false
+		var wholePackageFallback *PackageStatus
+		if allBlocked {
+			wholePackageBlocked = true
+			metadataURL := pypiAllVersionsMetadataURL(nc.url, nc.repo, pin.Name)
+			pkStatus, getErr := nc.getBlockedPackageDetails(metadataURL, pin.Name, allVersionsBlockedText)
+			if getErr != nil {
+				log.Debug(fmt.Sprintf("curation-blocked resolution fallback: whole-package policy recovery failed for %s: %v",
+					pin.Name, getErr))
+			}
+			if pkStatus == nil {
+				pkStatus = &PackageStatus{
+					PackageName:       pin.Name,
+					BlockedPackageUrl: metadataURL,
+					Action:            blocked,
+					BlockingReason:    BlockingReasonUnknown,
+					PkgType:           string(nc.tech),
+				}
+			}
+			pkStatus.PackageName = pin.Name
+			pkStatus.PackageVersion = allVersionsBlockedText
+			pkStatus.ParentName = effectiveParent(pin)
+			pkStatus.ParentVersion = effectiveParentVersion(pin, true)
+			pkStatus.DepRelation = depRelation
+
+			if len(pkStatus.Policy) > 0 {
+				applyTransitiveAwareRecommendation(pkStatus, depRelation == directRelation)
+			}
+			wholePackageFallback = pkStatus
+
+			if pin.VersionRange != "" || pin.Version == "" {
+				statuses = append(statuses, wholePackageFallback)
+				continue
+			}
+		}
+
 		// ── Step 1: resolve range / no-version → exact version ───────────────
 		resolvedVersion := pin.Version
-		if pin.VersionRange != "" || resolvedVersion == "" {
+		if !wholePackageBlocked && (pin.VersionRange != "" || resolvedVersion == "") {
 			// Either a range spec or a ResolutionImpossible entry with no version.
-			// Use the unfiltered all-versions metadata API to find the newest match.
-			allVersions, err := nc.lookupPypiAllVersions(pin.Name)
-			if err != nil {
+			// Reuse the all-versions list already fetched in step 0 — not
+			// whole-package-blocked, so avErr (if any) is a real, non-403 failure.
+			if avErr != nil {
 				log.Debug(fmt.Sprintf("curation-blocked resolution fallback: all-versions lookup failed for %s%s: %v",
-					pin.Name, pin.VersionRange, err))
+					pin.Name, pin.VersionRange, avErr))
 				continue
 			}
 			if pin.VersionRange != "" {
@@ -2837,17 +2943,24 @@ func (nc *treeAnalyzer) fetchCvsBlockedStatus(pins []python.PinnedRequirement) [
 			log.Debug(fmt.Sprintf("curation-blocked resolution fallback: resolved %s%s → %s",
 				pin.Name, pin.VersionRange, resolvedVersion))
 		}
+		// A pinned exact pin already has its version and never needed the
+		// all-versions list at all, so any avErr above (a transient, non-403
+		// failure) is deliberately ignored here rather than dropping the pin.
 
 		// ── Step 2: metadata API → normal download URL ────────────────────────
 		dlURL, err := nc.lookupPypiNormalDownloadURL(pin.Name, resolvedVersion)
 		if err != nil {
+			log.Debug(fmt.Sprintf("curation-blocked resolution fallback: metadata lookup failed for %s==%s: %v — treating as unresolved",
+				pin.Name, resolvedVersion, err))
+			if wholePackageBlocked {
+				statuses = append(statuses, wholePackageFallback)
+				continue
+			}
 			// Version is absent from the metadata API (removed from the index, or
 			// a typo/nonexistent version). There is no recoverable policy to show,
 			// so skip it: with no recoverable blockers the command falls back to
 			// the graceful "Affected package(s)" message (PR #761 behaviour),
 			// rather than rendering a misleading empty table row.
-			log.Debug(fmt.Sprintf("curation-blocked resolution fallback: metadata lookup failed for %s==%s: %v — treating as unresolved",
-				pin.Name, resolvedVersion, err))
 			continue
 		}
 
@@ -2863,12 +2976,21 @@ func (nc *treeAnalyzer) fetchCvsBlockedStatus(pins []python.PinnedRequirement) [
 		if headErr != nil && (headResp == nil || headResp.StatusCode != http.StatusForbidden) {
 			log.Debug(fmt.Sprintf("curation-blocked resolution fallback: HEAD probe failed for %s==%s: %v",
 				pin.Name, resolvedVersion, headErr))
+			if wholePackageBlocked {
+				statuses = append(statuses, wholePackageFallback)
+			}
 			continue
 		}
 		// Package is accessible — CVS cache may be stale; not currently blocked.
+		// If the whole package was already confirmed blocked in Step 0, trust that
+		// package-level result over this single stale-looking probe rather than
+		// silently dropping the row.
 		if headErr == nil && headResp != nil && headResp.StatusCode != http.StatusForbidden {
 			log.Debug(fmt.Sprintf("curation-blocked resolution fallback: HEAD probe returned %d for %s==%s — not CVS-blocked, skipping",
 				headResp.StatusCode, pin.Name, resolvedVersion))
+			if wholePackageBlocked {
+				statuses = append(statuses, wholePackageFallback)
+			}
 			continue
 		}
 
@@ -2882,15 +3004,11 @@ func (nc *treeAnalyzer) fetchCvsBlockedStatus(pins []python.PinnedRequirement) [
 					pin.Name, resolvedVersion, getErr))
 			}
 		}
-		depRelation := directRelation
-		if effectiveParent(pin) != pin.Name {
-			depRelation = indirectRelation
-		} else if pin.Version == "" && pin.VersionRange == "" {
-			// Name-only entry from ResolutionImpossible — parent attribution is
-			// unknown but these are always transitive deps by definition.
-			depRelation = indirectRelation
-		}
 		if pkStatus == nil {
+			if wholePackageBlocked {
+				statuses = append(statuses, wholePackageFallback)
+				continue
+			}
 			// HEAD returned 403 but GET probe errored — CVS stripped the version
 			// from the index but policy details aren't available via this path;
 			// record with unknown reason so the package is never silently dropped.
@@ -2898,7 +3016,7 @@ func (nc *treeAnalyzer) fetchCvsBlockedStatus(pins []python.PinnedRequirement) [
 				PackageName:       pin.Name,
 				PackageVersion:    resolvedVersion,
 				ParentName:        effectiveParent(pin),
-				ParentVersion:     effectiveParentVersion(pin),
+				ParentVersion:     effectiveParentVersion(pin, false),
 				DepRelation:       depRelation,
 				BlockedPackageUrl: dlURL,
 				Action:            blocked,
@@ -2909,13 +3027,26 @@ func (nc *treeAnalyzer) fetchCvsBlockedStatus(pins []python.PinnedRequirement) [
 		}
 
 		// Policy recovered — set parent attribution from the parsed blocker.
+		// When the whole package was confirmed blocked in Step 0, label the row
+		// "All versions blocked" (like npm) even though the rich policy detail
+		// below came from probing this one pinned version's own download URL.
 		pkStatus.PackageName = pin.Name
-		pkStatus.PackageVersion = resolvedVersion
+		if wholePackageBlocked {
+			pkStatus.PackageVersion = allVersionsBlockedText
+		} else {
+			pkStatus.PackageVersion = resolvedVersion
+		}
 		pkStatus.ParentName = effectiveParent(pin)
-		pkStatus.ParentVersion = effectiveParentVersion(pin)
+		pkStatus.ParentVersion = effectiveParentVersion(pin, wholePackageBlocked)
 		pkStatus.DepRelation = depRelation
+		// Normalize only the entries that match the aggregate's policy+condition — a
+		// second, genuinely different real policy in the same probe must be preserved.
+		if wholePackageBlocked && wholePackageFallback != nil && len(wholePackageFallback.Policy) > 0 {
+			normalizeMatchingWholePackagePolicies(pkStatus, wholePackageFallback.Policy, depRelation == directRelation)
+		}
 		statuses = append(statuses, pkStatus)
 	}
+
 	return statuses
 }
 
@@ -2931,18 +3062,23 @@ func effectiveParent(pin python.PinnedRequirement) string {
 }
 
 // effectiveParentVersion returns the version to show in the "Direct Dependency
-// Version" column. For exact pins it is the pinned version.
+// Version" column.
 //
-// For a ranged DIRECT dependency (parent == package, e.g. requirements.txt has
-// "langchain-core>=1.4.0") the range spec itself is shown so the column is not
-// blank. For a TRANSITIVE blocker (parent differs from the package) the range
-// describes the blocked package, not the parent — so it must not be shown in
-// the parent column; we leave it blank when the parent version is unknown.
-func effectiveParentVersion(pin python.PinnedRequirement) string {
-	if pin.ParentVersion != "" {
+// For a genuine TRANSITIVE blocker (parent differs from the package), the
+// parent's own version is shown, whole-package-blocked or not — it resolved fine.
+//
+// For a DIRECT dependency (self-attributed: parent == package or unset), a whole
+// package block leaves this blank — matching npm, which never resolves a concrete
+// version (pinned or ranged) once the packument fetch itself is blocked. Otherwise
+// exact pins show their pinned version, and a ranged spec is shown so it's not blank.
+func effectiveParentVersion(pin python.PinnedRequirement, wholePackageBlocked bool) string {
+	if pin.ParentName != "" && pin.ParentName != pin.Name {
 		return pin.ParentVersion
 	}
-	if pin.VersionRange != "" && (pin.ParentName == "" || pin.ParentName == pin.Name) {
+	if wholePackageBlocked {
+		return ""
+	}
+	if pin.VersionRange != "" {
 		return pin.VersionRange
 	}
 	return pin.Version
@@ -3024,6 +3160,21 @@ func (nc *treeAnalyzer) getBlockedPackageDetails(packageUrl string, name string,
 				BlockingReason:    blockingReason,
 				WaiverAllowed:     strings.Contains(respError.Errors[0].Message, "[waivers allowed]"),
 				PkgType:           string(nc.tech),
+			}, nil
+		}
+		if m := allVersionsBlockedMsgRegex.FindStringSubmatch(respError.Errors[0].Message); m != nil {
+			return &PackageStatus{
+				PackageName:       name,
+				PackageVersion:    version,
+				BlockedPackageUrl: packageUrl,
+				Action:            blocked,
+				BlockingReason:    BlockingReasonPolicy,
+				Policy: []Policy{{
+					Policy:      strings.TrimSpace(m[1]),
+					Condition:   strings.TrimSpace(m[2]),
+					Explanation: allVersionsBlockedText,
+				}},
+				PkgType: string(nc.tech),
 			}, nil
 		}
 	}

--- a/commands/curation/curationaudit_test.go
+++ b/commands/curation/curationaudit_test.go
@@ -685,14 +685,14 @@ func getTestCasesForDoCurationAudit() []testCase {
 			pathToProject:            filepath.Join("projects", "package-managers", "go", "curation-project"),
 			createServerWithoutCreds: true,
 			serveResources: map[string]string{
-				"v1.5.2.mod":                              filepath.Join("resources", "quote-v1.5.2.mod"),
-				"v1.5.2.zip":                              filepath.Join("resources", "quote-v1.5.2.zip"),
-				"v1.5.2.info":                             filepath.Join("resources", "quote-v1.5.2.info"),
-				"v1.3.0.mod":                              filepath.Join("resources", "sampler-v1.3.0.mod"),
-				"v1.3.0.zip":                              filepath.Join("resources", "sampler-v1.3.0.zip"),
-				"v1.3.0.info":                             filepath.Join("resources", "sampler-v1.3.0.info"),
-				"v0.0.0-20170915032832-14c0d48ead0c.mod":  filepath.Join("resources", "text-v0.0.0-20170915032832-14c0d48ead0c.mod"),
-				"v0.0.0-20170915032832-14c0d48ead0c.zip":  filepath.Join("resources", "text-v0.0.0-20170915032832-14c0d48ead0c.zip"),
+				"v1.5.2.mod":                             filepath.Join("resources", "quote-v1.5.2.mod"),
+				"v1.5.2.zip":                             filepath.Join("resources", "quote-v1.5.2.zip"),
+				"v1.5.2.info":                            filepath.Join("resources", "quote-v1.5.2.info"),
+				"v1.3.0.mod":                             filepath.Join("resources", "sampler-v1.3.0.mod"),
+				"v1.3.0.zip":                             filepath.Join("resources", "sampler-v1.3.0.zip"),
+				"v1.3.0.info":                            filepath.Join("resources", "sampler-v1.3.0.info"),
+				"v0.0.0-20170915032832-14c0d48ead0c.mod": filepath.Join("resources", "text-v0.0.0-20170915032832-14c0d48ead0c.mod"),
+				"v0.0.0-20170915032832-14c0d48ead0c.zip": filepath.Join("resources", "text-v0.0.0-20170915032832-14c0d48ead0c.zip"),
 				"v0.0.0-20170915032832-14c0d48ead0c.info": filepath.Join("resources", "text-v0.0.0-20170915032832-14c0d48ead0c.info"),
 			},
 			requestToFail: map[string]bool{
@@ -4334,19 +4334,25 @@ func TestRunCvsFallbackNoMatchesFound(t *testing.T) {
 // TestEffectiveParentVersion covers all branches of the effectiveParentVersion helper.
 func TestEffectiveParentVersion(t *testing.T) {
 	cases := []struct {
-		name string
-		pin  python.PinnedRequirement
-		want string
+		name                string
+		pin                 python.PinnedRequirement
+		wholePackageBlocked bool
+		want                string
 	}{
-		{"exact direct", python.PinnedRequirement{Name: "foo", Version: "1.0", ParentName: "foo", ParentVersion: "1.0"}, "1.0"},
-		{"direct range — shows range spec", python.PinnedRequirement{Name: "foo", VersionRange: ">=1.4", ParentName: "foo"}, ">=1.4"},
-		{"transitive range — parent ver unknown", python.PinnedRequirement{Name: "foo", VersionRange: ">=1.4", ParentName: "bar"}, ""},
-		{"transitive with known parent ver", python.PinnedRequirement{Name: "foo", VersionRange: ">=1.4", ParentName: "bar", ParentVersion: "2.3"}, "2.3"},
-		{"ResolutionImpossible — all empty", python.PinnedRequirement{Name: "foo", ParentName: "foo"}, ""},
+		{"exact direct", python.PinnedRequirement{Name: "foo", Version: "1.0", ParentName: "foo", ParentVersion: "1.0"}, false, "1.0"},
+		{"direct range — shows range spec", python.PinnedRequirement{Name: "foo", VersionRange: ">=1.4", ParentName: "foo"}, false, ">=1.4"},
+		{"direct range, whole package blocked — blank, matching npm", python.PinnedRequirement{Name: "foo", VersionRange: ">=1.4", ParentName: "foo"}, true, ""},
+		// Self-attributed pins have ParentVersion pre-set equal to Version by the production
+		// parser (see python_cvs_fallback.go) — this must still blank out, not fall through.
+		{"exact direct, whole package blocked — blank, matching npm", python.PinnedRequirement{Name: "foo", Version: "1.0", ParentName: "foo", ParentVersion: "1.0"}, true, ""},
+		{"transitive, whole package blocked, parent ver known — parent ver still shown", python.PinnedRequirement{Name: "foo", Version: "1.0", ParentName: "bar", ParentVersion: "2.3"}, true, "2.3"},
+		{"transitive range — parent ver unknown", python.PinnedRequirement{Name: "foo", VersionRange: ">=1.4", ParentName: "bar"}, false, ""},
+		{"transitive with known parent ver", python.PinnedRequirement{Name: "foo", VersionRange: ">=1.4", ParentName: "bar", ParentVersion: "2.3"}, false, "2.3"},
+		{"ResolutionImpossible — all empty", python.PinnedRequirement{Name: "foo", ParentName: "foo"}, false, ""},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			assert.Equal(t, tc.want, effectiveParentVersion(tc.pin))
+			assert.Equal(t, tc.want, effectiveParentVersion(tc.pin, tc.wholePackageBlocked))
 		})
 	}
 }
@@ -4694,7 +4700,7 @@ func TestCvsMetadataRejectsRedirectOutsideRepository(t *testing.T) {
 		{
 			name: "all versions metadata",
 			call: func(analyzer *treeAnalyzer) error {
-				_, err := analyzer.lookupPypiAllVersions("urllib3")
+				_, _, err := analyzer.lookupPypiAllVersions("urllib3")
 				return err
 			},
 		},
@@ -5400,6 +5406,759 @@ func TestFetchCvsBlockedStatusUvTransitive(t *testing.T) {
 	assert.Equal(t, expectedExpl, s.Policy[0].Explanation)
 	assert.Equal(t, expectedRec, s.Policy[0].Recommendation)
 	assert.Equal(t, blocked, s.Action)
+}
+
+// TestFetchCvsBlockedStatusPinnedWholePackageBlocked verifies that a pinned exact version
+// (e.g. "requests==2.31.0") whose whole package is confirmed blocked (Step 0) still gets
+// full policy detail via the per-version probe (Steps 1-3), when the package-level 403
+// body has no parseable policy message — and that detail is preserved as-is, since Step 0
+// found no policy of its own to compare it against.
+func TestFetchCvsBlockedStatusPinnedWholePackageBlocked(t *testing.T) {
+	const (
+		blockedPkg      = "requests"
+		blockedVer      = "2.31.0"
+		repo            = "test-pip-repo"
+		expectedPolicy  = "openssf"
+		expectedCond    = "openssf-condition"
+		expectedExpl    = "The OpenSSF value is missing"
+		expectedRec     = "Apply a waiver and install again if suitable for use"
+		whlRelativePath = "packages/2a/c1/requests-2.31.0-py3-none-any.whl"
+	)
+	// Package-level 403: no parseable policy detail (mirrors the real backend gap).
+	wholePackageBlockResponse := `{"errors":[{"status":403,"message":"Package blocked"}]}`
+	blockMsg := fmt.Sprintf(
+		"Package %s:%s download was blocked by JFrog Packages Curation service due to the following policies violated {%s, %s, %s, %s}.",
+		blockedPkg, blockedVer, expectedPolicy, expectedCond, expectedExpl, expectedRec,
+	)
+	versionBlockResponse := fmt.Sprintf(`{"errors":[{"status":403,"message":%q}]}`, blockMsg)
+	versionMetaJSON := fmt.Sprintf(`{"urls":[{"packagetype":"bdist_wheel","url":"../../%s"}]}`, whlRelativePath)
+
+	serverMock, serverDetails, _ := coreCommonTests.CreateRtRestsMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		// All-versions metadata: /api/pypi/<repo>/pypi/<name>/json — confirmed whole-package block.
+		case r.Method == http.MethodGet && strings.HasSuffix(r.URL.Path, "/pypi/"+blockedPkg+"/json"):
+			w.WriteHeader(http.StatusForbidden)
+			_, _ = w.Write([]byte(wholePackageBlockResponse))
+		// Version-specific metadata is CVS-unfiltered — still returns the file path.
+		case r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/pypi/"+blockedPkg+"/"+blockedVer+"/json"):
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(versionMetaJSON))
+		case r.Method == http.MethodHead && strings.Contains(r.URL.Path, whlRelativePath):
+			w.WriteHeader(http.StatusForbidden)
+		case r.Method == http.MethodGet && strings.Contains(r.URL.Path, whlRelativePath):
+			w.WriteHeader(http.StatusForbidden)
+			_, _ = w.Write([]byte(versionBlockResponse))
+		default:
+			t.Fatalf("unexpected request %s %s", r.Method, r.URL.Path)
+		}
+	})
+	defer serverMock.Close()
+
+	rtManager, err := rtUtils.CreateServiceManager(serverDetails, 0, 0, false)
+	require.NoError(t, err)
+	rtAuth := rtManager.GetConfig().GetServiceDetails()
+	analyzer := treeAnalyzer{
+		rtManager:            rtManager,
+		extractPoliciesRegex: regexp.MustCompile(extractPoliciesRegexTemplate),
+		rtAuth:               rtAuth,
+		httpClientDetails:    rtAuth.CreateHttpClientDetails(),
+		url:                  rtAuth.GetUrl(),
+		repo:                 repo,
+		tech:                 techutils.Pip,
+	}
+
+	// Pinned exact pin — same shape parseCvsFailedPackages produces for "requests==2.31.0".
+	pins := []python.PinnedRequirement{
+		{Name: blockedPkg, Version: blockedVer, ParentName: blockedPkg, ParentVersion: blockedVer},
+	}
+
+	statuses := analyzer.fetchCvsBlockedStatus(pins)
+	require.Len(t, statuses, 1)
+
+	s := statuses[0]
+	assert.Equal(t, blockedPkg, s.PackageName)
+	assert.Equal(t, allVersionsBlockedText, s.PackageVersion, "pinned + whole-package-blocked must show 'All versions blocked', not the pinned version")
+	assert.Equal(t, blockedPkg, s.ParentName, "direct pin: parent equals package")
+	assert.Equal(t, directRelation, s.DepRelation)
+	assert.Equal(t, blocked, s.Action)
+	require.Len(t, s.Policy, 1, "must recover full policy detail from the per-version download URL, not just the package-level 403")
+	assert.Equal(t, expectedPolicy, s.Policy[0].Policy)
+	assert.Equal(t, expectedCond, s.Policy[0].Condition)
+	assert.Equal(t, expectedExpl, s.Policy[0].Explanation)
+	assert.Equal(t, expectedRec, s.Policy[0].Recommendation)
+}
+
+// TestFetchCvsBlockedStatusPinnedWholePackageBlockedEnrichmentFails verifies the
+// fallback path: when the whole package is confirmed blocked (Step 0) but the
+// per-version enrichment probe fails for any reason (here: the version-specific
+// metadata lookup itself fails), the row must still be rendered using the
+// package-level fallback — never silently dropped.
+func TestFetchCvsBlockedStatusPinnedWholePackageBlockedEnrichmentFails(t *testing.T) {
+	const (
+		blockedPkg = "requests"
+		blockedVer = "2.31.0"
+		repo       = "test-pip-repo"
+	)
+	wholePackageBlockResponse := `{"errors":[{"status":403,"message":"Package blocked"}]}`
+
+	serverMock, serverDetails, _ := coreCommonTests.CreateRtRestsMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && strings.HasSuffix(r.URL.Path, "/pypi/"+blockedPkg+"/json"):
+			w.WriteHeader(http.StatusForbidden)
+			_, _ = w.Write([]byte(wholePackageBlockResponse))
+		// Version-specific metadata lookup fails (e.g. transient 500) — enrichment
+		// cannot proceed, so the package-level fallback must be used instead.
+		case r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/pypi/"+blockedPkg+"/"+blockedVer+"/json"):
+			w.WriteHeader(http.StatusInternalServerError)
+		default:
+			t.Fatalf("unexpected request %s %s", r.Method, r.URL.Path)
+		}
+	})
+	defer serverMock.Close()
+
+	rtManager, err := rtUtils.CreateServiceManager(serverDetails, 0, 0, false)
+	require.NoError(t, err)
+	rtAuth := rtManager.GetConfig().GetServiceDetails()
+	analyzer := treeAnalyzer{
+		rtManager:            rtManager,
+		extractPoliciesRegex: regexp.MustCompile(extractPoliciesRegexTemplate),
+		rtAuth:               rtAuth,
+		httpClientDetails:    rtAuth.CreateHttpClientDetails(),
+		url:                  rtAuth.GetUrl(),
+		repo:                 repo,
+		tech:                 techutils.Pip,
+	}
+
+	pins := []python.PinnedRequirement{
+		{Name: blockedPkg, Version: blockedVer, ParentName: blockedPkg, ParentVersion: blockedVer},
+	}
+
+	statuses := analyzer.fetchCvsBlockedStatus(pins)
+	require.Len(t, statuses, 1, "whole-package block must never be silently dropped, even if enrichment fails")
+
+	s := statuses[0]
+	assert.Equal(t, blockedPkg, s.PackageName)
+	assert.Equal(t, allVersionsBlockedText, s.PackageVersion)
+	assert.Equal(t, blocked, s.Action)
+	assert.Equal(t, BlockingReasonUnknown, s.BlockingReason)
+}
+
+// TestFetchCvsBlockedStatusRangedWholePackageBlocked verifies a RANGED direct pin (e.g.
+// "urllib3>=2.0.0") whose package is fully blocked renders as "All versions blocked" with
+// full policy detail, using Artifactory's real whole-package-block message format
+// ("All versions blocked - {policy:X,condition:Y}").
+func TestFetchCvsBlockedStatusRangedWholePackageBlocked(t *testing.T) {
+	const (
+		blockedPkg          = "urllib3"
+		repo                = "test-pip-repo"
+		expectedPolicy      = "openssf-jfca"
+		expectedCond        = "openssf"
+		expectedRecTemplate = "Remove this package from your project and replace with an alternate package"
+	)
+	blockResponse := fmt.Sprintf(
+		`{"errors":[{"status":403,"message":"All versions blocked - {policy:%s,condition:%s}"}]}`,
+		expectedPolicy, expectedCond,
+	)
+
+	serverMock, serverDetails, _ := coreCommonTests.CreateRtRestsMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && strings.HasSuffix(r.URL.Path, "/pypi/"+blockedPkg+"/json"):
+			w.WriteHeader(http.StatusForbidden)
+			_, _ = w.Write([]byte(blockResponse))
+		default:
+			t.Fatalf("unexpected request %s %s — a whole-package block must never probe a per-version URL", r.Method, r.URL.Path)
+		}
+	})
+	defer serverMock.Close()
+
+	rtManager, err := rtUtils.CreateServiceManager(serverDetails, 0, 0, false)
+	require.NoError(t, err)
+	rtAuth := rtManager.GetConfig().GetServiceDetails()
+	analyzer := treeAnalyzer{
+		rtManager:            rtManager,
+		extractPoliciesRegex: regexp.MustCompile(extractPoliciesRegexTemplate),
+		rtAuth:               rtAuth,
+		httpClientDetails:    rtAuth.CreateHttpClientDetails(),
+		url:                  rtAuth.GetUrl(),
+		repo:                 repo,
+		tech:                 techutils.Pip,
+	}
+
+	// Ranged direct pin — same shape parseCvsFailedPackages produces for "urllib3>=2.0.0".
+	pins := []python.PinnedRequirement{
+		{Name: blockedPkg, VersionRange: ">=2.0.0", ParentName: blockedPkg},
+	}
+
+	statuses := analyzer.fetchCvsBlockedStatus(pins)
+	require.Len(t, statuses, 1, "ranged whole-package block must no longer be silently dropped")
+
+	s := statuses[0]
+	assert.Equal(t, blockedPkg, s.PackageName)
+	assert.Equal(t, allVersionsBlockedText, s.PackageVersion)
+	assert.Equal(t, directRelation, s.DepRelation)
+	assert.Equal(t, blocked, s.Action)
+	require.Len(t, s.Policy, 1, "must recover policy detail from the whole-package-block message, not just BlockingReasonUnknown")
+	assert.Equal(t, expectedPolicy, s.Policy[0].Policy)
+	assert.Equal(t, expectedCond, s.Policy[0].Condition)
+	assert.Equal(t, allVersionsBlockedText, s.Policy[0].Explanation)
+	assert.Equal(t, expectedRecTemplate, s.Policy[0].Recommendation, "direct dependency must get the 'remove and replace' recommendation")
+}
+
+// TestFetchCvsBlockedStatusPinnedWholePackageBlockedDifferentPolicyThanAggregate covers a
+// pinned version blocked by a DIFFERENT policy than the one Step 0's aggregate check found
+// (e.g. per-version immature-30 vs. aggregate openssf-test). The per-version detail must be
+// preserved as-is, not overwritten with generic text tied to the unrelated aggregate policy.
+func TestFetchCvsBlockedStatusPinnedWholePackageBlockedDifferentPolicyThanAggregate(t *testing.T) {
+	const (
+		blockedPkg       = "deepagents"
+		blockedVer       = "0.7.8"
+		repo             = "test-pip-repo"
+		aggregatePolicy  = "openssf-test"
+		aggregateCond    = "openssf"
+		perVersionPolicy = "immature-30"
+		perVersionCond   = "immature"
+		perVersionExpl   = "Package version is 28 days old"
+		perVersionRec    = "Use an older version or wait until this version is no longer immature"
+		whlRelativePath  = "packages/de/ep/deepagents-0.7.8-py3-none-any.whl"
+	)
+	// Step 0's aggregate probe: confirmed whole-package block, but under a DIFFERENT policy.
+	wholePackageBlockResponse := fmt.Sprintf(
+		`{"errors":[{"status":403,"message":"All versions blocked - {policy:%s,condition:%s}"}]}`,
+		aggregatePolicy, aggregateCond,
+	)
+	// Steps 1-3's per-version probe: a different, real policy detail for this pinned version.
+	blockMsg := fmt.Sprintf(
+		"Package %s:%s download was blocked by JFrog Packages Curation service due to the following policies violated {%s, %s, %s, %s}.",
+		blockedPkg, blockedVer, perVersionPolicy, perVersionCond, perVersionExpl, perVersionRec,
+	)
+	versionBlockResponse := fmt.Sprintf(`{"errors":[{"status":403,"message":%q}]}`, blockMsg)
+	versionMetaJSON := fmt.Sprintf(`{"urls":[{"packagetype":"bdist_wheel","url":"../../%s"}]}`, whlRelativePath)
+
+	serverMock, serverDetails, _ := coreCommonTests.CreateRtRestsMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && strings.HasSuffix(r.URL.Path, "/pypi/"+blockedPkg+"/json"):
+			w.WriteHeader(http.StatusForbidden)
+			_, _ = w.Write([]byte(wholePackageBlockResponse))
+		case r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/pypi/"+blockedPkg+"/"+blockedVer+"/json"):
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(versionMetaJSON))
+		case r.Method == http.MethodHead && strings.Contains(r.URL.Path, whlRelativePath):
+			w.WriteHeader(http.StatusForbidden)
+		case r.Method == http.MethodGet && strings.Contains(r.URL.Path, whlRelativePath):
+			w.WriteHeader(http.StatusForbidden)
+			_, _ = w.Write([]byte(versionBlockResponse))
+		default:
+			t.Fatalf("unexpected request %s %s", r.Method, r.URL.Path)
+		}
+	})
+	defer serverMock.Close()
+
+	rtManager, err := rtUtils.CreateServiceManager(serverDetails, 0, 0, false)
+	require.NoError(t, err)
+	rtAuth := rtManager.GetConfig().GetServiceDetails()
+	analyzer := treeAnalyzer{
+		rtManager:            rtManager,
+		extractPoliciesRegex: regexp.MustCompile(extractPoliciesRegexTemplate),
+		rtAuth:               rtAuth,
+		httpClientDetails:    rtAuth.CreateHttpClientDetails(),
+		url:                  rtAuth.GetUrl(),
+		repo:                 repo,
+		tech:                 techutils.Pip,
+	}
+
+	pins := []python.PinnedRequirement{
+		{Name: blockedPkg, Version: blockedVer, ParentName: blockedPkg, ParentVersion: blockedVer},
+	}
+
+	statuses := analyzer.fetchCvsBlockedStatus(pins)
+	require.Len(t, statuses, 1)
+
+	s := statuses[0]
+	assert.Equal(t, allVersionsBlockedText, s.PackageVersion)
+	require.Len(t, s.Policy, 1)
+	assert.Equal(t, perVersionPolicy, s.Policy[0].Policy, "must show the policy actually found for this pinned version, not the aggregate one")
+	assert.Equal(t, perVersionCond, s.Policy[0].Condition)
+	assert.Equal(t, perVersionExpl, s.Policy[0].Explanation, "must preserve the real per-version explanation, not the generic whole-package text")
+	assert.Equal(t, perVersionRec, s.Policy[0].Recommendation, "must preserve the real per-version recommendation, not the generic 'remove and replace' text")
+}
+
+// TestFetchCvsBlockedStatusPinnedWholePackageBlockedSamePolicyAsAggregate is a regression
+// test: a pinned version (e.g. "urllib3==2.0.0") never takes Step 0's shortcut return (only
+// ranged/version-less pins do), so it always falls through to the per-version probe. When
+// that probe finds the SAME policy+condition as the aggregate check, the row must be
+// normalized to generic text — not leak the raw, inconsistently-worded backend message.
+func TestFetchCvsBlockedStatusPinnedWholePackageBlockedSamePolicyAsAggregate(t *testing.T) {
+	const (
+		blockedPkg      = "urllib3"
+		blockedVer      = "2.0.0"
+		repo            = "test-pip-repo"
+		policyName      = "openssf-jfca-test"
+		condName        = "openssf"
+		rawExpl         = "The OpenSSF value is missing condition is set to 'block in case check value is missing'."
+		rawRec          = "After reviewing the package please apply a waiver and install again if it is deemed suitable for use."
+		whlRelativePath = "packages/ca/25/urllib3-2.0.0-py3-none-any.whl"
+	)
+	// Step 0's aggregate probe: confirmed whole-package block under policy openssf-jfca-test/openssf.
+	wholePackageBlockResponse := fmt.Sprintf(
+		`{"errors":[{"status":403,"message":"All versions blocked - {policy:%s,condition:%s}"}]}`,
+		policyName, condName,
+	)
+	// Steps 1-3's per-version probe: the SAME policy+condition, but with the raw,
+	// inconsistently-worded backend message (as opposed to Step 0's generic phrasing).
+	blockMsg := fmt.Sprintf(
+		"Package %s:%s download was blocked by JFrog Packages Curation service due to the following policies violated {%s, %s, %s, %s}.",
+		blockedPkg, blockedVer, policyName, condName, rawExpl, rawRec,
+	)
+	versionBlockResponse := fmt.Sprintf(`{"errors":[{"status":403,"message":%q}]}`, blockMsg)
+	versionMetaJSON := fmt.Sprintf(`{"urls":[{"packagetype":"bdist_wheel","url":"../../%s"}]}`, whlRelativePath)
+
+	serverMock, serverDetails, _ := coreCommonTests.CreateRtRestsMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && strings.HasSuffix(r.URL.Path, "/pypi/"+blockedPkg+"/json"):
+			w.WriteHeader(http.StatusForbidden)
+			_, _ = w.Write([]byte(wholePackageBlockResponse))
+		case r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/pypi/"+blockedPkg+"/"+blockedVer+"/json"):
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(versionMetaJSON))
+		case r.Method == http.MethodHead && strings.Contains(r.URL.Path, whlRelativePath):
+			w.WriteHeader(http.StatusForbidden)
+		case r.Method == http.MethodGet && strings.Contains(r.URL.Path, whlRelativePath):
+			w.WriteHeader(http.StatusForbidden)
+			_, _ = w.Write([]byte(versionBlockResponse))
+		default:
+			t.Fatalf("unexpected request %s %s", r.Method, r.URL.Path)
+		}
+	})
+	defer serverMock.Close()
+
+	rtManager, err := rtUtils.CreateServiceManager(serverDetails, 0, 0, false)
+	require.NoError(t, err)
+	rtAuth := rtManager.GetConfig().GetServiceDetails()
+	analyzer := treeAnalyzer{
+		rtManager:            rtManager,
+		extractPoliciesRegex: regexp.MustCompile(extractPoliciesRegexTemplate),
+		rtAuth:               rtAuth,
+		httpClientDetails:    rtAuth.CreateHttpClientDetails(),
+		url:                  rtAuth.GetUrl(),
+		repo:                 repo,
+		tech:                 techutils.Pip,
+	}
+
+	// Pinned exact pin — same shape parseCvsFailedPackages produces for "urllib3==2.0.0".
+	pins := []python.PinnedRequirement{
+		{Name: blockedPkg, Version: blockedVer, ParentName: blockedPkg, ParentVersion: blockedVer},
+	}
+
+	statuses := analyzer.fetchCvsBlockedStatus(pins)
+	require.Len(t, statuses, 1)
+
+	s := statuses[0]
+	assert.Equal(t, allVersionsBlockedText, s.PackageVersion)
+	require.Len(t, s.Policy, 1)
+	assert.Equal(t, policyName, s.Policy[0].Policy)
+	assert.Equal(t, condName, s.Policy[0].Condition)
+	assert.Equal(t, allVersionsBlockedText, s.Policy[0].Explanation,
+		"same policy as aggregate must be normalized to the generic text, not leak the raw inconsistent backend message")
+	assert.Equal(t, "Remove this package from your project and replace with an alternate package", s.Policy[0].Recommendation,
+		"direct pinned dependency, same policy as aggregate, must get the generic npm-parity recommendation")
+}
+
+// TestFetchCvsBlockedStatusPinnedWholePackageBlockedMultiPolicyPartialMatch verifies that
+// when the per-version probe recovers MULTIPLE policies, only the entry matching the
+// aggregate's policy+condition is normalized to generic text — a second, genuinely different
+// real policy in the same probe result must be preserved untouched, not blanket-overwritten.
+func TestFetchCvsBlockedStatusPinnedWholePackageBlockedMultiPolicyPartialMatch(t *testing.T) {
+	const (
+		blockedPkg      = "urllib3"
+		blockedVer      = "2.0.0"
+		repo            = "test-pip-repo"
+		matchingPolicy  = "openssf-jfca-test"
+		matchingCond    = "openssf"
+		matchingRawExpl = "The OpenSSF value is missing"
+		matchingRawRec  = "Apply a waiver and install again if suitable for use"
+		otherPolicy     = "cve-7-9"
+		otherCond       = "CVE with CVSS score between 7.0 and 8.9"
+		otherExpl       = "Package version contains a known vulnerability"
+		otherRec        = "Upgrade to version 2.6.3"
+		whlRelativePath = "packages/ca/25/urllib3-2.0.0-py3-none-any.whl"
+	)
+	// Step 0's aggregate probe: confirmed whole-package block under matchingPolicy/matchingCond only.
+	wholePackageBlockResponse := fmt.Sprintf(
+		`{"errors":[{"status":403,"message":"All versions blocked - {policy:%s,condition:%s}"}]}`,
+		matchingPolicy, matchingCond,
+	)
+	// Steps 1-3's per-version probe: TWO policies — one matching the aggregate (raw wording),
+	// one genuinely different (a real, unrelated CVE finding for this specific version).
+	blockMsg := fmt.Sprintf(
+		"Package %s:%s download was blocked by JFrog Packages Curation service due to the following policies violated {%s, %s, %s, %s},{%s, %s, %s, %s}.",
+		blockedPkg, blockedVer, matchingPolicy, matchingCond, matchingRawExpl, matchingRawRec,
+		otherPolicy, otherCond, otherExpl, otherRec,
+	)
+	versionBlockResponse := fmt.Sprintf(`{"errors":[{"status":403,"message":%q}]}`, blockMsg)
+	versionMetaJSON := fmt.Sprintf(`{"urls":[{"packagetype":"bdist_wheel","url":"../../%s"}]}`, whlRelativePath)
+
+	serverMock, serverDetails, _ := coreCommonTests.CreateRtRestsMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && strings.HasSuffix(r.URL.Path, "/pypi/"+blockedPkg+"/json"):
+			w.WriteHeader(http.StatusForbidden)
+			_, _ = w.Write([]byte(wholePackageBlockResponse))
+		case r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/pypi/"+blockedPkg+"/"+blockedVer+"/json"):
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(versionMetaJSON))
+		case r.Method == http.MethodHead && strings.Contains(r.URL.Path, whlRelativePath):
+			w.WriteHeader(http.StatusForbidden)
+		case r.Method == http.MethodGet && strings.Contains(r.URL.Path, whlRelativePath):
+			w.WriteHeader(http.StatusForbidden)
+			_, _ = w.Write([]byte(versionBlockResponse))
+		default:
+			t.Fatalf("unexpected request %s %s", r.Method, r.URL.Path)
+		}
+	})
+	defer serverMock.Close()
+
+	rtManager, err := rtUtils.CreateServiceManager(serverDetails, 0, 0, false)
+	require.NoError(t, err)
+	rtAuth := rtManager.GetConfig().GetServiceDetails()
+	analyzer := treeAnalyzer{
+		rtManager:            rtManager,
+		extractPoliciesRegex: regexp.MustCompile(extractPoliciesRegexTemplate),
+		rtAuth:               rtAuth,
+		httpClientDetails:    rtAuth.CreateHttpClientDetails(),
+		url:                  rtAuth.GetUrl(),
+		repo:                 repo,
+		tech:                 techutils.Pip,
+	}
+
+	pins := []python.PinnedRequirement{
+		{Name: blockedPkg, Version: blockedVer, ParentName: blockedPkg, ParentVersion: blockedVer},
+	}
+
+	statuses := analyzer.fetchCvsBlockedStatus(pins)
+	require.Len(t, statuses, 1)
+
+	s := statuses[0]
+	require.Len(t, s.Policy, 2, "both policies from the per-version probe must be preserved")
+
+	assert.Equal(t, matchingPolicy, s.Policy[0].Policy)
+	assert.Equal(t, matchingCond, s.Policy[0].Condition)
+	assert.Equal(t, allVersionsBlockedText, s.Policy[0].Explanation,
+		"the entry matching the aggregate's policy+condition must be normalized")
+	assert.Equal(t, "Remove this package from your project and replace with an alternate package", s.Policy[0].Recommendation)
+
+	assert.Equal(t, otherPolicy, s.Policy[1].Policy)
+	assert.Equal(t, otherCond, s.Policy[1].Condition)
+	assert.Equal(t, otherExpl, s.Policy[1].Explanation,
+		"a second, genuinely different policy must NOT be overwritten by the aggregate-match normalization")
+	assert.Equal(t, otherRec, s.Policy[1].Recommendation)
+}
+
+// TestFetchCvsBlockedStatusTransitivePinnedWholePackageBlocked verifies a TRANSITIVE blocker
+// with an exact PINNED version (Version set, VersionRange empty) — which, unlike a name-only
+// ResolutionImpossible entry, never takes Step 0's shortcut return and always falls through to
+// the per-version probe (Steps 1-3). Confirms the real parent's version is still shown (not
+// blanked, since only whole-package-blocked DIRECT dependencies blank the version column) and
+// DepRelation/Recommendation correctly reflect the transitive relationship.
+func TestFetchCvsBlockedStatusTransitivePinnedWholePackageBlocked(t *testing.T) {
+	const (
+		blockedPkg      = "charset-normalizer"
+		blockedVer      = "3.3.2"
+		parentPkg       = "requests"
+		parentVer       = "2.31.0"
+		repo            = "test-pip-repo"
+		policyName      = "openssf-jfca"
+		condName        = "openssf"
+		whlRelativePath = "packages/6d/8c/charset-normalizer-3.3.2-py3-none-any.whl"
+	)
+	wholePackageBlockResponse := fmt.Sprintf(
+		`{"errors":[{"status":403,"message":"All versions blocked - {policy:%s,condition:%s}"}]}`,
+		policyName, condName,
+	)
+	versionMetaJSON := fmt.Sprintf(`{"urls":[{"packagetype":"bdist_wheel","url":"../../%s"}]}`, whlRelativePath)
+
+	serverMock, serverDetails, _ := coreCommonTests.CreateRtRestsMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && strings.HasSuffix(r.URL.Path, "/pypi/"+blockedPkg+"/json"):
+			w.WriteHeader(http.StatusForbidden)
+			_, _ = w.Write([]byte(wholePackageBlockResponse))
+		case r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/pypi/"+blockedPkg+"/"+blockedVer+"/json"):
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(versionMetaJSON))
+		case r.Method == http.MethodHead && strings.Contains(r.URL.Path, whlRelativePath):
+			w.WriteHeader(http.StatusForbidden)
+		case r.Method == http.MethodGet && strings.Contains(r.URL.Path, whlRelativePath):
+			// GET probe body is unparsable — falls back to the Step 0 whole-package result.
+			w.WriteHeader(http.StatusForbidden)
+			_, _ = w.Write([]byte(`not json`))
+		default:
+			t.Fatalf("unexpected request %s %s", r.Method, r.URL.Path)
+		}
+	})
+	defer serverMock.Close()
+
+	rtManager, err := rtUtils.CreateServiceManager(serverDetails, 0, 0, false)
+	require.NoError(t, err)
+	rtAuth := rtManager.GetConfig().GetServiceDetails()
+	analyzer := treeAnalyzer{
+		rtManager:            rtManager,
+		extractPoliciesRegex: regexp.MustCompile(extractPoliciesRegexTemplate),
+		rtAuth:               rtAuth,
+		httpClientDetails:    rtAuth.CreateHttpClientDetails(),
+		url:                  rtAuth.GetUrl(),
+		repo:                 repo,
+		tech:                 techutils.Pip,
+	}
+
+	// Exact pinned transitive child (e.g. requests==2.31.0 constrains charset-normalizer
+	// to exactly 3.3.2) — Version is set, so this never takes Step 0's shortcut return.
+	pins := []python.PinnedRequirement{
+		{Name: blockedPkg, Version: blockedVer, ParentName: parentPkg, ParentVersion: parentVer},
+	}
+
+	statuses := analyzer.fetchCvsBlockedStatus(pins)
+	require.Len(t, statuses, 1, "must fall through to the per-version probe, then back to the whole-package fallback, never dropped")
+
+	s := statuses[0]
+	assert.Equal(t, blockedPkg, s.PackageName)
+	assert.Equal(t, allVersionsBlockedText, s.PackageVersion)
+	assert.Equal(t, parentPkg, s.ParentName, "must attribute to the real parent, not self")
+	assert.Equal(t, parentVer, s.ParentVersion, "a transitive blocker's parent version is shown even when the child's whole package is blocked")
+	assert.Equal(t, indirectRelation, s.DepRelation)
+	assert.Equal(t, blocked, s.Action)
+}
+
+// TestFetchCvsBlockedStatusTransitiveWholePackageBlocked verifies a TRANSITIVE blocker
+// (attributed to a real parent) whose package is fully blocked renders "All versions
+// blocked" with indirect DepRelation, correct parent attribution, and a Recommendation
+// naming the real parent.
+func TestFetchCvsBlockedStatusTransitiveWholePackageBlocked(t *testing.T) {
+	const (
+		blockedPkg     = "charset-normalizer"
+		parentPkg      = "requests"
+		parentVer      = "2.31.0"
+		repo           = "test-pip-repo"
+		expectedPolicy = "openssf-jfca"
+		expectedCond   = "openssf"
+	)
+	blockResponse := fmt.Sprintf(
+		`{"errors":[{"status":403,"message":"All versions blocked - {policy:%s,condition:%s}"}]}`,
+		expectedPolicy, expectedCond,
+	)
+
+	serverMock, serverDetails, _ := coreCommonTests.CreateRtRestsMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && strings.HasSuffix(r.URL.Path, "/pypi/"+blockedPkg+"/json"):
+			w.WriteHeader(http.StatusForbidden)
+			_, _ = w.Write([]byte(blockResponse))
+		default:
+			t.Fatalf("unexpected request %s %s — a whole-package block must never probe a per-version URL", r.Method, r.URL.Path)
+		}
+	})
+	defer serverMock.Close()
+
+	rtManager, err := rtUtils.CreateServiceManager(serverDetails, 0, 0, false)
+	require.NoError(t, err)
+	rtAuth := rtManager.GetConfig().GetServiceDetails()
+	analyzer := treeAnalyzer{
+		rtManager:            rtManager,
+		extractPoliciesRegex: regexp.MustCompile(extractPoliciesRegexTemplate),
+		rtAuth:               rtAuth,
+		httpClientDetails:    rtAuth.CreateHttpClientDetails(),
+		url:                  rtAuth.GetUrl(),
+		repo:                 repo,
+		tech:                 techutils.Pip,
+	}
+
+	// ResolutionImpossible name-only entry, attributed to its real direct-dependency parent.
+	pins := []python.PinnedRequirement{
+		{Name: blockedPkg, ParentName: parentPkg, ParentVersion: parentVer},
+	}
+
+	statuses := analyzer.fetchCvsBlockedStatus(pins)
+	require.Len(t, statuses, 1, "transitive whole-package block must no longer be silently dropped")
+
+	s := statuses[0]
+	assert.Equal(t, blockedPkg, s.PackageName)
+	assert.Equal(t, allVersionsBlockedText, s.PackageVersion)
+	assert.Equal(t, parentPkg, s.ParentName, "must attribute to the real direct-dependency parent, not self")
+	assert.Equal(t, parentVer, s.ParentVersion)
+	assert.Equal(t, indirectRelation, s.DepRelation, "transitive whole-package block must be indirect")
+	assert.Equal(t, blocked, s.Action)
+	require.Len(t, s.Policy, 1, "must recover policy detail from the whole-package-block message, not just BlockingReasonUnknown")
+	assert.Equal(t, expectedPolicy, s.Policy[0].Policy)
+	assert.Equal(t, expectedCond, s.Policy[0].Condition)
+	assert.Equal(t, allVersionsBlockedText, s.Policy[0].Explanation)
+	assert.Contains(t, s.Policy[0].Recommendation, parentPkg, "transitive dependency must name the real parent in its recommendation")
+	assert.Contains(t, s.Policy[0].Recommendation, blockedPkg)
+}
+
+// TestFetchCvsBlockedStatusWholePackageBlockedUnparsableBody verifies that a confirmed
+// whole-package block (403 on the all-versions metadata API) whose body doesn't carry a
+// parseable policy message still renders a row — with BlockingReasonUnknown — rather than
+// being silently dropped, matching getBlockedPackageDetails's existing defensive behavior
+// for the per-version path.
+func TestFetchCvsBlockedStatusWholePackageBlockedUnparsableBody(t *testing.T) {
+	const (
+		blockedPkg = "some-pkg"
+		repo       = "test-pip-repo"
+	)
+
+	serverMock, serverDetails, _ := coreCommonTests.CreateRtRestsMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && strings.HasSuffix(r.URL.Path, "/pypi/"+blockedPkg+"/json"):
+			w.WriteHeader(http.StatusForbidden)
+			_, _ = w.Write([]byte("<html>not json</html>"))
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	})
+	defer serverMock.Close()
+
+	rtManager, err := rtUtils.CreateServiceManager(serverDetails, 0, 0, false)
+	require.NoError(t, err)
+	rtAuth := rtManager.GetConfig().GetServiceDetails()
+	analyzer := treeAnalyzer{
+		rtManager:            rtManager,
+		extractPoliciesRegex: regexp.MustCompile(extractPoliciesRegexTemplate),
+		rtAuth:               rtAuth,
+		httpClientDetails:    rtAuth.CreateHttpClientDetails(),
+		url:                  rtAuth.GetUrl(),
+		repo:                 repo,
+		tech:                 techutils.Pip,
+	}
+
+	pins := []python.PinnedRequirement{
+		{Name: blockedPkg, Version: "1.0.0", ParentName: blockedPkg, ParentVersion: "1.0.0"},
+	}
+
+	statuses := analyzer.fetchCvsBlockedStatus(pins)
+	require.Len(t, statuses, 1, "a confirmed 403 must never be silently dropped, even with an unparsable body")
+
+	s := statuses[0]
+	assert.Equal(t, blockedPkg, s.PackageName)
+	assert.Equal(t, allVersionsBlockedText, s.PackageVersion)
+	assert.Equal(t, BlockingReasonUnknown, s.BlockingReason)
+	assert.Equal(t, blocked, s.Action)
+}
+
+// TestFetchCvsBlockedStatusWholePackageBlockedAcrossTechs verifies the whole-package-block
+// path (Step 0 in fetchCvsBlockedStatus) works identically for poetry, pipenv, and uv.
+func TestFetchCvsBlockedStatusWholePackageBlockedAcrossTechs(t *testing.T) {
+	const (
+		blockedPkg     = "urllib3"
+		repo           = "test-repo"
+		expectedPolicy = "openssf-jfca"
+		expectedCond   = "openssf"
+	)
+	blockResponse := fmt.Sprintf(
+		`{"errors":[{"status":403,"message":"All versions blocked - {policy:%s,condition:%s}"}]}`,
+		expectedPolicy, expectedCond,
+	)
+
+	for _, tech := range []techutils.Technology{techutils.Poetry, techutils.Pipenv, techutils.Uv} {
+		t.Run(tech.String(), func(t *testing.T) {
+			serverMock, serverDetails, _ := coreCommonTests.CreateRtRestsMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+				switch {
+				case r.Method == http.MethodGet && strings.HasSuffix(r.URL.Path, "/pypi/"+blockedPkg+"/json"):
+					w.WriteHeader(http.StatusForbidden)
+					_, _ = w.Write([]byte(blockResponse))
+				default:
+					t.Fatalf("unexpected request %s %s — a whole-package block must never probe a per-version URL", r.Method, r.URL.Path)
+				}
+			})
+			defer serverMock.Close()
+
+			rtManager, err := rtUtils.CreateServiceManager(serverDetails, 0, 0, false)
+			require.NoError(t, err)
+			rtAuth := rtManager.GetConfig().GetServiceDetails()
+			analyzer := treeAnalyzer{
+				rtManager:            rtManager,
+				extractPoliciesRegex: regexp.MustCompile(extractPoliciesRegexTemplate),
+				rtAuth:               rtAuth,
+				httpClientDetails:    rtAuth.CreateHttpClientDetails(),
+				url:                  rtAuth.GetUrl(),
+				repo:                 repo,
+				tech:                 tech,
+			}
+
+			// Ranged direct pin — the previously-broken case (npm-parity fix), exercised
+			// once per technology to prove Step 0 isn't accidentally pip-specific.
+			pins := []python.PinnedRequirement{
+				{Name: blockedPkg, VersionRange: ">=2.0.0", ParentName: blockedPkg},
+			}
+			statuses := analyzer.fetchCvsBlockedStatus(pins)
+			require.Len(t, statuses, 1, "ranged whole-package block must not be dropped for %s", tech)
+
+			s := statuses[0]
+			assert.Equal(t, blockedPkg, s.PackageName)
+			assert.Equal(t, allVersionsBlockedText, s.PackageVersion)
+			assert.Equal(t, string(tech), s.PkgType, "package type must reflect the actual technology")
+			assert.Equal(t, directRelation, s.DepRelation)
+			assert.Equal(t, blocked, s.Action)
+			require.Len(t, s.Policy, 1)
+			assert.Equal(t, expectedPolicy, s.Policy[0].Policy)
+			assert.Equal(t, expectedCond, s.Policy[0].Condition)
+		})
+	}
+}
+
+// TestFetchCvsBlockedStatusUvRangedDirectNoVersionEcho reproduces the uv self-referential
+// recommendation bug: a ranged direct dependency (e.g. `urllib3>=2.0.0`) whose whole package
+// gets blocked. uv's error text for this case ("X was not found in the package registry")
+// never echoes the range, so python.parseCvsFailedPackages can't populate either Version or
+// VersionRange on the pin — the only signal that this is a direct dependency (rather than a
+// deep transitive blocker with an unrecoverable parent) is ConfirmedDirect, set from uv's
+// "your project depends on X" phrasing. Without honoring it, DepRelation is misclassified as
+// indirect and the recommendation text becomes self-referential ("urllib3 is a transitive
+// dependency of urllib3").
+func TestFetchCvsBlockedStatusUvRangedDirectNoVersionEcho(t *testing.T) {
+	const (
+		blockedPkg     = "urllib3"
+		repo           = "test-repo"
+		expectedPolicy = "openssf-jfca"
+		expectedCond   = "openssf"
+	)
+	blockResponse := fmt.Sprintf(
+		`{"errors":[{"status":403,"message":"All versions blocked - {policy:%s,condition:%s}"}]}`,
+		expectedPolicy, expectedCond,
+	)
+
+	serverMock, serverDetails, _ := coreCommonTests.CreateRtRestsMockServer(t, func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && strings.HasSuffix(r.URL.Path, "/pypi/"+blockedPkg+"/json"):
+			w.WriteHeader(http.StatusForbidden)
+			_, _ = w.Write([]byte(blockResponse))
+		default:
+			t.Fatalf("unexpected request %s %s — a whole-package block must never probe a per-version URL", r.Method, r.URL.Path)
+		}
+	})
+	defer serverMock.Close()
+
+	rtManager, err := rtUtils.CreateServiceManager(serverDetails, 0, 0, false)
+	require.NoError(t, err)
+	rtAuth := rtManager.GetConfig().GetServiceDetails()
+	analyzer := treeAnalyzer{
+		rtManager:            rtManager,
+		extractPoliciesRegex: regexp.MustCompile(extractPoliciesRegexTemplate),
+		rtAuth:               rtAuth,
+		httpClientDetails:    rtAuth.CreateHttpClientDetails(),
+		url:                  rtAuth.GetUrl(),
+		repo:                 repo,
+		tech:                 techutils.Uv,
+	}
+
+	// Self-attributed, no Version, no VersionRange — exactly what uv's parser produces for
+	// this case — but ConfirmedDirect is set from uv's "your project depends on urllib3" text.
+	pins := []python.PinnedRequirement{
+		{Name: blockedPkg, ParentName: blockedPkg, ConfirmedDirect: true},
+	}
+	statuses := analyzer.fetchCvsBlockedStatus(pins)
+	require.Len(t, statuses, 1)
+
+	s := statuses[0]
+	assert.Equal(t, blockedPkg, s.PackageName)
+	assert.Equal(t, allVersionsBlockedText, s.PackageVersion)
+	assert.Equal(t, directRelation, s.DepRelation, "ConfirmedDirect must override the no-version-info heuristic")
+	assert.Equal(t, blockedPkg, s.ParentName, "a direct dependency's parent is itself")
 }
 
 // TestResolveUvTech verifies that pip is promoted to uv when the right config signals are present.

--- a/sca/bom/buildinfo/technologies/python/python_cvs_fallback.go
+++ b/sca/bom/buildinfo/technologies/python/python_cvs_fallback.go
@@ -18,6 +18,10 @@ type PinnedRequirement struct {
 	VersionRange  string
 	ParentName    string
 	ParentVersion string
+	// ConfirmedDirect is true when the tool's output explicitly confirms this is a
+	// direct dependency (e.g. uv's "your project depends on X"), even with no
+	// Version/VersionRange recovered. Prevents misclassifying it as transitive.
+	ConfirmedDirect bool
 }
 
 // CvsBlockedError is returned when CVS hides a pinned version from the simple index.
@@ -93,6 +97,11 @@ var uvCvsBlockedReqRegex = regexp.MustCompile(
 var uvNotFoundInRegistryRegex = regexp.MustCompile(
 	`([A-Za-z0-9][A-Za-z0-9._-]*) was not found in the package registry`)
 
+// uvProjectDependsOnRegex matches uv's "your project depends on <name>" — its explicit
+// marker that a package is a direct dependency, even when no version/range text follows.
+var uvProjectDependsOnRegex = regexp.MustCompile(
+	`your\s+project\s+depends\s+on\s+([A-Za-z0-9][A-Za-z0-9._-]*)`)
+
 // uvDependsOnPinnedRegex extracts name==version from uv's "depends on name==version" clause,
 // used to recover the pinned version when paired with uvNotFoundInRegistryRegex.
 var uvDependsOnPinnedRegex = regexp.MustCompile(
@@ -106,6 +115,20 @@ var uvDependsOnPinnedRegex = regexp.MustCompile(
 var uvDependsOnParentRegex = regexp.MustCompile(
 	`([A-Za-z0-9][A-Za-z0-9._-]*)(?:\[[^\]]*\])?==([0-9][0-9A-Za-z._+\-]*)\s+depends on\s+` +
 		`([A-Za-z0-9][A-Za-z0-9._-]*)(?:\[[^\]]*\])?==([0-9][0-9A-Za-z._+\-]*)`)
+
+// looseDependsOnParentRegex is a fallback for "parent==version depends on child" clauses
+// where the child has no exact version (constrained by a range, not a pin). Applied last,
+// after tool-specific parsing, to attribute otherwise self-attributed blockers.
+var looseDependsOnParentRegex = regexp.MustCompile(
+	`([A-Za-z0-9][A-Za-z0-9._-]*)(?:\[[^\]]*\])?==([0-9][0-9A-Za-z._+\-]*)\s+depends on\s+` +
+		`([A-Za-z0-9][A-Za-z0-9._-]*)`)
+
+// pipDependsOnParentRegex matches pip/pipenv's "parent version depends on child" phrasing
+// (space-separated, no "=="), e.g. "requests 2.31.0 depends on charset-normalizer<4".
+// Same purpose as looseDependsOnParentRegex, for pip's different wording.
+var pipDependsOnParentRegex = regexp.MustCompile(
+	`([A-Za-z0-9][A-Za-z0-9._-]*)(?:\[[^\]]*\])?\s+([0-9][0-9A-Za-z._+\-]*)\s+depends on\s+` +
+		`([A-Za-z0-9][A-Za-z0-9._-]*)`)
 
 // parseCvsFailedPackages extracts blockers from pip, poetry, and uv failure output.
 // Only packages that caused the failure are returned, not every requirements entry.
@@ -276,6 +299,42 @@ func parseCvsFailedPackages(pipOutput string) []PinnedRequirement {
 				pr.ParentName, pr.ParentVersion = parent.Name, parent.Version
 			}
 			failed = append(failed, pr)
+		}
+	}
+
+	// Last resort: attribute any still-self-attributed entry to a real parent found via
+	// the loose "depends on" patterns above (keyed by child name, across all tools).
+	looseParentByChild := map[string]PinnedRequirement{}
+	for _, m := range looseDependsOnParentRegex.FindAllStringSubmatch(pipOutput, -1) {
+		n := normalizePyPIName(m[3])
+		if _, already := looseParentByChild[n]; !already {
+			looseParentByChild[n] = PinnedRequirement{Name: normalizePyPIName(m[1]), Version: m[2]}
+		}
+	}
+	for _, m := range pipDependsOnParentRegex.FindAllStringSubmatch(pipOutput, -1) {
+		n := normalizePyPIName(m[3])
+		if _, already := looseParentByChild[n]; !already {
+			looseParentByChild[n] = PinnedRequirement{Name: normalizePyPIName(m[1]), Version: m[2]}
+		}
+	}
+	for i := range failed {
+		if failed[i].ParentName != "" && failed[i].ParentName != failed[i].Name {
+			continue // already correctly attributed to a real, different parent
+		}
+		if parent, ok := looseParentByChild[normalizePyPIName(failed[i].Name)]; ok && parent.Name != failed[i].Name {
+			failed[i].ParentName, failed[i].ParentVersion = parent.Name, parent.Version
+		}
+	}
+
+	// uv explicitly confirms direct dependencies via "your project depends on X" —
+	// trust it even when no Version/VersionRange could be parsed.
+	directConfirmedByName := map[string]bool{}
+	for _, m := range uvProjectDependsOnRegex.FindAllStringSubmatch(pipOutput, -1) {
+		directConfirmedByName[normalizePyPIName(m[1])] = true
+	}
+	for i := range failed {
+		if directConfirmedByName[normalizePyPIName(failed[i].Name)] {
+			failed[i].ConfirmedDirect = true
 		}
 	}
 

--- a/sca/bom/buildinfo/technologies/python/python_cvs_fallback_test.go
+++ b/sca/bom/buildinfo/technologies/python/python_cvs_fallback_test.go
@@ -125,13 +125,13 @@ func TestParseCvsFailedPackages(t *testing.T) {
 				"╰─▶ Because there is no version of telnyx==4.87.1 and your project depends\n" +
 				"    on telnyx==4.87.1, we can conclude that your project's requirements\n" +
 				"    are unsatisfiable.",
-			want: []PinnedRequirement{{Name: "telnyx", Version: "4.87.1", ParentName: "telnyx", ParentVersion: "4.87.1"}},
+			want: []PinnedRequirement{{Name: "telnyx", Version: "4.87.1", ParentName: "telnyx", ParentVersion: "4.87.1", ConfirmedDirect: true}},
 		},
 		{
 			name: "uv: deduplicates repeated name==version in output",
 			output: "Because there is no version of requests==2.28.0 and your project depends\n" +
 				"on requests==2.28.0, we can conclude...",
-			want: []PinnedRequirement{{Name: "requests", Version: "2.28.0", ParentName: "requests", ParentVersion: "2.28.0"}},
+			want: []PinnedRequirement{{Name: "requests", Version: "2.28.0", ParentName: "requests", ParentVersion: "2.28.0", ConfirmedDirect: true}},
 		},
 		{
 			name: "uv: transitive CVS-stripped dependency attributed to its real parent",
@@ -157,6 +157,33 @@ func TestParseCvsFailedPackages(t *testing.T) {
 				"be used.",
 			want: []PinnedRequirement{{Name: "langsmith", Version: "0.10.0", ParentName: "deepagents", ParentVersion: "0.6.12"}},
 		},
+		{
+			name: "uv: transitive package-not-found, parent constrains child by range not exact pin",
+			output: "× No solution found when resolving dependencies:\n" +
+				"╰─▶ Because charset-normalizer was not found in the package registry and\n" +
+				"    requests==2.31.0 depends on charset-normalizer, we can conclude that\n" +
+				"    requests==2.31.0 cannot be used.\n" +
+				"    And because your project depends on requests==2.31.0, we can conclude\n" +
+				"    that your project's requirements are unsatisfiable.",
+			want: []PinnedRequirement{{Name: "charset-normalizer", ParentName: "requests", ParentVersion: "2.31.0"}},
+		},
+		{
+			name: "pipenv: transitive range dep attributed to its real parent (space-separated phrasing)",
+			output: "✘ Locking Failed!\n" +
+				"ERROR: No matching distribution found for charset-normalizer<4,>=2\n" +
+				"\n" +
+				"The conflict is caused by:\n" +
+				"    requests 2.31.0 depends on charset-normalizer<4 and >=2\n",
+			want: []PinnedRequirement{{Name: "charset-normalizer", VersionRange: "<4,>=2", ParentName: "requests", ParentVersion: "2.31.0"}},
+		},
+		{
+			name: "uv: ranged direct dependency, whole package blocked, no version echoed",
+			output: "× No solution found when resolving dependencies:\n" +
+				"╰─▶ Because urllib3 was not found in the package registry and your project\n" +
+				"    depends on urllib3, we can conclude that your project's requirements are\n" +
+				"    unsatisfiable.",
+			want: []PinnedRequirement{{Name: "urllib3", ParentName: "urllib3", ConfirmedDirect: true}},
+		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -170,9 +197,9 @@ func TestIsCvsVersionFilteredOutput(t *testing.T) {
 		"Additionally, some packages in these conflicts have no matching distributions available for your environment:\n" +
 		"    langgraph-sdk"
 	cases := map[string]bool{
-		"ERROR: No matching distribution found for deepagents==0.5.5":                                                        true,
-		"ERROR: Could not find a version that satisfies the requirement langchain-core<2.0.0,>=1.3.2":                        true,
-		"Because sample-poetry-project depends on telnyx (4.87.1) which doesn't match any versions, version solving failed.": true,
+		"ERROR: No matching distribution found for deepagents==0.5.5":                                                                                                                                                         true,
+		"ERROR: Could not find a version that satisfies the requirement langchain-core<2.0.0,>=1.3.2":                                                                                                                         true,
+		"Because sample-poetry-project depends on telnyx (4.87.1) which doesn't match any versions, version solving failed.":                                                                                                  true,
 		"× No solution found when resolving dependencies:\n╰─▶ Because there is no version of telnyx==4.87.1 and your project depends on telnyx==4.87.1, we can conclude that your project's requirements are unsatisfiable.": true,
 		resolutionImpossible:                               true,
 		"ERROR: 403 Forbidden":                             false,


### PR DESCRIPTION
- [ ] The pull request is targeting the `dev` branch.
- [ ] The code has been validated to compile successfully by running `go vet ./...`.
- [ ] The code has been formatted properly using `go fmt ./...`.
- [ ] All [static analysis checks](https://github.com/jfrog/jfrog-cli-security/actions/workflows/analysis.yml) passed.
- [ ] All [tests](https://github.com/jfrog/jfrog-cli-security/actions/workflows/test.yml) have passed. If this feature is not already covered by the tests, new tests have been added.
- [ ] Updated the [Contributing page](https://github.com/jfrog/jfrog-cli-security/blob/main/CONTRIBUTING.md) / [ReadMe page](https://github.com/jfrog/jfrog-cli-security/blob/main/README.md) / [CI Workflow files](https://github.com/jfrog/jfrog-cli-security/tree/main/.github/workflows) if needed.
- [ ] All changes are detailed at the description. if not already covered at [JFrog Documentation](https://github.com/jfrog/documentation), new documentation have been added.

-----
## Summary
Fixes CVS (curation) fallback reporting for PyPI (pip/poetry/pipenv/uv) so pinned, ranged, and
transitive whole-package blocks show consistent, npm-parity policy detail.
- Adds a whole-package check before probing a specific version: if the package is blocked at
  every version, the row renders as `All versions blocked` (mirrors npm), instead of resolving
  to one version and reporting on just that one.
- Normalizes `Explanation`/`Recommendation` to npm's generic text when a policy matches the
  whole-package block, but keeps the real per-version detail when it's a genuinely different
  policy (e.g. `immature-30` on one version vs. an `openssf` block on the whole package).
- Adds a loose "depends on" fallback to recover the real parent for transitive blockers across
  pip/poetry/pipenv/uv when the child has no exact version in the tool's error text.
  
## Testing
- 9 new unit tests in `curationaudit_test.go` covering pinned/ranged/transitive whole-package
  blocks and same-policy vs. different-policy normalization.
- Verified end-to-end against a live D2C environment across pip, poetry, pipenv, and uv.
<img width="1727" height="373" alt="Screenshot 2026-09-09 at 10 38 48 PM" src="https://github.com/user-attachments/assets/e394e795-854a-40c8-9355-e8b8e1b41973" />
<img width="1728" height="275" alt="Screenshot 2026-09-09 at 10 39 05 PM" src="https://github.com/user-attachments/assets/63cbf9e8-ca79-4523-8da1-f86104be5e0e" />
